### PR TITLE
Suppress ^date rules

### DIFF
--- a/src/processor/Package.ts
+++ b/src/processor/Package.ts
@@ -374,9 +374,13 @@ export class Package {
       const DEFAULT_DATE = new ExportableCaretValueRule('');
       DEFAULT_DATE.caretPath = 'date';
       DEFAULT_DATE.value = date;
-      [...this.profiles, ...this.extensions, ...this.valueSets, ...this.codeSystems].forEach(resource => {
-        (resource.rules as ExportableRule[]) = (resource.rules as ExportableRule[]).filter(rule => !isEqual(rule, DEFAULT_DATE));
-      });
+      [...this.profiles, ...this.extensions, ...this.valueSets, ...this.codeSystems].forEach(
+        resource => {
+          (resource.rules as ExportableRule[]) = (resource.rules as ExportableRule[]).filter(
+            rule => !isEqual(rule, DEFAULT_DATE)
+          );
+        }
+      );
     }
   }
 }

--- a/src/processor/Package.ts
+++ b/src/processor/Package.ts
@@ -11,7 +11,8 @@ import {
   ExportableContainsRule,
   ExportableOnlyRule,
   ExportableCaretValueRule,
-  ExportableFixedValueRule
+  ExportableFixedValueRule,
+  ExportableRule
 } from '../exportable';
 import { FHIRProcessor } from './FHIRProcessor';
 import { logger } from '../utils';
@@ -368,19 +369,13 @@ export class Package {
     // See: http://hl7.org/fhir/R4/datatypes.html#dateTime
     const dateTimeRegex = /^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|1[0-2])(-(0[1-9]|[1-2][0-9]|3[0-1])(T([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\.[0-9]+)?(Z|(\+|-)((0[0-9]|1[0-3]):[0-5][0-9]|14:00)))?)?)?$/;
     const dateTimeMatch = date.match(dateTimeRegex);
-    const usesGMT = dateTimeMatch ? date.endsWith('+00:00') : false; // If it is a valid FHIR dateTime, check that it uses GMT time zone
+    const usesGMT = dateTimeMatch && date.endsWith('+00:00'); // If it is a valid FHIR dateTime, check that it uses GMT time zone
     if (allDatesMatch && usesGMT) {
       const DEFAULT_DATE = new ExportableCaretValueRule('');
       DEFAULT_DATE.caretPath = 'date';
       DEFAULT_DATE.value = date;
-      [...this.profiles, ...this.extensions].forEach(sd => {
-        sd.rules = sd.rules.filter(rule => !isEqual(rule, DEFAULT_DATE));
-      });
-      this.valueSets.forEach(vs => {
-        vs.rules = vs.rules.filter(rule => !isEqual(rule, DEFAULT_DATE));
-      });
-      this.codeSystems.forEach(cs => {
-        cs.rules = cs.rules.filter(rule => !isEqual(rule, DEFAULT_DATE));
+      [...this.profiles, ...this.extensions, ...this.valueSets, ...this.codeSystems].forEach(resource => {
+        (resource.rules as ExportableRule[]) = (resource.rules as ExportableRule[]).filter(rule => !isEqual(rule, DEFAULT_DATE));
       });
     }
   }

--- a/test/processor/Package.test.ts
+++ b/test/processor/Package.test.ts
@@ -1092,5 +1092,76 @@ describe('Package', () => {
       expect(extension.rules).toHaveLength(1); // Default slicing rules removed, only contains rule
       expect(extension.rules[0]).toBeInstanceOf(ExportableContainsRule);
     });
+
+    it('should remove date caret rules if date appears to be set by IG publisher', () => {
+      const extension = new ExportableExtension('ExtraExtension');
+      const profile = new ExportableProfile('ExtraProfile');
+      profile.parent = 'Observation';
+      const dateCaretRule = new ExportableCaretValueRule('');
+      dateCaretRule.caretPath = 'date';
+      dateCaretRule.value = '2020-03-24T22:19:43+00:00';
+      profile.rules = [dateCaretRule];
+      extension.rules = [dateCaretRule];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(profile.rules).toHaveLength(0); // date CaretValueRule removed
+      expect(extension.rules).toHaveLength(0); // date CaretValueRule removed
+    });
+
+    it('should not remove date caret rules if date appears to be set by IG publisher (different dates)', () => {
+      const extension = new ExportableExtension('ExtraExtension');
+      const profile = new ExportableProfile('ExtraProfile');
+      profile.parent = 'Observation';
+      const dateCaretRule1 = new ExportableCaretValueRule('');
+      dateCaretRule1.caretPath = 'date';
+      dateCaretRule1.value = '2020-12-01T04:12:06+00:00'; // different from date2
+      const dateCaretRule2 = new ExportableCaretValueRule('');
+      dateCaretRule2.caretPath = 'date';
+      dateCaretRule2.value = '2020-03-24T22:19:43+00:00'; // different from date1
+      profile.rules = [dateCaretRule1];
+      extension.rules = [dateCaretRule2];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(profile.rules).toHaveLength(1); // date CaretValueRule is not removed
+      expect(extension.rules).toHaveLength(1); // date CaretValueRule is not removed
+    });
+
+    it('should not remove date caret rules if date appears to be set by IG publisher (no time)', () => {
+      const extension = new ExportableExtension('ExtraExtension');
+      const profile = new ExportableProfile('ExtraProfile');
+      profile.parent = 'Observation';
+      const dateCaretRule = new ExportableCaretValueRule('');
+      dateCaretRule.caretPath = 'date';
+      dateCaretRule.value = '2020-03-24'; // No time specified (FHIR does not allow a time without a timezone)
+      profile.rules = [dateCaretRule];
+      extension.rules = [dateCaretRule];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(profile.rules).toHaveLength(1); // date CaretValueRule is not removed
+      expect(extension.rules).toHaveLength(1); // date CaretValueRule is not removed
+    });
+
+    it('should not remove date caret rules if date appears to be set by IG publisher (different time zone)', () => {
+      const extension = new ExportableExtension('ExtraExtension');
+      const profile = new ExportableProfile('ExtraProfile');
+      profile.parent = 'Observation';
+      const dateCaretRule = new ExportableCaretValueRule('');
+      dateCaretRule.caretPath = 'date';
+      dateCaretRule.value = '2020-03-24T22:19:43+04:00'; // Different timezone, not GMT
+      profile.rules = [dateCaretRule];
+      extension.rules = [dateCaretRule];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(profile.rules).toHaveLength(1); // date CaretValueRule is not removed
+      expect(extension.rules).toHaveLength(1); // date CaretValueRule is not removed
+    });
   });
 });

--- a/test/processor/Package.test.ts
+++ b/test/processor/Package.test.ts
@@ -1118,7 +1118,7 @@ describe('Package', () => {
       expect(codeSystem.rules).toHaveLength(0); // date CaretValueRule removed
     });
 
-    it('should not remove date caret rules if date appears to be set by IG publisher (different dates)', () => {
+    it('should not remove date caret rules if date appears to not be set by IG publisher (different dates)', () => {
       const extension = new ExportableExtension('ExtraExtension');
       const profile = new ExportableProfile('ExtraProfile');
       profile.parent = 'Observation';
@@ -1138,7 +1138,7 @@ describe('Package', () => {
       expect(extension.rules).toHaveLength(1); // date CaretValueRule is not removed
     });
 
-    it('should not remove date caret rules if date appears to be set by IG publisher (no time)', () => {
+    it('should not remove date caret rules if date appears to not be set by IG publisher (no time)', () => {
       const extension = new ExportableExtension('ExtraExtension');
       const profile = new ExportableProfile('ExtraProfile');
       profile.parent = 'Observation';
@@ -1155,7 +1155,7 @@ describe('Package', () => {
       expect(extension.rules).toHaveLength(1); // date CaretValueRule is not removed
     });
 
-    it('should not remove date caret rules if date appears to be set by IG publisher (different time zone)', () => {
+    it('should not remove date caret rules if date appears to not be set by IG publisher (different time zone)', () => {
       const extension = new ExportableExtension('ExtraExtension');
       const profile = new ExportableProfile('ExtraProfile');
       profile.parent = 'Observation';

--- a/test/processor/Package.test.ts
+++ b/test/processor/Package.test.ts
@@ -1097,17 +1097,25 @@ describe('Package', () => {
       const extension = new ExportableExtension('ExtraExtension');
       const profile = new ExportableProfile('ExtraProfile');
       profile.parent = 'Observation';
+      const valueSet = new ExportableValueSet('ExtraValueSet');
+      const codeSystem = new ExportableCodeSystem('ExtraCodeSystem');
       const dateCaretRule = new ExportableCaretValueRule('');
       dateCaretRule.caretPath = 'date';
       dateCaretRule.value = '2020-03-24T22:19:43+00:00';
       profile.rules = [dateCaretRule];
       extension.rules = [dateCaretRule];
+      valueSet.rules = [dateCaretRule];
+      codeSystem.rules = [dateCaretRule];
       const myPackage = new Package();
       myPackage.add(profile);
       myPackage.add(extension);
+      myPackage.add(valueSet);
+      myPackage.add(codeSystem);
       myPackage.optimize(processor);
       expect(profile.rules).toHaveLength(0); // date CaretValueRule removed
       expect(extension.rules).toHaveLength(0); // date CaretValueRule removed
+      expect(valueSet.rules).toHaveLength(0); // date CaretValueRule removed
+      expect(codeSystem.rules).toHaveLength(0); // date CaretValueRule removed
     });
 
     it('should not remove date caret rules if date appears to be set by IG publisher (different dates)', () => {


### PR DESCRIPTION
This PR addresses [CIMPL-531](https://standardhealthrecord.atlassian.net/browse/CIMPL-531). It suppresses `^date` rules if they appear to be set by the IG Publisher, rather than through a FSH rule. `^date` rules are considered to be set by the IG publisher if:

- all the dates at the root level of the resource are the same across every resource in the package
- the date has a time with hours, minutes, and seconds
- the date has GMT timezone specified (+00:00)

If all three of those conditions are met, the `^date` rule will be removed.

I do have one question about this approach. Should another condition included here be that every resource in the package has a date set? Right now, it will check that any resource with a date has the same date, but I'm thinking it might also be helpful to check that every resource has a date and that the date is the same across the package.