### PR TITLE
Suppress URL Assignment Rules when possible

### DIFF
--- a/src/processor/Package.ts
+++ b/src/processor/Package.ts
@@ -233,15 +233,17 @@ export class Package {
 
   private suppressUrlAssignmentOnExtensions(): void {
     // Loop over all profiles and extensions, removing assignment rules on inline extensions
+    // NOTE: Inline extensions on a profile are allowed by SUSHI, but they are technically not
+    // valid FHIR and the IG Publisher does not like this
     [...this.profiles, ...this.extensions].forEach(sd => {
       const rulesToRemove: number[] = [];
       sd.rules.forEach(rule => {
-        if (rule instanceof ExportableContainsRule && rule.path.endsWith('extension')) {
+        if (rule instanceof ExportableContainsRule && /(modifierE|e)xtension$/.test(rule.path)) {
           rule.items.forEach(item => {
             const assignmentRuleIdx = sd.rules.findIndex(
               other =>
-                other.path === `${rule.path}[${item.name}].url` &&
                 other instanceof ExportableFixedValueRule &&
+                other.path === `${rule.path}[${item.name}].url` &&
                 other.fixedValue === item.name
             );
             if (assignmentRuleIdx >= 0) {

--- a/src/processor/Package.ts
+++ b/src/processor/Package.ts
@@ -66,6 +66,7 @@ export class Package {
     this.constructNamedExtensionContainsRules();
     this.suppressChoiceSlicingRules();
     this.removeDefaultExtensionContextRules();
+    this.removeImpliedZeroToZeroCardRules();
   }
 
   private resolveProfileParents(processor: FHIRProcessor): void {
@@ -191,6 +192,40 @@ export class Package {
           pullAt(sd.rules, [typeRuleIdx, expressionRuleIdx]);
         }
       }
+    });
+  }
+
+  // If an extension has meaningful value[x] rules, SUSHI will constrain extension to 0..0.
+  // If an extension adds sub-extensions, SUSHI will constrain value[x] to 0..0.
+  // GoFSH does not need to output these 0..0 rules since SUSHI will automatically add them.
+  // This goes for top-value paths in extensions as well as all sub-extensions.
+  private removeImpliedZeroToZeroCardRules(): void {
+    this.extensions.forEach(sd => {
+      const rulesToRemove: number[] = [];
+      sd.rules.forEach((r, i) => {
+        if (
+          // r is a 0..0 card rule, AND
+          r instanceof ExportableCardRule &&
+          r.max === '0' &&
+          //r is an extension path and there exist sibling value paths that are not 0..0, OR
+          ((r.path.endsWith('extension') &&
+            sd.rules.some(
+              r2 =>
+                r2.path.startsWith(r.path.replace(/extension$/, 'value')) &&
+                !(r2 instanceof ExportableCardRule && r2.max === '0')
+            )) ||
+            // r is a value[x] path and there exist sibling extension paths that are not 0..0
+            (r.path.endsWith('value[x]') &&
+              sd.rules.some(
+                r2 =>
+                  r2.path.startsWith(r.path.replace(/value\[x]$/, 'extension')) &&
+                  !(r2 instanceof ExportableCardRule && r2.max === '0')
+              )))
+        ) {
+          rulesToRemove.push(i);
+        }
+      });
+      pullAt(sd.rules, rulesToRemove);
     });
   }
 }

--- a/test/processor/Package.test.ts
+++ b/test/processor/Package.test.ts
@@ -627,5 +627,85 @@ describe('Package', () => {
       myPackage.optimize(processor);
       expect(profile.rules).toEqual([valueRule, extRule]);
     });
+    // suppressUrlAssignmentOnExtensions
+    it('should remove URL assignment rules on inline extensions on an extension', () => {
+      const extension = new ExportableExtension('MyExtension');
+      const containsRule = new ExportableContainsRule('extension');
+      containsRule.items.push({ name: 'foo' });
+      const assignmentRule = new ExportableFixedValueRule('extension[foo].url');
+      assignmentRule.fixedValue = 'foo';
+      extension.rules = [containsRule, assignmentRule];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(extension.rules).toEqual([containsRule]);
+    });
+
+    it('should remove URL assignment rules on inline extensions on a profile', () => {
+      const profile = new ExportableProfile('MyProfile');
+      const containsRule = new ExportableContainsRule('extension');
+      containsRule.items.push({ name: 'foo' });
+      const assignmentRule = new ExportableFixedValueRule('extension[foo].url');
+      assignmentRule.fixedValue = 'foo';
+      profile.rules = [containsRule, assignmentRule];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+      expect(profile.rules).toEqual([containsRule]);
+    });
+
+    it('should not remove other URL rules on inline extensions on a profile', () => {
+      const profile = new ExportableProfile('MyProfile');
+      const containsRule = new ExportableContainsRule('extension');
+      containsRule.items.push({ name: 'foo' });
+      const assignmentRule = new ExportableFlagRule('extension[foo].url');
+      assignmentRule.mustSupport = true;
+      profile.rules = [containsRule, assignmentRule];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+      expect(profile.rules).toEqual([containsRule, assignmentRule]);
+    });
+
+    it('should remove a URL assignment rule on an extension only when that URL matches the canonical', () => {
+      const extension = new ExportableExtension('MyExtension');
+      const assignmentRule = new ExportableFixedValueRule('url');
+      assignmentRule.fixedValue = 'http://example.org/StructureDefinition/MyExtension';
+      extension.rules = [assignmentRule];
+      const myPackage = new Package();
+      myPackage.configuration = new ExportableConfiguration({
+        fhirVersion: ['4.0.1'],
+        canonical: 'http://example.org'
+      });
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(extension.rules).toEqual([]);
+    });
+
+    it('should not remove a URL assignment rule on an extension when that URL does not match the canonical', () => {
+      const extension = new ExportableExtension('MyExtension');
+      const assignmentRule = new ExportableFixedValueRule('url');
+      assignmentRule.fixedValue = 'http://example.org/StructureDefinition/MyExtension';
+      extension.rules = [assignmentRule];
+      const myPackage = new Package();
+      myPackage.configuration = new ExportableConfiguration({
+        fhirVersion: ['4.0.1'],
+        canonical: 'http://other-canonical.org'
+      });
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(extension.rules).toEqual([assignmentRule]);
+    });
+
+    it('should not remove a URL assignment rule on an extension if there is no configuration', () => {
+      const extension = new ExportableExtension('MyExtension');
+      const assignmentRule = new ExportableFixedValueRule('url');
+      assignmentRule.fixedValue = 'http://example.org/StructureDefinition/MyExtension';
+      extension.rules = [assignmentRule];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(extension.rules).toEqual([assignmentRule]);
+    });
   });
 });

--- a/test/processor/Package.test.ts
+++ b/test/processor/Package.test.ts
@@ -627,6 +627,7 @@ describe('Package', () => {
       myPackage.optimize(processor);
       expect(profile.rules).toEqual([valueRule, extRule]);
     });
+
     // suppressUrlAssignmentOnExtensions
     it('should remove URL assignment rules on inline extensions on an extension', () => {
       const extension = new ExportableExtension('MyExtension');
@@ -655,6 +656,8 @@ describe('Package', () => {
     });
 
     it('should remove URL assignment rules on inline extensions on a profile', () => {
+      // Note that inline extensions on a profile are poor form, SUSHI allows it, but it is not valid
+      // FHIR and the IG Publisher will get mad
       const profile = new ExportableProfile('MyProfile');
       const containsRule = new ExportableContainsRule('extension');
       containsRule.items.push({ name: 'foo' });

--- a/test/processor/Package.test.ts
+++ b/test/processor/Package.test.ts
@@ -674,13 +674,13 @@ describe('Package', () => {
       const profile = new ExportableProfile('MyProfile');
       const containsRule = new ExportableContainsRule('extension');
       containsRule.items.push({ name: 'foo' });
-      const assignmentRule = new ExportableFlagRule('extension[foo].url');
-      assignmentRule.mustSupport = true;
-      profile.rules = [containsRule, assignmentRule];
+      const flagRule = new ExportableFlagRule('extension[foo].url');
+      flagRule.mustSupport = true;
+      profile.rules = [containsRule, flagRule];
       const myPackage = new Package();
       myPackage.add(profile);
       myPackage.optimize(processor);
-      expect(profile.rules).toEqual([containsRule, assignmentRule]);
+      expect(profile.rules).toEqual([containsRule, flagRule]);
     });
 
     it('should remove a URL assignment rule on an extension only when that URL matches the canonical', () => {

--- a/test/processor/Package.test.ts
+++ b/test/processor/Package.test.ts
@@ -641,6 +641,19 @@ describe('Package', () => {
       expect(extension.rules).toEqual([containsRule]);
     });
 
+    it('should remove URL assignment rules on inline extensions on a modifierExtension', () => {
+      const extension = new ExportableExtension('MyExtension');
+      const containsRule = new ExportableContainsRule('modifierExtension');
+      containsRule.items.push({ name: 'foo' });
+      const assignmentRule = new ExportableFixedValueRule('modifierExtension[foo].url');
+      assignmentRule.fixedValue = 'foo';
+      extension.rules = [containsRule, assignmentRule];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(extension.rules).toEqual([containsRule]);
+    });
+
     it('should remove URL assignment rules on inline extensions on a profile', () => {
       const profile = new ExportableProfile('MyProfile');
       const containsRule = new ExportableContainsRule('extension');

--- a/test/processor/Package.test.ts
+++ b/test/processor/Package.test.ts
@@ -13,7 +13,8 @@ import {
   ExportableContainsRule,
   ExportableOnlyRule,
   ExportableCaretValueRule,
-  ExportableFixedValueRule
+  ExportableFixedValueRule,
+  ExportableValueSetRule
 } from '../../src/exportable';
 import { FHIRProcessor } from '../../src/processor/FHIRProcessor';
 import { ExportableCombinedCardFlagRule } from '../../src/exportable/ExportableCombinedCardFlagRule';
@@ -475,6 +476,156 @@ describe('Package', () => {
       myPackage.add(profile);
       myPackage.optimize(processor);
       expect(profile.rules).toHaveLength(2);
+    });
+
+    it('should remove value[x] 0..0 rules from Extensions when there are extension rules', () => {
+      const extension = new ExportableExtension('ExtraExtension');
+      const extRule = new ExportableContainsRule('extension');
+      extRule.items = [{ name: 'my-sub-extension' }];
+      const valueRule = new ExportableCardRule('value[x]');
+      valueRule.min = 0;
+      valueRule.max = '0';
+      extension.rules = [extRule, valueRule];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(extension.rules).toEqual([extRule]);
+    });
+
+    it('should remove extension 0..0 rules from Extensions when there are value[x] rules', () => {
+      const extension = new ExportableExtension('ExtraExtension');
+      const valueRule = new ExportableOnlyRule('value[x]');
+      valueRule.types = [{ type: 'Quantity' }];
+      const extRule = new ExportableCardRule('extension');
+      extRule.min = 0;
+      extRule.max = '0';
+      extension.rules = [valueRule, extRule];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(extension.rules).toEqual([valueRule]);
+    });
+
+    it('should remove extension 0..0 rules from Extensions when there are specific value choice rules', () => {
+      const extension = new ExportableExtension('ExtraExtension');
+      const valueRule = new ExportableValueSetRule('valueCodeableConcept');
+      valueRule.strength = 'required';
+      valueRule.valueSet = 'http://example.org/FooVS';
+      const extRule = new ExportableCardRule('extension');
+      extRule.min = 0;
+      extRule.max = '0';
+      extension.rules = [valueRule, extRule];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(extension.rules).toEqual([valueRule]);
+    });
+
+    it('should remove nested value[x] 0..0 rules from Extensions when there are nested extension rules', () => {
+      const extension = new ExportableExtension('ExtraExtension');
+      const extRule = new ExportableContainsRule('extension');
+      extRule.items = [{ name: 'my-sub-extension' }];
+      const nestedExtRule = new ExportableContainsRule('extension[my-sub-extension].extension');
+      nestedExtRule.items = [{ name: 'my-sub-sub-extension' }];
+      const nestedValueRule = new ExportableCardRule('extension[my-sub-extension].value[x]');
+      nestedValueRule.min = 0;
+      nestedValueRule.max = '0';
+      const valueRule = new ExportableCardRule('value[x]');
+      valueRule.min = 0;
+      valueRule.max = '0';
+      extension.rules = [extRule, nestedExtRule, nestedValueRule, valueRule];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(extension.rules).toEqual([extRule, nestedExtRule]);
+    });
+
+    it('should remove nested extension 0..0 rules from Extensions when there are nested value rules', () => {
+      const extension = new ExportableExtension('ExtraExtension');
+      const extRule = new ExportableContainsRule('extension');
+      extRule.items = [{ name: 'my-sub-extension' }];
+      const nestedValueRule = new ExportableOnlyRule('extension[my-sub-extension].value[x]');
+      nestedValueRule.types = [{ type: 'Quantity' }];
+      const nestedExtRule = new ExportableCardRule('extension[my-sub-extension].extension');
+      nestedExtRule.min = 0;
+      nestedExtRule.max = '0';
+      const valueRule = new ExportableCardRule('value[x]');
+      valueRule.min = 0;
+      valueRule.max = '0';
+      extension.rules = [extRule, nestedValueRule, nestedExtRule, valueRule];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(extension.rules).toEqual([extRule, nestedValueRule]);
+    });
+
+    it('should not remove value[x] 0..0 rules from Extensions if there are not any extension rules', () => {
+      const extension = new ExportableExtension('ExtraExtension');
+      const valueRule = new ExportableCardRule('value[x]');
+      valueRule.min = 0;
+      valueRule.max = '0';
+      extension.rules = [valueRule];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(extension.rules).toEqual([valueRule]);
+    });
+
+    it('should not remove extension 0..0 rules from Extensions if there are not any value[x] rules', () => {
+      const extension = new ExportableExtension('ExtraExtension');
+      const extRule = new ExportableCardRule('extension');
+      extRule.min = 0;
+      extRule.max = '0';
+      extension.rules = [extRule];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(extension.rules).toEqual([extRule]);
+    });
+
+    it('should not remove value[x] 0..0 rules or extension 0..0 rules if both are present', () => {
+      const extension = new ExportableExtension('ExtraExtension');
+      const extRule = new ExportableCardRule('extension');
+      extRule.min = 0;
+      extRule.max = '0';
+      const valueRule = new ExportableCardRule('value[x]');
+      valueRule.min = 0;
+      valueRule.max = '0';
+      extension.rules = [extRule, valueRule];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(extension.rules).toEqual([extRule, valueRule]);
+    });
+
+    it('should not remove value[x] 0..0 rules from Profiles', () => {
+      const profile = new ExportableProfile('ExtraProfile');
+      profile.parent = 'Observation';
+      const extRule = new ExportableContainsRule('extension');
+      extRule.items = [{ name: 'my-sub-extension' }];
+      const valueRule = new ExportableCardRule('value[x]');
+      valueRule.min = 0;
+      valueRule.max = '0';
+      profile.rules = [extRule, valueRule];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+      expect(profile.rules).toEqual([extRule, valueRule]);
+    });
+
+    it('should not remove extension 0..0 rules from Profiles when there are value[x] rules', () => {
+      const profile = new ExportableProfile('ExtraProfile');
+      profile.parent = 'Observation';
+      const valueRule = new ExportableOnlyRule('value[x]');
+      valueRule.types = [{ type: 'Quantity' }];
+      const extRule = new ExportableCardRule('extension');
+      extRule.min = 0;
+      extRule.max = '0';
+      profile.rules = [valueRule, extRule];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+      expect(profile.rules).toEqual([valueRule, extRule]);
     });
   });
 });


### PR DESCRIPTION
This suppresses URL assignment rules on extensions when appropriate. There are two cases addressed here. 

The first is that when a new inline extension is created, SUSHI will add a `fixedUri` of the `sliceName` of the extension to the `url` element on that extension. So, if GoFSH creates two rules like this:
```
* extension contains detailed 0..*
* extension[detailed].url = "detailed" (exactly)
```
the `optimize` function will now recognize that SUSHI will infer the second rule, and the second rule is removed.

The second case is for standalone extension definitions. Similar to above, SUSHI will add a `fixedUri` of the `url` of the extension to the `url` element on the extension. So, if on an extension definition, GoFSH creates a  rule like this:
```
* url = "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race" (exactly)
```
And that url matches the one generated by combining the canonical and the Extensions `id`, then the `optimize` function of GoFSH will remove that rule. Note that this optimization requires that the canonical is known. If that information is not available, we cannot know for sure if SUSHI will infer the rule correctly, so we leave the rule on the Extension.