### PR TITLE
Extension do not set Parent to Extension URL

### DIFF
--- a/src/exportable/common.ts
+++ b/src/exportable/common.ts
@@ -13,7 +13,10 @@ export function metadataToFSH(
     }
   } else if (definition instanceof ExportableExtension) {
     resultLines.push(`Extension: ${definition.name}`);
-    if (definition.parent != 'Extension') {
+    if (
+      definition.parent != 'Extension' &&
+      definition.parent != 'http://hl7.org/fhir/StructureDefinition/Extension'
+    ) {
       resultLines.push(`Parent: ${definition.parent}`);
     }
   } else if (definition instanceof ExportableCodeSystem) {

--- a/test/exportable/ExportableExtension.test.ts
+++ b/test/exportable/ExportableExtension.test.ts
@@ -24,10 +24,28 @@ describe('ExportableExtension', () => {
 
     const expectedResult = [
       'Extension: MyExtension',
-      // NOTE: Since parent is Extension, it is ommitted from FSH
+      // NOTE: Since parent is Extension, it is omitted from FSH
       'Id: my-extension',
       'Title: "My Extension"',
       'Description: "My extension is not very extensive."'
+    ].join(EOL);
+    const result = input.toFSH();
+    expect(result).toBe(expectedResult);
+  });
+
+  it('should export an extension with additional metadata without extension url as Parent', () => {
+    const input = new ExportableExtension('MyExtension');
+    input.parent = 'http://hl7.org/fhir/StructureDefinition/Extension'; // baseDefinition of Extension StructureDefinition
+    input.id = 'my-extension';
+    input.title = 'My Extension';
+    input.description = 'This extension will not have the Extension URL as the parent.';
+
+    const expectedResult = [
+      'Extension: MyExtension',
+      // NOTE: Since parent is Extension baseDefinition, it is omitted from FSH
+      'Id: my-extension',
+      'Title: "My Extension"',
+      'Description: "This extension will not have the Extension URL as the parent."'
     ].join(EOL);
     const result = input.toFSH();
     expect(result).toBe(expectedResult);


### PR DESCRIPTION
This PR addresses [CIMPL-533](https://standardhealthrecord.atlassian.net/browse/CIMPL-533) and suppresses the Parent on Extensions when the parent is extension, such as:

```
Extension: MyExtension
Parent: http://hl7.org/fhir/StructureDefinition/Extension
```
We were already trying to suppress the parent if it was set to `Extension`, so I added the extension base definition URL to the list to check when suppressing.