### PR TITLE
Remove default slicing rules

### DIFF
--- a/src/processor/Package.ts
+++ b/src/processor/Package.ts
@@ -278,27 +278,29 @@ export class Package {
     [...this.profiles, ...this.extensions].forEach(sd => {
       const rulesToMaybeRemove: number[] = [];
       sd.rules.forEach((rule, i, allRules) => {
-        if (
-          rule instanceof ExportableCaretValueRule &&
-          (rule.path.endsWith('extension') || rule.path.endsWith('modifierExtension'))
-        ) {
-          const hasSlicingDiscriminatorTypeRule =
-            rule.caretPath === 'slicing.discriminator[0].type' &&
-            rule.value instanceof FshCode &&
-            rule.value.code === 'value';
-          const hasSlicingDiscriminatorPathRule =
-            rule.caretPath === 'slicing.discriminator[0].path' && rule.value === 'url';
-          const hasSlicingOrderedRule =
-            rule.caretPath === 'slicing.ordered' && rule.value === false;
-          const hasSlicingRulesRule =
-            rule.caretPath === 'slicing.rules' &&
-            rule.value instanceof FshCode &&
-            rule.value.code === 'open';
+        if (rule instanceof ExportableCaretValueRule && /(modifierE|e)xtension$/.test(rule.path)) {
+          // * path ^slicing.discriminator[0].type = #value
+          const DEFAULT_SLICING_DISCRIMINATOR_TYPE = new ExportableCaretValueRule(rule.path);
+          DEFAULT_SLICING_DISCRIMINATOR_TYPE.caretPath = 'slicing.discriminator[0].type';
+          DEFAULT_SLICING_DISCRIMINATOR_TYPE.value = new FshCode('value');
+          // * path ^slicing.discriminator[0].value = "url"
+          const DEFAULT_SLICING_DISCRIMINATOR_PATH = new ExportableCaretValueRule(rule.path);
+          DEFAULT_SLICING_DISCRIMINATOR_PATH.caretPath = 'slicing.discriminator[0].path';
+          DEFAULT_SLICING_DISCRIMINATOR_PATH.value = 'url';
+          // * path ^slicing.ordered = false
+          const DEFAULT_SLICING_ORDERED = new ExportableCaretValueRule(rule.path);
+          DEFAULT_SLICING_ORDERED.caretPath = 'slicing.ordered';
+          DEFAULT_SLICING_ORDERED.value = false;
+          // * path ^slicing.rules = #open
+          const DEFAULT_SLICING_RULES = new ExportableCaretValueRule(rule.path);
+          DEFAULT_SLICING_RULES.caretPath = 'slicing.rules';
+          DEFAULT_SLICING_RULES.value = new FshCode('open');
           const hasContainsRule = allRules.some(
             otherRule => otherRule instanceof ExportableContainsRule && otherRule.path === rule.path
           );
           const hasOneSlicingDiscriminatorRule = !allRules.some(
             otherRule =>
+              otherRule.path === rule.path &&
               otherRule instanceof ExportableCaretValueRule &&
               otherRule.caretPath !== 'slicing.discriminator[0].type' &&
               otherRule.caretPath !== 'slicing.discriminator[0].path' &&
@@ -306,13 +308,13 @@ export class Package {
           );
           if (
             // One of the four default rules
-            (hasSlicingDiscriminatorTypeRule ||
-              hasSlicingDiscriminatorPathRule ||
-              hasSlicingOrderedRule ||
-              hasSlicingRulesRule) &&
+            (isEqual(rule, DEFAULT_SLICING_DISCRIMINATOR_TYPE) ||
+              isEqual(rule, DEFAULT_SLICING_DISCRIMINATOR_PATH) ||
+              isEqual(rule, DEFAULT_SLICING_ORDERED) ||
+              isEqual(rule, DEFAULT_SLICING_RULES)) &&
             // Some contains rule at the same path
             hasContainsRule &&
-            // No other slicing.discriminator rules
+            // No other slicing.discriminator rules at the same path
             hasOneSlicingDiscriminatorRule
           ) {
             rulesToMaybeRemove.push(i);

--- a/test/processor/Package.test.ts
+++ b/test/processor/Package.test.ts
@@ -929,6 +929,51 @@ describe('Package', () => {
       expect(profile.rules).toHaveLength(7); // No rules removed
     });
 
+    it('should remove default slicing from profiles when additional discriminators present on other paths', () => {
+      const profile = new ExportableProfile('ProfileWithSlice');
+      const defaultDiscriminatorTypeRule = new ExportableCaretValueRule('extension');
+      defaultDiscriminatorTypeRule.caretPath = 'slicing.discriminator[0].type';
+      defaultDiscriminatorTypeRule.value = new FshCode('value');
+      const defaultDiscriminatorPathRule = new ExportableCaretValueRule('extension');
+      defaultDiscriminatorPathRule.caretPath = 'slicing.discriminator[0].path';
+      defaultDiscriminatorPathRule.value = 'url';
+      const otherDiscriminatorTypeRuleA = new ExportableCaretValueRule('status.extension');
+      otherDiscriminatorTypeRuleA.caretPath = 'slicing.discriminator[0].type';
+      otherDiscriminatorTypeRuleA.value = new FshCode('profile');
+      const otherDiscriminatorPathRuleA = new ExportableCaretValueRule('status.extension');
+      otherDiscriminatorPathRuleA.caretPath = 'slicing.discriminator[0].path';
+      otherDiscriminatorPathRuleA.value = 'system';
+      const otherDiscriminatorTypeRuleB = new ExportableCaretValueRule('status.extension');
+      otherDiscriminatorTypeRuleB.caretPath = 'slicing.discriminator[1].type';
+      otherDiscriminatorTypeRuleB.value = new FshCode('profile');
+      const otherDiscriminatorPathRuleB = new ExportableCaretValueRule('status.extension');
+      otherDiscriminatorPathRuleB.caretPath = 'slicing.discriminator[1].path';
+      otherDiscriminatorPathRuleB.value = 'system';
+      const orderedRule = new ExportableCaretValueRule('extension');
+      orderedRule.caretPath = 'slicing.ordered';
+      orderedRule.value = false;
+      const rulesRule = new ExportableCaretValueRule('extension');
+      rulesRule.caretPath = 'slicing.rules';
+      rulesRule.value = new FshCode('open');
+      const containsRule = new ExportableContainsRule('extension');
+      containsRule.items.push({ name: 'foo' });
+      profile.rules = [
+        defaultDiscriminatorTypeRule,
+        defaultDiscriminatorPathRule,
+        otherDiscriminatorTypeRuleA,
+        otherDiscriminatorPathRuleA,
+        otherDiscriminatorTypeRuleB,
+        otherDiscriminatorPathRuleB,
+        orderedRule,
+        rulesRule,
+        containsRule
+      ];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+      expect(profile.rules).toHaveLength(5); // Default rules on extension removed, rules on status.extension not removed
+    });
+
     it('should not remove default slicing from profiles if any default is missing', () => {
       const profile = new ExportableProfile('ProfileWithSlice');
       const discriminatorTypeRule = new ExportableCaretValueRule('extension');

--- a/test/processor/Package.test.ts
+++ b/test/processor/Package.test.ts
@@ -723,5 +723,329 @@ describe('Package', () => {
       myPackage.optimize(processor);
       expect(extension.rules).toEqual([assignmentRule]);
     });
+
+    it('should remove default slicing rules from profiles', () => {
+      const profile = new ExportableProfile('ProfileWithSlice');
+      const discriminatorTypeRule = new ExportableCaretValueRule('extension');
+      discriminatorTypeRule.caretPath = 'slicing.discriminator[0].type';
+      discriminatorTypeRule.value = new FshCode('value');
+      const discriminatorPathRule = new ExportableCaretValueRule('extension');
+      discriminatorPathRule.caretPath = 'slicing.discriminator[0].path';
+      discriminatorPathRule.value = 'url';
+      const orderedRule = new ExportableCaretValueRule('extension');
+      orderedRule.caretPath = 'slicing.ordered';
+      orderedRule.value = false;
+      const rulesRule = new ExportableCaretValueRule('extension');
+      rulesRule.caretPath = 'slicing.rules';
+      rulesRule.value = new FshCode('open');
+      const containsRule = new ExportableContainsRule('extension');
+      containsRule.items.push({ name: 'foo' });
+      profile.rules = [
+        discriminatorTypeRule,
+        discriminatorPathRule,
+        orderedRule,
+        rulesRule,
+        containsRule
+      ];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+      expect(profile.rules).toHaveLength(1); // Default slicing rules removed, only contains rule
+      expect(profile.rules[0]).toBeInstanceOf(ExportableContainsRule);
+    });
+
+    it('should not remove non-default slicing rules from profiles (different discriminator.type)', () => {
+      const profile = new ExportableProfile('ProfileWithSlice');
+      const discriminatorTypeRule = new ExportableCaretValueRule('extension');
+      discriminatorTypeRule.caretPath = 'slicing.discriminator[0].type';
+      discriminatorTypeRule.value = new FshCode('profile'); // Non-default type
+      const discriminatorPathRule = new ExportableCaretValueRule('extension');
+      discriminatorPathRule.caretPath = 'slicing.discriminator[0].path';
+      discriminatorPathRule.value = 'url';
+      const orderedRule = new ExportableCaretValueRule('extension');
+      orderedRule.caretPath = 'slicing.ordered';
+      orderedRule.value = false;
+      const rulesRule = new ExportableCaretValueRule('extension');
+      rulesRule.caretPath = 'slicing.rules';
+      rulesRule.value = new FshCode('open');
+      const containsRule = new ExportableContainsRule('extension');
+      containsRule.items.push({ name: 'foo' });
+      profile.rules = [
+        discriminatorTypeRule,
+        discriminatorPathRule,
+        orderedRule,
+        rulesRule,
+        containsRule
+      ];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+      expect(profile.rules).toHaveLength(5); // No rules removed
+    });
+
+    it('should not remove non-default slicing rules from profiles (different discriminator.path)', () => {
+      const profile = new ExportableProfile('ProfileWithSlice');
+      const discriminatorTypeRule = new ExportableCaretValueRule('extension');
+      discriminatorTypeRule.caretPath = 'slicing.discriminator[0].type';
+      discriminatorTypeRule.value = new FshCode('value');
+      const discriminatorPathRule = new ExportableCaretValueRule('extension');
+      discriminatorPathRule.caretPath = 'slicing.discriminator[0].path';
+      discriminatorPathRule.value = 'system'; // Non-default path
+      const orderedRule = new ExportableCaretValueRule('extension');
+      orderedRule.caretPath = 'slicing.ordered';
+      orderedRule.value = false;
+      const rulesRule = new ExportableCaretValueRule('extension');
+      rulesRule.caretPath = 'slicing.rules';
+      rulesRule.value = new FshCode('open');
+      const containsRule = new ExportableContainsRule('extension');
+      containsRule.items.push({ name: 'foo' });
+      profile.rules = [
+        discriminatorTypeRule,
+        discriminatorPathRule,
+        orderedRule,
+        rulesRule,
+        containsRule
+      ];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+      expect(profile.rules).toHaveLength(5); // No rules removed
+    });
+
+    it('should not remove non-default slicing rules from profiles (different ordered)', () => {
+      const profile = new ExportableProfile('ProfileWithSlice');
+      const discriminatorTypeRule = new ExportableCaretValueRule('extension');
+      discriminatorTypeRule.caretPath = 'slicing.discriminator[0].type';
+      discriminatorTypeRule.value = new FshCode('value');
+      const discriminatorPathRule = new ExportableCaretValueRule('extension');
+      discriminatorPathRule.caretPath = 'slicing.discriminator[0].path';
+      discriminatorPathRule.value = 'url';
+      const orderedRule = new ExportableCaretValueRule('extension');
+      orderedRule.caretPath = 'slicing.ordered';
+      orderedRule.value = true; // Non-default ordered
+      const rulesRule = new ExportableCaretValueRule('extension');
+      rulesRule.caretPath = 'slicing.rules';
+      rulesRule.value = new FshCode('open');
+      const containsRule = new ExportableContainsRule('extension');
+      containsRule.items.push({ name: 'foo' });
+      profile.rules = [
+        discriminatorTypeRule,
+        discriminatorPathRule,
+        orderedRule,
+        rulesRule,
+        containsRule
+      ];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+      expect(profile.rules).toHaveLength(5); // No rules removed
+    });
+
+    it('should not remove non-default slicing rules from profiles (different rules)', () => {
+      const profile = new ExportableProfile('ProfileWithSlice');
+      const discriminatorTypeRule = new ExportableCaretValueRule('extension');
+      discriminatorTypeRule.caretPath = 'slicing.discriminator[0].type';
+      discriminatorTypeRule.value = new FshCode('value');
+      const discriminatorPathRule = new ExportableCaretValueRule('extension');
+      discriminatorPathRule.caretPath = 'slicing.discriminator[0].path';
+      discriminatorPathRule.value = 'url';
+      const orderedRule = new ExportableCaretValueRule('extension');
+      orderedRule.caretPath = 'slicing.ordered';
+      orderedRule.value = false;
+      const rulesRule = new ExportableCaretValueRule('extension');
+      rulesRule.caretPath = 'slicing.rules';
+      rulesRule.value = new FshCode('closed'); // Non-default rules
+      const containsRule = new ExportableContainsRule('extension');
+      containsRule.items.push({ name: 'foo' });
+      profile.rules = [
+        discriminatorTypeRule,
+        discriminatorPathRule,
+        orderedRule,
+        rulesRule,
+        containsRule
+      ];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+      expect(profile.rules).toHaveLength(5); // No rules removed
+    });
+
+    it('should not remove default slicing rules from profiles if no contains rule follows', () => {
+      const profile = new ExportableProfile('ProfileWithSlice');
+      const discriminatorTypeRule = new ExportableCaretValueRule('extension');
+      discriminatorTypeRule.caretPath = 'slicing.discriminator[0].type';
+      discriminatorTypeRule.value = new FshCode('value');
+      const discriminatorPathRule = new ExportableCaretValueRule('extension');
+      discriminatorPathRule.caretPath = 'slicing.discriminator[0].path';
+      discriminatorPathRule.value = 'url';
+      const orderedRule = new ExportableCaretValueRule('extension');
+      orderedRule.caretPath = 'slicing.ordered';
+      orderedRule.value = false;
+      const rulesRule = new ExportableCaretValueRule('extension');
+      rulesRule.caretPath = 'slicing.rules';
+      rulesRule.value = new FshCode('open');
+      // No contains rule
+      profile.rules = [discriminatorTypeRule, discriminatorPathRule, orderedRule, rulesRule];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+      expect(profile.rules).toHaveLength(4); // No rules removed
+    });
+
+    it('should not remove default slicing from profiles when additional discriminators present', () => {
+      const profile = new ExportableProfile('ProfileWithSlice');
+      const defaultDiscriminatorTypeRule = new ExportableCaretValueRule('extension');
+      defaultDiscriminatorTypeRule.caretPath = 'slicing.discriminator[0].type';
+      defaultDiscriminatorTypeRule.value = new FshCode('value');
+      const defaultDiscriminatorPathRule = new ExportableCaretValueRule('extension');
+      defaultDiscriminatorPathRule.caretPath = 'slicing.discriminator[0].path';
+      defaultDiscriminatorPathRule.value = 'url';
+      const otherDiscriminatorTypeRule = new ExportableCaretValueRule('extension');
+      otherDiscriminatorTypeRule.caretPath = 'slicing.discriminator[1].type';
+      otherDiscriminatorTypeRule.value = new FshCode('profile');
+      const otherDiscriminatorPathRule = new ExportableCaretValueRule('extension');
+      otherDiscriminatorPathRule.caretPath = 'slicing.discriminator[1].path';
+      otherDiscriminatorPathRule.value = 'system';
+      const orderedRule = new ExportableCaretValueRule('extension');
+      orderedRule.caretPath = 'slicing.ordered';
+      orderedRule.value = false;
+      const rulesRule = new ExportableCaretValueRule('extension');
+      rulesRule.caretPath = 'slicing.rules';
+      rulesRule.value = new FshCode('open');
+      const containsRule = new ExportableContainsRule('extension');
+      containsRule.items.push({ name: 'foo' });
+      profile.rules = [
+        defaultDiscriminatorTypeRule,
+        defaultDiscriminatorPathRule,
+        otherDiscriminatorTypeRule,
+        otherDiscriminatorPathRule,
+        orderedRule,
+        rulesRule,
+        containsRule
+      ];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+      expect(profile.rules).toHaveLength(7); // No rules removed
+    });
+
+    it('should not remove default slicing from profiles if any default is missing', () => {
+      const profile = new ExportableProfile('ProfileWithSlice');
+      const discriminatorTypeRule = new ExportableCaretValueRule('extension');
+      discriminatorTypeRule.caretPath = 'slicing.discriminator[0].type';
+      discriminatorTypeRule.value = new FshCode('value');
+      const discriminatorPathRule = new ExportableCaretValueRule('extension');
+      discriminatorPathRule.caretPath = 'slicing.discriminator[0].path';
+      discriminatorPathRule.value = 'url';
+      const orderedRule = new ExportableCaretValueRule('extension');
+      orderedRule.caretPath = 'slicing.ordered';
+      orderedRule.value = false;
+      const rulesRule = new ExportableCaretValueRule('status');
+      rulesRule.caretPath = 'slicing.rules';
+      rulesRule.value = new FshCode('open'); // Default rule on different path
+      const containsRule = new ExportableContainsRule('extension');
+      containsRule.items.push({ name: 'foo' });
+      profile.rules = [
+        discriminatorTypeRule,
+        discriminatorPathRule,
+        orderedRule,
+        rulesRule,
+        containsRule
+      ];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+      expect(profile.rules).toHaveLength(5); // No rules removed
+    });
+
+    it('should remove default slicing on modifierExtensions on profiles', () => {
+      const profile = new ExportableProfile('ProfileWithSlice');
+      const discriminatorTypeRule = new ExportableCaretValueRule('modifierExtension');
+      discriminatorTypeRule.caretPath = 'slicing.discriminator[0].type';
+      discriminatorTypeRule.value = new FshCode('value');
+      const discriminatorPathRule = new ExportableCaretValueRule('modifierExtension');
+      discriminatorPathRule.caretPath = 'slicing.discriminator[0].path';
+      discriminatorPathRule.value = 'url';
+      const orderedRule = new ExportableCaretValueRule('modifierExtension');
+      orderedRule.caretPath = 'slicing.ordered';
+      orderedRule.value = false;
+      const rulesRule = new ExportableCaretValueRule('modifierExtension');
+      rulesRule.caretPath = 'slicing.rules';
+      rulesRule.value = new FshCode('open');
+      const containsRule = new ExportableContainsRule('modifierExtension');
+      containsRule.items.push({ name: 'foo' });
+      profile.rules = [
+        discriminatorTypeRule,
+        discriminatorPathRule,
+        orderedRule,
+        rulesRule,
+        containsRule
+      ];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+      expect(profile.rules).toHaveLength(1); // Default slicing rules removed, only contains rule
+      expect(profile.rules[0]).toBeInstanceOf(ExportableContainsRule);
+    });
+
+    it('should remove default slicing on any path from profiles', () => {
+      const profile = new ExportableProfile('ProfileWithSlice');
+      const discriminatorTypeRule = new ExportableCaretValueRule('status.extension');
+      discriminatorTypeRule.caretPath = 'slicing.discriminator[0].type';
+      discriminatorTypeRule.value = new FshCode('value');
+      const discriminatorPathRule = new ExportableCaretValueRule('status.extension');
+      discriminatorPathRule.caretPath = 'slicing.discriminator[0].path';
+      discriminatorPathRule.value = 'url';
+      const orderedRule = new ExportableCaretValueRule('status.extension');
+      orderedRule.caretPath = 'slicing.ordered';
+      orderedRule.value = false;
+      const rulesRule = new ExportableCaretValueRule('status.extension');
+      rulesRule.caretPath = 'slicing.rules';
+      rulesRule.value = new FshCode('open');
+      const containsRule = new ExportableContainsRule('status.extension');
+      containsRule.items.push({ name: 'foo' });
+      profile.rules = [
+        discriminatorTypeRule,
+        discriminatorPathRule,
+        orderedRule,
+        rulesRule,
+        containsRule
+      ];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+      expect(profile.rules).toHaveLength(1); // Default slicing rules removed, only contains rule
+      expect(profile.rules[0]).toBeInstanceOf(ExportableContainsRule);
+    });
+
+    it('should remove default slicing from extensions', () => {
+      const extension = new ExportableExtension('ProfileWithSlice');
+      const discriminatorTypeRule = new ExportableCaretValueRule('extension');
+      discriminatorTypeRule.caretPath = 'slicing.discriminator[0].type';
+      discriminatorTypeRule.value = new FshCode('value');
+      const discriminatorPathRule = new ExportableCaretValueRule('extension');
+      discriminatorPathRule.caretPath = 'slicing.discriminator[0].path';
+      discriminatorPathRule.value = 'url';
+      const orderedRule = new ExportableCaretValueRule('extension');
+      orderedRule.caretPath = 'slicing.ordered';
+      orderedRule.value = false;
+      const rulesRule = new ExportableCaretValueRule('extension');
+      rulesRule.caretPath = 'slicing.rules';
+      rulesRule.value = new FshCode('open');
+      const containsRule = new ExportableContainsRule('extension');
+      containsRule.items.push({ name: 'foo' });
+      extension.rules = [
+        discriminatorTypeRule,
+        discriminatorPathRule,
+        orderedRule,
+        rulesRule,
+        containsRule
+      ];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(extension.rules).toHaveLength(1); // Default slicing rules removed, only contains rule
+      expect(extension.rules[0]).toBeInstanceOf(ExportableContainsRule);
+    });
   });
 });


### PR DESCRIPTION
This PR addresses [CIMPL-529](https://standardhealthrecord.atlassian.net/browse/CIMPL-529) and supports removing the default slicing rules when present. The rules removed are: 

```
* extension ^slicing.discriminator[0].type = #value
* extension ^slicing.discriminator[0].path = "url"
* extension ^slicing.ordered = false
* extension ^slicing.rules = #open
```
These rules can be on extensions on any element, as well as on modifierExtensions. When they are present, there is also a contains rule at the same path, and there are no additional `slicing.discriminator` rules present, these four rules will be removed.