### PR TITLE
Write Mapping and MappingRule

### DIFF
--- a/src/exportable/ExportableMapping.ts
+++ b/src/exportable/ExportableMapping.ts
@@ -1,0 +1,18 @@
+import { EOL } from 'os';
+import { fshtypes } from 'fsh-sushi';
+import { Exportable, ExportableMappingRule, ExportableInsertRule } from '.';
+import { metadataToFSH } from './common';
+
+export class ExportableMapping extends fshtypes.Mapping implements Exportable {
+  rules: (ExportableMappingRule | ExportableInsertRule)[];
+
+  constructor(name: string) {
+    super(name);
+  }
+
+  toFSH(): string {
+    const metadataFSH = metadataToFSH(this);
+    const rulesFSH = this.rules.map(r => r.toFSH()).join(EOL);
+    return `${metadataFSH}${rulesFSH.length ? EOL + rulesFSH : ''}`;
+  }
+}

--- a/src/exportable/ExportableMappingRule.ts
+++ b/src/exportable/ExportableMappingRule.ts
@@ -1,4 +1,5 @@
 import { fshrules } from 'fsh-sushi';
+import { fshifyString } from '../exportable/common';
 import { ExportableRule } from '.';
 
 export class ExportableMappingRule extends fshrules.MappingRule implements ExportableRule {
@@ -7,9 +8,9 @@ export class ExportableMappingRule extends fshrules.MappingRule implements Expor
   }
 
   toFSH(): string {
-    const path = this.path ? `${this.path} ` : '';
-    const comment = this.comment ? ` "${this.comment}"` : '';
+    const path = this.path ? ` ${this.path}` : '';
+    const comment = this.comment ? ` "${fshifyString(this.comment)}"` : '';
     const language = this.language ? ` ${this.language.toString()}` : '';
-    return `* ${path}-> "${this.map}"${comment}${language}`;
+    return `*${path} -> "${fshifyString(this.map)}"${comment}${language}`;
   }
 }

--- a/src/exportable/ExportableMappingRule.ts
+++ b/src/exportable/ExportableMappingRule.ts
@@ -1,0 +1,15 @@
+import { fshrules } from 'fsh-sushi';
+import { ExportableRule } from '.';
+
+export class ExportableMappingRule extends fshrules.MappingRule implements ExportableRule {
+  constructor(path: string) {
+    super(path);
+  }
+
+  toFSH(): string {
+    const path = this.path ? `${this.path} ` : '';
+    const comment = this.comment ? ` "${this.comment}"` : '';
+    const language = this.language ? ` ${this.language.toString()}` : '';
+    return `* ${path}-> "${this.map}"${comment}${language}`;
+  }
+}

--- a/src/exportable/common.ts
+++ b/src/exportable/common.ts
@@ -3,11 +3,17 @@ import {
   ExportableProfile,
   ExportableExtension,
   ExportableCodeSystem,
-  ExportableInvariant
+  ExportableInvariant,
+  ExportableMapping
 } from '.';
 
 export function metadataToFSH(
-  definition: ExportableProfile | ExportableExtension | ExportableCodeSystem | ExportableInvariant
+  definition:
+    | ExportableProfile
+    | ExportableExtension
+    | ExportableCodeSystem
+    | ExportableInvariant
+    | ExportableMapping
 ): string {
   const resultLines: string[] = [];
   if (definition instanceof ExportableProfile) {
@@ -28,6 +34,8 @@ export function metadataToFSH(
     resultLines.push(`CodeSystem: ${definition.name}`);
   } else if (definition instanceof ExportableInvariant) {
     resultLines.push(`Invariant: ${definition.name}`);
+  } else if (definition instanceof ExportableMapping) {
+    resultLines.push(`Mapping: ${definition.name}`);
   }
 
   // Invariants do not use the Id and Title keywords
@@ -51,6 +59,14 @@ export function metadataToFSH(
     }
     if (definition.xpath) {
       resultLines.push(`XPath: "${fshifyString(definition.xpath)}"`);
+    }
+  }
+  if (definition instanceof ExportableMapping) {
+    if (definition.source) {
+      resultLines.push(`Source: ${definition.source}`);
+    }
+    if (definition.target) {
+      resultLines.push(`Target: ${definition.target}`);
     }
   }
   return resultLines.join(EOL);

--- a/src/exportable/index.ts
+++ b/src/exportable/index.ts
@@ -12,6 +12,8 @@ export * from './ExportableFlagRule';
 export * from './ExportableInsertRule';
 export * from './ExportableInstance';
 export * from './ExportableInvariant';
+export * from './ExportableMapping';
+export * from './ExportableMappingRule';
 export * from './ExportableObeysRule';
 export * from './ExportableOnlyRule';
 export * from './ExportableProfile';

--- a/test/exportable/ExportableMapping.test.ts
+++ b/test/exportable/ExportableMapping.test.ts
@@ -1,0 +1,66 @@
+import { EOL } from 'os';
+import { ExportableMapping, ExportableMappingRule } from '../../src/exportable';
+
+describe('ExportableMapping', () => {
+  it('should export the simplest Mapping', () => {
+    const input = new ExportableMapping('SimpleMapping');
+
+    const expectedResult = ['Mapping: SimpleMapping', 'Id: SimpleMapping'].join(EOL);
+    const result = input.toFSH();
+    expect(result).toBe(expectedResult);
+  });
+
+  it('should export a Mapping with additional metadata', () => {
+    const input = new ExportableMapping('MetaMapping');
+    input.id = 'meta-mapping';
+    input.title = 'Meta Mapping';
+    input.description = 'This is a Mapping with some metadata';
+    input.source = 'ProfiledPatient';
+    input.target = 'http://example.org';
+
+    const expectedResult = [
+      'Mapping: MetaMapping',
+      'Id: meta-mapping',
+      'Title: "Meta Mapping"',
+      'Description: "This is a Mapping with some metadata"',
+      'Source: ProfiledPatient',
+      'Target: http://example.org'
+    ].join(EOL);
+    const result = input.toFSH();
+    expect(result).toBe(expectedResult);
+  });
+
+  it('should export a Mapping with metadata that contains characters that are escaped in FSH', () => {
+    const input = new ExportableMapping('NewLineMapping');
+    input.id = 'new-line-mapping';
+    input.description =
+      'This description\nhas a newline in it. Is that \\not allowed\\? Is that "not okay"?';
+
+    const expectedResult = [
+      'Mapping: NewLineMapping',
+      'Id: new-line-mapping',
+      'Description: "This description\\nhas a newline in it. Is that \\\\not allowed\\\\? Is that \\"not okay\\"?"'
+    ].join(EOL);
+    const result = input.toFSH();
+    expect(result).toBe(expectedResult);
+  });
+
+  it('should export a Mapping with rules', () => {
+    const input = new ExportableMapping('MyMapping');
+    const mappingRule1 = new ExportableMappingRule('foo');
+    mappingRule1.map = 'bar.baz';
+    input.rules.push(mappingRule1);
+    const mappingRule2 = new ExportableMappingRule('oof');
+    mappingRule2.map = 'rab.zab';
+    input.rules.push(mappingRule2);
+
+    const expectedResult = [
+      'Mapping: MyMapping',
+      'Id: MyMapping',
+      '* foo -> "bar.baz"',
+      '* oof -> "rab.zab"'
+    ].join(EOL);
+    const result = input.toFSH();
+    expect(result).toBe(expectedResult);
+  });
+});

--- a/test/exportable/ExportableMappingRule.test.ts
+++ b/test/exportable/ExportableMappingRule.test.ts
@@ -1,0 +1,45 @@
+import { fshtypes } from 'fsh-sushi';
+import { ExportableMappingRule } from '../../src/exportable';
+
+describe('ExportableMappingRule', () => {
+  it('should export a basic mapping rule', () => {
+    const rule = new ExportableMappingRule('identifier');
+    rule.map = 'Patient.otherIdentifier';
+
+    expect(rule.toFSH()).toBe('* identifier -> "Patient.otherIdentifier"');
+  });
+
+  it('should export a mapping rule with no path', () => {
+    const rule = new ExportableMappingRule('');
+    rule.map = 'Patient';
+
+    expect(rule.toFSH()).toBe('* -> "Patient"');
+  });
+
+  it('should export a mapping rule with a comment', () => {
+    const rule = new ExportableMappingRule('identifier');
+    rule.map = 'Patient.otherIdentifier';
+    rule.comment = 'This is a comment';
+
+    expect(rule.toFSH()).toBe('* identifier -> "Patient.otherIdentifier" "This is a comment"');
+  });
+
+  it('should export a mapping rule with a language', () => {
+    const rule = new ExportableMappingRule('identifier');
+    rule.map = 'Patient.otherIdentifier';
+    rule.language = new fshtypes.FshCode('lang');
+
+    expect(rule.toFSH()).toBe('* identifier -> "Patient.otherIdentifier" #lang');
+  });
+
+  it('should export a mapping rule with a comment and target', () => {
+    const rule = new ExportableMappingRule('identifier');
+    rule.map = 'Patient.otherIdentifier';
+    rule.comment = 'This is a comment';
+    rule.language = new fshtypes.FshCode('lang');
+
+    expect(rule.toFSH()).toBe(
+      '* identifier -> "Patient.otherIdentifier" "This is a comment" #lang'
+    );
+  });
+});

--- a/test/exportable/ExportableMappingRule.test.ts
+++ b/test/exportable/ExportableMappingRule.test.ts
@@ -42,4 +42,21 @@ describe('ExportableMappingRule', () => {
       '* identifier -> "Patient.otherIdentifier" "This is a comment" #lang'
     );
   });
+
+  it('should export a mapping rule with a map that contains characters that are escaped in FSH', () => {
+    const rule = new ExportableMappingRule('identifier');
+    rule.map = 'Patient.\\somethingFu\nnky';
+
+    expect(rule.toFSH()).toBe('* identifier -> "Patient.\\\\somethingFu\\nnky"');
+  });
+
+  it('should export a mapping rule with a comment that contains characters that are escaped in FSH', () => {
+    const rule = new ExportableMappingRule('identifier');
+    rule.map = 'Patient.otherIdentifier';
+    rule.comment = 'This has a \n newline, which is pretty \\wild.';
+
+    expect(rule.toFSH()).toBe(
+      '* identifier -> "Patient.otherIdentifier" "This has a \\n newline, which is pretty \\\\wild."'
+    );
+  });
 });


### PR DESCRIPTION
This PR adds support for writing `Mapping`s and mapping rules ([CIMPL-517](https://standardhealthrecord.atlassian.net/browse/CIMPL-517))

I followed a similar pattern to invariants with keywords that are specific to Mappings. Since the processing side of things have not been implemented yet, I think this is safe to be merge into master.