### PR TITLE
Generate configuration YAML from ImplementationGuide

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2405,11 +2405,11 @@
       "integrity": "sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg=="
     },
     "fhir": {
-      "version": "4.7.9",
-      "resolved": "https://registry.npmjs.org/fhir/-/fhir-4.7.9.tgz",
-      "integrity": "sha512-f8cpFML+/8RxnDLmbsyxB40D0qqPmjrDt7Qa5gBAnyEnhRietAnxRSp7hZ1BeBosnJ24FjfqCh+e1hcp1oEA3A==",
+      "version": "4.7.10",
+      "resolved": "https://registry.npmjs.org/fhir/-/fhir-4.7.10.tgz",
+      "integrity": "sha512-sLYnMSFNlZ8xhgnVJogasH3Tt0rs5D5hn4lXaq12HZFRsaCVTEty/Yngphj+0/wuowRS0xj/PPQj7P3Nr/Kz7g==",
       "requires": {
-        "lodash": "^4.17.14",
+        "lodash": "^4.17.19",
         "path": "^0.12.7",
         "q": "^1.4.1",
         "randomatic": "^3.1.0",
@@ -2421,7 +2421,7 @@
           "bundled": true
         },
         "lodash": {
-          "version": "4.17.15",
+          "version": "4.17.19",
           "bundled": true
         },
         "path": {
@@ -2611,9 +2611,9 @@
       "optional": true
     },
     "fsh-sushi": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-0.15.1.tgz",
-      "integrity": "sha512-OwOrX0ghRI+KHm71sMwqZS2yHpWO7z4lTxFvNM0WdrGY7PobyOFtn4M2y2RxzcMkIad0DG/rNmGK3ORCgARdGw==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-0.16.0.tgz",
+      "integrity": "sha512-3jOk9/Lye6P3Dou1Myf5HLpnTfcEPJM8i12uFI7I2ql0buhZuEZfxf1rRMTHhbjBxZumjV3OHx+frqKR0gomOQ==",
       "requires": {
         "@types/antlr4": "^4.7.1",
         "antlr4": "^4.8.0",
@@ -4666,9 +4666,9 @@
       }
     },
     "minizlib": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.0.tgz",
-      "integrity": "sha512-EzTZN/fjSvifSX0SlqUERCN39o6T40AMarPbv0MrarSFtIITCBh7bi+dU8nxGFHuqs9jdIAeoYoKuQAAASsPPA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
       "requires": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -6416,9 +6416,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.1.tgz",
-      "integrity": "sha512-RjxApKkrPJB6kjJxQS3iZlf///REXWYxYJxO/MpmlQzVkDWVI3PSnCBWezMecmTU/TRkNxrl8bmsfFQCp+LO+Q=="
+      "version": "3.10.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.4.tgz",
+      "integrity": "sha512-kBFT3U4Dcj4/pJ52vfjCSfyLyvG9VYYuGYPmrPvAxRw/i7xHiT4VvCev+uiEMcEEiu6UNB6KgWmGtSUYIWScbw=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -54,9 +54,10 @@
     "commander": "^6.0.0",
     "flat": "^5.0.2",
     "fs-extra": "^9.0.1",
-    "fsh-sushi": "^0.15.1",
+    "fsh-sushi": "^0.16.0",
     "lodash": "^4.17.19",
     "temp": "^0.9.1",
-    "winston": "^3.3.3"
+    "winston": "^3.3.3",
+    "yaml": "^1.10.0"
   }
 }

--- a/src/exportable/ExportableConfiguration.ts
+++ b/src/exportable/ExportableConfiguration.ts
@@ -1,0 +1,21 @@
+import YAML from 'yaml';
+import { fshtypes } from 'fsh-sushi';
+import { Exportable } from '.';
+
+export class ExportableConfiguration implements Exportable {
+  constructor(public config: fshtypes.Configuration) {}
+
+  toFSH(): string {
+    // canonical and fhirVersion are always present
+    const yaml = new YAML.Document();
+    yaml.contents = YAML.createNode({
+      canonical: this.config.canonical,
+      fhirVersion: this.config.fhirVersion?.[0] ?? '4.0.1'
+    });
+    if (this.config.id) {
+      yaml.contents.add({ key: 'id', value: this.config.id });
+    }
+
+    return yaml.toString();
+  }
+}

--- a/src/exportable/ExportableConfiguration.ts
+++ b/src/exportable/ExportableConfiguration.ts
@@ -10,12 +10,21 @@ export class ExportableConfiguration implements Exportable {
     const yaml = new YAML.Document();
     yaml.contents = YAML.createNode({
       canonical: this.config.canonical,
-      fhirVersion: this.config.fhirVersion?.[0] ?? '4.0.1'
+      fhirVersion: this.config.fhirVersion[0]
     });
+    // id, name, status, and version are the optional configuration properties.
     if (this.config.id) {
       yaml.contents.add({ key: 'id', value: this.config.id });
     }
-
+    if (this.config.name) {
+      yaml.contents.add({ key: 'name', value: this.config.name });
+    }
+    if (this.config.status) {
+      yaml.contents.add({ key: 'status', value: this.config.status });
+    }
+    if (this.config.version) {
+      yaml.contents.add({ key: 'version', value: this.config.version });
+    }
     return yaml.toString();
   }
 }

--- a/src/exportable/index.ts
+++ b/src/exportable/index.ts
@@ -4,6 +4,7 @@ export * from './ExportableCaretValueRule';
 export * from './ExportableCodeSystem';
 export * from './ExportableCombinedCardFlagRule';
 export * from './ExportableConceptRule';
+export * from './ExportableConfiguration';
 export * from './ExportableContainsRule';
 export * from './ExportableExtension';
 export * from './ExportableFixedValueRule';

--- a/src/processor/ConfigurationProcessor.ts
+++ b/src/processor/ConfigurationProcessor.ts
@@ -1,0 +1,33 @@
+import { fshtypes } from 'fsh-sushi';
+import { ExportableConfiguration } from '../exportable';
+import { logger } from 'fsh-sushi/dist/utils';
+
+export class ConfigurationProcessor {
+  static process(input: any): ExportableConfiguration {
+    // canonical and fhirVersion are the minimal required properties for configuration
+    // canonical is inferred from the url property
+    const missingProperties: string[] = [];
+    if (!input.url) {
+      missingProperties.push('url');
+    }
+    if (!input.fhirVersion?.length) {
+      missingProperties.push('fhirVersion');
+    }
+    if (missingProperties.length > 0) {
+      logger.warn(
+        `ImplementationGuide missing properties needed to generate configuration file: ${missingProperties.join(
+          ', '
+        )}`
+      );
+      return;
+    }
+    const config: fshtypes.Configuration = {
+      canonical: input.url?.replace(/\/ImplementationGuide.*/, ''),
+      fhirVersion: input.fhirVersion
+    };
+    if (input.id) {
+      config.id = input.id;
+    }
+    return new ExportableConfiguration(config);
+  }
+}

--- a/src/processor/ConfigurationProcessor.ts
+++ b/src/processor/ConfigurationProcessor.ts
@@ -1,10 +1,10 @@
 import { fshtypes } from 'fsh-sushi';
 import { ExportableConfiguration } from '../exportable';
-import { logger } from 'fsh-sushi/dist/utils';
+import { logger } from '../utils/GoFSHLogger';
 
 export class ConfigurationProcessor {
   static process(input: any): ExportableConfiguration {
-    // canonical and fhirVersion are the minimal required properties for configuration
+    // canonical and fhirVersion are the minimal required configuration properties for configuration
     // canonical is inferred from the url property
     const missingProperties: string[] = [];
     if (!input.url) {
@@ -22,12 +22,14 @@ export class ConfigurationProcessor {
       return;
     }
     const config: fshtypes.Configuration = {
-      canonical: input.url?.replace(/\/ImplementationGuide.*/, ''),
+      canonical: input.url.replace(/\/ImplementationGuide.*/, ''),
       fhirVersion: input.fhirVersion
     };
-    if (input.id) {
-      config.id = input.id;
-    }
+    // id, name, status, and version are the optional configuration properties.
+    config.id = input.id;
+    config.name = input.name;
+    config.status = input.status;
+    config.version = input.version;
     return new ExportableConfiguration(config);
   }
 }

--- a/src/processor/ConfigurationProcessor.ts
+++ b/src/processor/ConfigurationProcessor.ts
@@ -22,7 +22,7 @@ export class ConfigurationProcessor {
       return;
     }
     const config: fshtypes.Configuration = {
-      canonical: input.url.replace(/\/ImplementationGuide.*/, ''),
+      canonical: input.url.replace(/\/ImplementationGuide\/[^/]+$/, ''),
       fhirVersion: input.fhirVersion
     };
     // id, name, status, and version are the optional configuration properties.

--- a/src/processor/FHIRProcessor.ts
+++ b/src/processor/FHIRProcessor.ts
@@ -4,6 +4,7 @@ import { logger } from '../utils';
 import { ProfileProcessor } from './ProfileProcessor';
 import { ExtensionProcessor } from './ExtensionProcessor';
 import { CodeSystemProcessor } from './CodeSystemProcessor';
+import { ConfigurationProcessor } from './ConfigurationProcessor';
 
 export class FHIRProcessor {
   public readonly structureDefinitions: any[] = [];
@@ -29,6 +30,8 @@ export class FHIRProcessor {
     } else if (rawContent['resourceType'] === 'CodeSystem') {
       logger.debug(`Processing contents of ${inputPath} as CodeSystem.`);
       return CodeSystemProcessor.process(rawContent);
+    } else if (rawContent['resourceType'] === 'ImplementationGuide') {
+      return ConfigurationProcessor.process(rawContent);
     }
   }
 }

--- a/src/processor/Package.ts
+++ b/src/processor/Package.ts
@@ -4,6 +4,7 @@ import {
   ExportableInstance,
   ExportableValueSet,
   ExportableCodeSystem,
+  ExportableConfiguration,
   ExportableFlagRule,
   ExportableCardRule,
   ExportableCombinedCardFlagRule
@@ -18,6 +19,7 @@ export class Package {
   public readonly instances: ExportableInstance[] = [];
   public readonly valueSets: ExportableValueSet[] = [];
   public readonly codeSystems: ExportableCodeSystem[] = [];
+  public configuration: ExportableConfiguration;
 
   constructor() {}
 
@@ -28,6 +30,7 @@ export class Package {
       | ExportableInstance
       | ExportableValueSet
       | ExportableCodeSystem
+      | ExportableConfiguration
   ) {
     if (resource instanceof ExportableProfile) {
       this.profiles.push(resource);
@@ -39,11 +42,20 @@ export class Package {
       this.valueSets.push(resource);
     } else if (resource instanceof ExportableCodeSystem) {
       this.codeSystems.push(resource);
+    } else if (resource instanceof ExportableConfiguration) {
+      if (this.configuration) {
+        logger.warning(
+          `Multiple implementation guide resources found in input folder. Skipping implementation guide with ${
+            resource.config.id ? `id ${resource.config.id}` : 'unknown id'
+          }.`
+        );
+      } else {
+        this.configuration = resource;
+      }
     }
   }
 
   // TODO: if more optimization steps are added, break them into separate functions.
-  // TODO: Optimization step: combine CardRule and FlagRule
   // TODO: Optimization step: combine ContainsRule and OnlyRule for contained item with one type
   optimize(processor: FHIRProcessor) {
     logger.debug('Optimizing FSH definitions...');

--- a/src/processor/Package.ts
+++ b/src/processor/Package.ts
@@ -48,10 +48,8 @@ export class Package {
       this.codeSystems.push(resource);
     } else if (resource instanceof ExportableConfiguration) {
       if (this.configuration) {
-        logger.warning(
-          `Multiple implementation guide resources found in input folder. Skipping implementation guide with ${
-            resource.config.id ? `id ${resource.config.id}` : 'unknown id'
-          }.`
+        logger.warn(
+          `Multiple implementation guide resources found in input folder. Skipping implementation guide with canonical ${resource.config.canonical}`
         );
       } else {
         this.configuration = resource;

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -40,6 +40,11 @@ export function writeFSH(resources: Package, outDir: string) {
   const outputPath = path.join(outDir, 'resources.fsh');
   fs.writeFileSync(outputPath, exporter.export());
   logger.info(`Wrote fsh to ${outputPath}.`);
+  if (resources.configuration) {
+    const configPath = path.join(outDir, 'config.yaml');
+    fs.writeFileSync(configPath, resources.configuration.toFSH());
+    logger.info(`Wrote config to ${configPath}.`);
+  }
 }
 
 // thanks, peturv

--- a/test/exportable/ExportableConfiguration.test.ts
+++ b/test/exportable/ExportableConfiguration.test.ts
@@ -1,0 +1,20 @@
+import { ExportableConfiguration } from '../../src/exportable';
+
+describe('ExportableConfiguration', () => {
+  let config: ExportableConfiguration;
+
+  beforeAll(() => {
+    config = new ExportableConfiguration({
+      id: 'my.test.package',
+      canonical: 'http://example.org/test/package',
+      fhirVersion: ['4.0.1']
+    });
+  });
+
+  it('should include the required configuration fields in the exported yaml', () => {
+    const yaml = config.toFSH();
+    expect(yaml).toMatch(/id: my\.test\.package/s);
+    expect(yaml).toMatch(/canonical: http:\/\/example.org\/test\/package/s);
+    expect(yaml).toMatch(/fhirVersion: 4\.0\.1/s);
+  });
+});

--- a/test/exportable/ExportableConfiguration.test.ts
+++ b/test/exportable/ExportableConfiguration.test.ts
@@ -1,20 +1,62 @@
 import { ExportableConfiguration } from '../../src/exportable';
 
 describe('ExportableConfiguration', () => {
-  let config: ExportableConfiguration;
+  describe('#requiredFields', () => {
+    let result: string;
 
-  beforeAll(() => {
-    config = new ExportableConfiguration({
-      id: 'my.test.package',
-      canonical: 'http://example.org/test/package',
-      fhirVersion: ['4.0.1']
+    beforeAll(() => {
+      const config = new ExportableConfiguration({
+        canonical: 'http://example.org/test/package',
+        fhirVersion: ['4.0.1']
+      });
+      result = config.toFSH();
+    });
+
+    it('should include the canonical url', () => {
+      expect(result).toMatch(/^canonical: http:\/\/example.org\/test\/package/m);
+    });
+
+    it('should include the FHIR version', () => {
+      expect(result).toMatch(/^fhirVersion: 4\.0\.1/m);
+    });
+
+    it('should not include optional fields not present in the configuration', () => {
+      expect(result).not.toMatch(/^id: /m);
+      expect(result).not.toMatch(/^name: /m);
+      expect(result).not.toMatch(/^status: /m);
+      expect(result).not.toMatch(/^version: /m);
     });
   });
 
-  it('should include the required configuration fields in the exported yaml', () => {
-    const yaml = config.toFSH();
-    expect(yaml).toMatch(/id: my\.test\.package/s);
-    expect(yaml).toMatch(/canonical: http:\/\/example.org\/test\/package/s);
-    expect(yaml).toMatch(/fhirVersion: 4\.0\.1/s);
+  describe('#optionalFields', () => {
+    let result: string;
+
+    beforeAll(() => {
+      const config = new ExportableConfiguration({
+        canonical: 'http://example.org/test/package',
+        fhirVersion: ['4.0.1'],
+        id: 'a.special.package',
+        name: 'SpecialTestPackage',
+        status: 'active',
+        version: '0.13.0'
+      });
+      result = config.toFSH();
+    });
+
+    it('should include the id when present', () => {
+      expect(result).toMatch(/^id: a\.special\.package/m);
+    });
+
+    it('should include the name when present', () => {
+      expect(result).toMatch(/^name: SpecialTestPackage/m);
+    });
+
+    it('should include the status when present', () => {
+      expect(result).toMatch(/^status: active/m);
+    });
+
+    it('should include the version when present', () => {
+      expect(result).toMatch(/^version: 0\.13.0/m);
+    });
   });
 });

--- a/test/processor/ConfigurationProcessor.test.ts
+++ b/test/processor/ConfigurationProcessor.test.ts
@@ -26,7 +26,7 @@ describe('ConfigurationProcessor', () => {
     );
   });
 
-  it('should not create a Configuration with a fhirVersion', () => {
+  it('should not create a Configuration without a fhirVersion', () => {
     const input = JSON.parse(
       fs.readFileSync(path.join(__dirname, 'fixtures', 'missing-fhir-version-ig.json'), 'utf-8')
     );

--- a/test/processor/ConfigurationProcessor.test.ts
+++ b/test/processor/ConfigurationProcessor.test.ts
@@ -1,0 +1,6 @@
+describe('ConfigurationProcessor', () => {
+  it.todo('should read an ImplementationGuide with url and fhirVersion properties');
+  it.todo('should log a warning when url is missing');
+  it.todo('should log a warning when fhirVersion is missing');
+  it.todo('should read an ImplementationGuide with additional properties');
+});

--- a/test/processor/ConfigurationProcessor.test.ts
+++ b/test/processor/ConfigurationProcessor.test.ts
@@ -1,6 +1,53 @@
+import path from 'path';
+import fs from 'fs-extra';
+import { ConfigurationProcessor } from '../../src/processor/ConfigurationProcessor';
+import { ExportableConfiguration } from '../../src/exportable';
+import { loggerSpy } from '../helpers/loggerSpy';
+
 describe('ConfigurationProcessor', () => {
-  it.todo('should read an ImplementationGuide with url and fhirVersion properties');
-  it.todo('should log a warning when url is missing');
-  it.todo('should log a warning when fhirVersion is missing');
-  it.todo('should read an ImplementationGuide with additional properties');
+  it('should create a Configuration from an ImplementationGuide with url and fhirVersion properties', () => {
+    const input = JSON.parse(
+      fs.readFileSync(path.join(__dirname, 'fixtures', 'simple-ig.json'), 'utf-8')
+    );
+    const result = ConfigurationProcessor.process(input);
+    expect(result).toBeInstanceOf(ExportableConfiguration);
+    expect(result.config.canonical).toBe('http://example.org/tests');
+    expect(result.config.fhirVersion).toEqual(['4.0.1']);
+  });
+
+  it('should not create a Configuration without a url', () => {
+    const input = JSON.parse(
+      fs.readFileSync(path.join(__dirname, 'fixtures', 'missing-url-ig.json'), 'utf-8')
+    );
+    const result = ConfigurationProcessor.process(input);
+    expect(result).toBeUndefined();
+    expect(loggerSpy.getLastMessage('warn')).toMatch(
+      /ImplementationGuide missing properties.*url/s
+    );
+  });
+
+  it('should not create a Configuration with a fhirVersion', () => {
+    const input = JSON.parse(
+      fs.readFileSync(path.join(__dirname, 'fixtures', 'missing-fhir-version-ig.json'), 'utf-8')
+    );
+    const result = ConfigurationProcessor.process(input);
+    expect(result).toBeUndefined();
+    expect(loggerSpy.getLastMessage('warn')).toMatch(
+      /ImplementationGuide missing properties.*fhirVersion/s
+    );
+  });
+
+  it('should create a Configuration with additional properties', () => {
+    const input = JSON.parse(
+      fs.readFileSync(path.join(__dirname, 'fixtures', 'bigger-ig.json'), 'utf-8')
+    );
+    const result = ConfigurationProcessor.process(input);
+    expect(result).toBeInstanceOf(ExportableConfiguration);
+    expect(result.config.canonical).toBe('http://example.org/tests');
+    expect(result.config.fhirVersion).toEqual(['4.0.1']);
+    expect(result.config.id).toBe('bigger.ig');
+    expect(result.config.name).toBe('BiggerImplementationGuideForTesting');
+    expect(result.config.status).toBe('active');
+    expect(result.config.version).toBe('0.12');
+  });
 });

--- a/test/processor/Package.test.ts
+++ b/test/processor/Package.test.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { fhirdefs, fshtypes } from 'fsh-sushi';
 import { Package } from '../../src/processor/Package';
 import {
   ExportableProfile,
@@ -6,6 +7,7 @@ import {
   ExportableInstance,
   ExportableValueSet,
   ExportableCodeSystem,
+  ExportableConfiguration,
   ExportableCardRule,
   ExportableFlagRule,
   ExportableContainsRule,
@@ -15,8 +17,7 @@ import {
 } from '../../src/exportable';
 import { FHIRProcessor } from '../../src/processor/FHIRProcessor';
 import { ExportableCombinedCardFlagRule } from '../../src/exportable/ExportableCombinedCardFlagRule';
-import '../helpers/loggerSpy'; // suppresses console logging
-import { fhirdefs, fshtypes } from 'fsh-sushi';
+import { loggerSpy } from '../helpers/loggerSpy';
 
 describe('Package', () => {
   describe('#add', () => {
@@ -24,6 +25,7 @@ describe('Package', () => {
 
     beforeEach(() => {
       myPackage = new Package();
+      loggerSpy.reset();
     });
 
     it('should add an ExportableProfile to the profiles array', () => {
@@ -54,6 +56,32 @@ describe('Package', () => {
       const myCodeSystem = new ExportableCodeSystem('MyCodeSystem');
       myPackage.add(myCodeSystem);
       expect(myPackage.codeSystems[0]).toBe(myCodeSystem);
+    });
+
+    it('should set the configuration when adding an ExportableConfiguration', () => {
+      const myConfiguration = new ExportableConfiguration({
+        canonical: 'https://demo.org',
+        fhirVersion: ['4.0.1']
+      });
+      myPackage.add(myConfiguration);
+      expect(myPackage.configuration).toBe(myConfiguration);
+    });
+
+    it('should not set the configuration and log a warning when adding an ExportableConfiguration and the configuration is already set', () => {
+      const myConfiguration = new ExportableConfiguration({
+        canonical: 'https://demo.org',
+        fhirVersion: ['4.0.1']
+      });
+      const extraConfiguration = new ExportableConfiguration({
+        canonical: 'https://oops.org',
+        fhirVersion: ['4.0.1']
+      });
+      myPackage.add(myConfiguration);
+      myPackage.add(extraConfiguration);
+      expect(myPackage.configuration).toBe(myConfiguration);
+      expect(loggerSpy.getLastMessage('warn')).toMatch(
+        /Skipping implementation guide with canonical https:\/\/oops\.org/s
+      );
     });
   });
 

--- a/test/processor/fixtures/bigger-ig.json
+++ b/test/processor/fixtures/bigger-ig.json
@@ -1,0 +1,9 @@
+{
+  "resourceType": "ImplementationGuide",
+  "url": "http://example.org/tests/ImplementationGuide/bigger.ig",
+  "fhirVersion": ["4.0.1"],
+  "id": "bigger.ig",
+  "name": "BiggerImplementationGuideForTesting",
+  "status": "active",
+  "version": "0.12"
+}

--- a/test/processor/fixtures/missing-fhir-version-ig.json
+++ b/test/processor/fixtures/missing-fhir-version-ig.json
@@ -1,0 +1,4 @@
+{
+  "resourceType": "ImplementationGuide",
+  "url": "http://example.org/tests/ImplementationGuide/simple.ig"
+}

--- a/test/processor/fixtures/missing-url-ig.json
+++ b/test/processor/fixtures/missing-url-ig.json
@@ -1,0 +1,4 @@
+{
+  "resourceType": "ImplementationGuide",
+  "fhirVersion": ["4.0.1"]
+}

--- a/test/processor/fixtures/simple-ig.json
+++ b/test/processor/fixtures/simple-ig.json
@@ -1,0 +1,5 @@
+{
+  "resourceType": "ImplementationGuide",
+  "url": "http://example.org/tests/ImplementationGuide/simple.ig",
+  "fhirVersion": ["4.0.1"]
+}


### PR DESCRIPTION
Completes task [CIMPL-530](https://standardhealthrecord.atlassian.net/browse/CIMPL-530).

When an ImplementationGuide JSON file is present, try to use it to create a config file. Since canonical and fhirVersion are required in the configuration, those are also required from the JSON. Since configuration isn't stored directly in the IG or anywhere else, goFSH assumes that the IG's url is in FSH's preferred format and works from there. Optional fields for id, name, status, and version are also included when available. If more than one ImplementationGuide is found, whichever one is found first is used, and a message is logged.