### PR TITLE
Remove default context rules from extensions

### DIFF
--- a/src/processor/Package.ts
+++ b/src/processor/Package.ts
@@ -101,7 +101,7 @@ export class Package {
             r instanceof ExportableCaretValueRule &&
             r.path === '' &&
             r.caretPath === 'context[0].type' &&
-            isEqual((r as ExportableCaretValueRule).value, new fshtypes.FshCode('element'))
+            isEqual(r.value, new fshtypes.FshCode('element'))
         );
         // * ^context[0].expression = "Element"
         const expressionRuleIdx = sd.rules.findIndex(

--- a/test/processor/Package.test.ts
+++ b/test/processor/Package.test.ts
@@ -179,7 +179,7 @@ describe('Package', () => {
       expect(extension.rules).toHaveLength(4);
     });
 
-    it('should remove default context from profiles', () => {
+    it('should not remove default context from profiles', () => {
       // Technically, I don't think having context on a profile is allowed, but check just in case
       const profile = new ExportableProfile('ExtraProfile');
       const typeRule = new ExportableCaretValueRule('');


### PR DESCRIPTION
If an Extension definition does not have a context specified by the author, SUSHI will add context equivalent to these rules:
```
* ^context[0].type = #element
* ^context[0].expression = "Element"
```

If GoFSH finds these rules, and they are the only context rules on the extension, they will be removed since they are generated by default by SUSHI.

If you want to test this manually, build a FSH project that has Extensions in it (without author-specified contexts).  Then run GoFSH on its output.  Using the GoFSH master branch, you'll see the `context` rules.  Using this branch, you will not see those rules.

A good manual negative test is running GoFSH against US Core.  Since US Core *does* define specific contexts for each Extension, there will be no difference between running master GoFSH and this branch's GoFSH.