### PR TITLE
Remove default 0..0 rules from extensions

### DIFF
--- a/src/processor/Package.ts
+++ b/src/processor/Package.ts
@@ -42,13 +42,12 @@ export class Package {
     }
   }
 
-  // TODO: if more optimization steps are added, break them into separate functions.
-  // TODO: Optimization step: combine CardRule and FlagRule
   // TODO: Optimization step: combine ContainsRule and OnlyRule for contained item with one type
   optimize(processor: FHIRProcessor) {
     logger.debug('Optimizing FSH definitions...');
     this.resolveProfileParents(processor);
     this.combineCardAndFlagRules();
+    this.removeImpliedZeroToZeroCardRules();
   }
 
   private resolveProfileParents(processor: FHIRProcessor): void {
@@ -78,6 +77,40 @@ export class Package {
             );
             rulesToRemove.push(flagRuleIdx);
           }
+        }
+      });
+      pullAt(sd.rules, rulesToRemove);
+    });
+  }
+
+  // If an extension has meaningful value[x] rules, SUSHI will constrain extension to 0..0.
+  // If an extension adds sub-extensions, SUSHI will constrain value[x] to 0..0.
+  // GoFSH does not need to output these 0..0 rules since SUSHI will automatically add them.
+  // This goes for top-value paths in extensions as well as all sub-extensions.
+  private removeImpliedZeroToZeroCardRules(): void {
+    this.extensions.forEach(sd => {
+      const rulesToRemove: number[] = [];
+      sd.rules.forEach((r, i) => {
+        if (
+          // r is a 0..0 card rule, AND
+          r instanceof ExportableCardRule &&
+          r.max === '0' &&
+          //r is an extension path and there exist sibling value paths that are not 0..0, OR
+          ((r.path.endsWith('extension') &&
+            sd.rules.some(
+              r2 =>
+                r2.path.startsWith(r.path.replace(/extension$/, 'value')) &&
+                !(r2 instanceof ExportableCardRule && r2.max === '0')
+            )) ||
+            // r is a value[x] path and there exist sibling extension paths that are not 0..0
+            (r.path.endsWith('value[x]') &&
+              sd.rules.some(
+                r2 =>
+                  r2.path.startsWith(r.path.replace(/value\[x]$/, 'extension')) &&
+                  !(r2 instanceof ExportableCardRule && r2.max === '0')
+              )))
+        ) {
+          rulesToRemove.push(i);
         }
       });
       pullAt(sd.rules, rulesToRemove);

--- a/test/processor/Package.test.ts
+++ b/test/processor/Package.test.ts
@@ -7,7 +7,10 @@ import {
   ExportableValueSet,
   ExportableCodeSystem,
   ExportableCardRule,
-  ExportableFlagRule
+  ExportableFlagRule,
+  ExportableContainsRule,
+  ExportableOnlyRule,
+  ExportableValueSetRule
 } from '../../src/exportable';
 import { FHIRProcessor } from '../../src/processor/FHIRProcessor';
 import { ExportableCombinedCardFlagRule } from '../../src/exportable/ExportableCombinedCardFlagRule';
@@ -109,6 +112,156 @@ describe('Package', () => {
       myPackage.add(profile);
       myPackage.optimize(processor);
       expect(profile.rules).toEqual([cardRule, flagRule]);
+    });
+
+    it('should remove value[x] 0..0 rules from Extensions when there are extension rules', () => {
+      const extension = new ExportableExtension('ExtraExtension');
+      const extRule = new ExportableContainsRule('extension');
+      extRule.items = [{ name: 'my-sub-extension' }];
+      const valueRule = new ExportableCardRule('value[x]');
+      valueRule.min = 0;
+      valueRule.max = '0';
+      extension.rules = [extRule, valueRule];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(extension.rules).toEqual([extRule]);
+    });
+
+    it('should remove extension 0..0 rules from Extensions when there are value[x] rules', () => {
+      const extension = new ExportableExtension('ExtraExtension');
+      const valueRule = new ExportableOnlyRule('value[x]');
+      valueRule.types = [{ type: 'Quantity' }];
+      const extRule = new ExportableCardRule('extension');
+      extRule.min = 0;
+      extRule.max = '0';
+      extension.rules = [valueRule, extRule];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(extension.rules).toEqual([valueRule]);
+    });
+
+    it('should remove extension 0..0 rules from Extensions when there are specific value choice rules', () => {
+      const extension = new ExportableExtension('ExtraExtension');
+      const valueRule = new ExportableValueSetRule('valueCodeableConcept');
+      valueRule.strength = 'required';
+      valueRule.valueSet = 'http://example.org/FooVS';
+      const extRule = new ExportableCardRule('extension');
+      extRule.min = 0;
+      extRule.max = '0';
+      extension.rules = [valueRule, extRule];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(extension.rules).toEqual([valueRule]);
+    });
+
+    it('should remove nested value[x] 0..0 rules from Extensions when there are nested extension rules', () => {
+      const extension = new ExportableExtension('ExtraExtension');
+      const extRule = new ExportableContainsRule('extension');
+      extRule.items = [{ name: 'my-sub-extension' }];
+      const nestedExtRule = new ExportableContainsRule('extension[my-sub-extension].extension');
+      nestedExtRule.items = [{ name: 'my-sub-sub-extension' }];
+      const nestedValueRule = new ExportableCardRule('extension[my-sub-extension].value[x]');
+      nestedValueRule.min = 0;
+      nestedValueRule.max = '0';
+      const valueRule = new ExportableCardRule('value[x]');
+      valueRule.min = 0;
+      valueRule.max = '0';
+      extension.rules = [extRule, nestedExtRule, nestedValueRule, valueRule];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(extension.rules).toEqual([extRule, nestedExtRule]);
+    });
+
+    it('should remove nested extension 0..0 rules from Extensions when there are nested value rules', () => {
+      const extension = new ExportableExtension('ExtraExtension');
+      const extRule = new ExportableContainsRule('extension');
+      extRule.items = [{ name: 'my-sub-extension' }];
+      const nestedValueRule = new ExportableOnlyRule('extension[my-sub-extension].value[x]');
+      nestedValueRule.types = [{ type: 'Quantity' }];
+      const nestedExtRule = new ExportableCardRule('extension[my-sub-extension].extension');
+      nestedExtRule.min = 0;
+      nestedExtRule.max = '0';
+      const valueRule = new ExportableCardRule('value[x]');
+      valueRule.min = 0;
+      valueRule.max = '0';
+      extension.rules = [extRule, nestedValueRule, nestedExtRule, valueRule];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(extension.rules).toEqual([extRule, nestedValueRule]);
+    });
+
+    it('should not remove value[x] 0..0 rules from Extensions if there are not any extension rules', () => {
+      const extension = new ExportableExtension('ExtraExtension');
+      const valueRule = new ExportableCardRule('value[x]');
+      valueRule.min = 0;
+      valueRule.max = '0';
+      extension.rules = [valueRule];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(extension.rules).toEqual([valueRule]);
+    });
+
+    it('should not remove extension 0..0 rules from Extensions if there are not any value[x] rules', () => {
+      const extension = new ExportableExtension('ExtraExtension');
+      const extRule = new ExportableCardRule('extension');
+      extRule.min = 0;
+      extRule.max = '0';
+      extension.rules = [extRule];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(extension.rules).toEqual([extRule]);
+    });
+
+    it('should not remove value[x] 0..0 rules or extension 0..0 rules if both are present', () => {
+      const extension = new ExportableExtension('ExtraExtension');
+      const extRule = new ExportableCardRule('extension');
+      extRule.min = 0;
+      extRule.max = '0';
+      const valueRule = new ExportableCardRule('value[x]');
+      valueRule.min = 0;
+      valueRule.max = '0';
+      extension.rules = [extRule, valueRule];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(extension.rules).toEqual([extRule, valueRule]);
+    });
+
+    it('should not remove value[x] 0..0 rules from Profiles', () => {
+      const profile = new ExportableProfile('ExtraProfile');
+      profile.parent = 'Observation';
+      const extRule = new ExportableContainsRule('extension');
+      extRule.items = [{ name: 'my-sub-extension' }];
+      const valueRule = new ExportableCardRule('value[x]');
+      valueRule.min = 0;
+      valueRule.max = '0';
+      profile.rules = [extRule, valueRule];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+      expect(profile.rules).toEqual([extRule, valueRule]);
+    });
+
+    it('should not remove extension 0..0 rules from Extensions when there are value[x] rules', () => {
+      const profile = new ExportableProfile('ExtraProfile');
+      profile.parent = 'Observation';
+      const valueRule = new ExportableOnlyRule('value[x]');
+      valueRule.types = [{ type: 'Quantity' }];
+      const extRule = new ExportableCardRule('extension');
+      extRule.min = 0;
+      extRule.max = '0';
+      profile.rules = [valueRule, extRule];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+      expect(profile.rules).toEqual([valueRule, extRule]);
     });
   });
 });

--- a/test/processor/Package.test.ts
+++ b/test/processor/Package.test.ts
@@ -585,7 +585,7 @@ describe('Package', () => {
       expect(profile.rules).toEqual([extRule, valueRule]);
     });
 
-    it('should not remove extension 0..0 rules from Extensions when there are value[x] rules', () => {
+    it('should not remove extension 0..0 rules from Profiles when there are value[x] rules', () => {
       const profile = new ExportableProfile('ExtraProfile');
       profile.parent = 'Observation';
       const valueRule = new ExportableOnlyRule('value[x]');


### PR DESCRIPTION
When SUSHI exports extensions, it creates default 0..0 rules for extension or value[x], whichever path was not used by the extension.  This is because FHIR says that you can only use extension or value[x], but not both.

Now if GoFSH detects that type of situation, it will remove the 0..0 rules since SUSHI should generate them automatically (and they are therefore redundant).

To manually test this, run GoFSH from master on an IG with extensions and then run GoFSH from this branch on the same IG.  You'll note that some of the extension zeroed-out rules are no longer exported using this branch.