### PR TITLE
Remove default slicing rules on choice elements

### DIFF
--- a/src/processor/Package.ts
+++ b/src/processor/Package.ts
@@ -108,7 +108,8 @@ export class Package {
                 rule.value instanceof fshtypes.FshCode &&
                 rule.value.code === 'open')) &&
             allRules.some(
-              otherRule => otherRule.path != rule.path && otherRule.path.startsWith(pathStart)
+              otherRule =>
+                !otherRule.path.startsWith(rule.path) && otherRule.path.startsWith(pathStart)
             )
           ) {
             rulesToMaybeRemove.push(i);

--- a/test/processor/Package.test.ts
+++ b/test/processor/Package.test.ts
@@ -7,12 +7,14 @@ import {
   ExportableValueSet,
   ExportableCodeSystem,
   ExportableCardRule,
-  ExportableFlagRule
+  ExportableFlagRule,
+  ExportableCaretValueRule,
+  ExportableFixedValueRule
 } from '../../src/exportable';
 import { FHIRProcessor } from '../../src/processor/FHIRProcessor';
 import { ExportableCombinedCardFlagRule } from '../../src/exportable/ExportableCombinedCardFlagRule';
 import '../helpers/loggerSpy'; // suppresses console logging
-import { fhirdefs } from 'fsh-sushi';
+import { fhirdefs, fshtypes } from 'fsh-sushi';
 
 describe('Package', () => {
   describe('#add', () => {
@@ -109,6 +111,99 @@ describe('Package', () => {
       myPackage.add(profile);
       myPackage.optimize(processor);
       expect(profile.rules).toEqual([cardRule, flagRule]);
+    });
+
+    it('should remove caret value rules on a choice element that apply standard choice slicing if one of the choices exists', () => {
+      const profile = new ExportableProfile('SlicedProfile');
+      profile.parent = 'Observation';
+      const slicingType = new ExportableCaretValueRule('value[x]');
+      slicingType.caretPath = 'slicing.discriminator[0].type';
+      slicingType.value = new fshtypes.FshCode('type');
+      const slicingPath = new ExportableCaretValueRule('value[x]');
+      slicingPath.caretPath = 'slicing.discriminator[0].path';
+      slicingPath.value = '$this';
+      const slicingOrdered = new ExportableCaretValueRule('value[x]');
+      slicingOrdered.caretPath = 'slicing.ordered';
+      slicingOrdered.value = false;
+      const slicingRules = new ExportableCaretValueRule('value[x]');
+      slicingRules.caretPath = 'slicing.rules';
+      slicingRules.value = new fshtypes.FshCode('open');
+
+      const fixedValueRule = new ExportableFixedValueRule('valueString');
+      fixedValueRule.fixedValue = 'Make a choice';
+      profile.rules.push(slicingType, slicingPath, slicingOrdered, slicingRules, fixedValueRule);
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+      expect(profile.rules).toHaveLength(1);
+      expect(profile.rules).toContain(fixedValueRule);
+    });
+
+    it('should not remove caret value rules on a choice element that apply standard choice slicing if none of the choices exist', () => {
+      const profile = new ExportableProfile('SlicedProfile');
+      profile.parent = 'Observation';
+      const slicingType = new ExportableCaretValueRule('value[x]');
+      slicingType.caretPath = 'slicing.discriminator[0].type';
+      slicingType.value = new fshtypes.FshCode('type');
+      const slicingPath = new ExportableCaretValueRule('value[x]');
+      slicingPath.caretPath = 'slicing.discriminator[0].path';
+      slicingPath.value = '$this';
+      const slicingOrdered = new ExportableCaretValueRule('value[x]');
+      slicingOrdered.caretPath = 'slicing.ordered';
+      slicingOrdered.value = false;
+      const slicingRules = new ExportableCaretValueRule('value[x]');
+      slicingRules.caretPath = 'slicing.rules';
+      slicingRules.value = new fshtypes.FshCode('open');
+
+      profile.rules.push(slicingType, slicingPath, slicingOrdered, slicingRules);
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+      expect(profile.rules).toHaveLength(4);
+    });
+
+    it('should not remove caret value rules that define slicing on a non-choice element', () => {
+      const profile = new ExportableProfile('SlicedProfile');
+      profile.parent = 'Observation';
+      const slicingType = new ExportableCaretValueRule('note');
+      slicingType.caretPath = 'slicing.discriminator[0].type';
+      slicingType.value = new fshtypes.FshCode('type');
+      const slicingPath = new ExportableCaretValueRule('note');
+      slicingPath.caretPath = 'slicing.discriminator[0].path';
+      slicingPath.value = '$this';
+      const slicingOrdered = new ExportableCaretValueRule('note');
+      slicingOrdered.caretPath = 'slicing.ordered';
+      slicingOrdered.value = false;
+      const slicingRules = new ExportableCaretValueRule('note');
+      slicingRules.caretPath = 'slicing.rules';
+      slicingRules.value = new fshtypes.FshCode('open');
+      profile.rules.push(slicingType, slicingPath, slicingOrdered, slicingRules);
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+      expect(profile.rules).toHaveLength(4);
+    });
+
+    it('should not remove caret value rules on a choice element that apply nonstandard choice slicing', () => {
+      const profile = new ExportableProfile('SlicedProfile');
+      profile.parent = 'Observation';
+      const slicingType = new ExportableCaretValueRule('value[x]');
+      slicingType.caretPath = 'slicing.discriminator[0].type';
+      slicingType.value = new fshtypes.FshCode('value');
+      const slicingPath = new ExportableCaretValueRule('value[x]');
+      slicingPath.caretPath = 'slicing.discriminator[0].path';
+      slicingPath.value = 'Observation.code';
+      const slicingOrdered = new ExportableCaretValueRule('value[x]');
+      slicingOrdered.caretPath = 'slicing.ordered';
+      slicingOrdered.value = true;
+      const slicingRules = new ExportableCaretValueRule('value[x]');
+      slicingRules.caretPath = 'slicing.rules';
+      slicingRules.value = new fshtypes.FshCode('closed');
+      profile.rules.push(slicingType, slicingPath, slicingOrdered, slicingRules);
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+      expect(profile.rules).toHaveLength(4);
     });
   });
 });

--- a/test/processor/Package.test.ts
+++ b/test/processor/Package.test.ts
@@ -154,12 +154,14 @@ describe('Package', () => {
       const slicingRules = new ExportableCaretValueRule('value[x]');
       slicingRules.caretPath = 'slicing.rules';
       slicingRules.value = new fshtypes.FshCode('open');
+      const fixedValueRule = new ExportableFixedValueRule('value[x].id');
+      fixedValueRule.fixedValue = 'special-id';
 
-      profile.rules.push(slicingType, slicingPath, slicingOrdered, slicingRules);
+      profile.rules.push(slicingType, slicingPath, slicingOrdered, slicingRules, fixedValueRule);
       const myPackage = new Package();
       myPackage.add(profile);
       myPackage.optimize(processor);
-      expect(profile.rules).toHaveLength(4);
+      expect(profile.rules).toHaveLength(5);
     });
 
     it('should not remove caret value rules that define slicing on a non-choice element', () => {

--- a/test/processor/Package.test.ts
+++ b/test/processor/Package.test.ts
@@ -192,7 +192,7 @@ describe('Package', () => {
       slicingType.value = new fshtypes.FshCode('value');
       const slicingPath = new ExportableCaretValueRule('value[x]');
       slicingPath.caretPath = 'slicing.discriminator[0].path';
-      slicingPath.value = 'Observation.code';
+      slicingPath.value = 'id';
       const slicingOrdered = new ExportableCaretValueRule('value[x]');
       slicingOrdered.caretPath = 'slicing.ordered';
       slicingOrdered.value = true;
@@ -204,6 +204,31 @@ describe('Package', () => {
       myPackage.add(profile);
       myPackage.optimize(processor);
       expect(profile.rules).toHaveLength(4);
+    });
+
+    it('should not remove caret value rules on a choice element that apply some but not all of the standard choice slicing', () => {
+      const profile = new ExportableProfile('SlicedProfile');
+      profile.parent = 'Observation';
+      const slicingType = new ExportableCaretValueRule('value[x]');
+      slicingType.caretPath = 'slicing.discriminator[0].type';
+      slicingType.value = new fshtypes.FshCode('value');
+      const slicingPath = new ExportableCaretValueRule('value[x]');
+      slicingPath.caretPath = 'slicing.discriminator[0].path';
+      slicingPath.value = 'id';
+      const slicingOrdered = new ExportableCaretValueRule('value[x]');
+      slicingOrdered.caretPath = 'slicing.ordered';
+      slicingOrdered.value = false;
+      const slicingRules = new ExportableCaretValueRule('value[x]');
+      slicingRules.caretPath = 'slicing.rules';
+      slicingRules.value = new fshtypes.FshCode('open');
+
+      const fixedValueRule = new ExportableFixedValueRule('valueString');
+      fixedValueRule.fixedValue = 'Make a choice';
+      profile.rules.push(slicingType, slicingPath, slicingOrdered, slicingRules, fixedValueRule);
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+      expect(profile.rules).toHaveLength(5);
     });
   });
 });


### PR DESCRIPTION
Completes task [CIMPL-540](https://standardhealthrecord.atlassian.net/browse/CIMPL-540).

When a choice element adheres to the default slicing rules provided by SUSHI, including those rules is not necessary as long as one of the choices exists. Therefore, if there is a rule with a path to one of those choices, slicing rules on the choice element can be removed if they have the default value applied.