### PR TITLE
Detect and replace FHIR core resource urls

### DIFF
--- a/src/processor/Package.ts
+++ b/src/processor/Package.ts
@@ -83,16 +83,16 @@ export class Package {
   }
 
   private resolveProfileParents(processor: FHIRProcessor): void {
-    for (const profile of this.profiles) {
-      if (profile.parent) {
+    for (const resource of [...this.profiles, ...this.extensions]) {
+      if (resource.parent) {
         // The parent might be another SD in the processor or a core FHIR resource
-        const parentSd = processor.structureDefinitions.find(sd => sd.url === profile.parent);
+        const parentSd = processor.structureDefinitions.find(sd => sd.url === resource.parent);
         if (parentSd?.name) {
-          profile.parent = parentSd.name;
+          resource.parent = parentSd.name;
         } else {
-          const fhirMatch = profile.parent.match(FHIR_BASE_URL);
+          const fhirMatch = resource.parent.match(FHIR_BASE_URL);
           if (fhirMatch?.[1]) {
-            profile.parent = fhirMatch[1];
+            resource.parent = fhirMatch[1];
           }
         }
       }

--- a/src/processor/Package.ts
+++ b/src/processor/Package.ts
@@ -21,6 +21,8 @@ import { pullAt, groupBy, values, flatten, isEqual } from 'lodash';
 import { fshtypes } from 'fsh-sushi';
 const { FshCode } = fshtypes;
 
+const FHIR_BASE_URL = /http:\/\/hl7\.org\/fhir\/StructureDefinition\/(.+)/;
+
 export class Package {
   public readonly profiles: ExportableProfile[] = [];
   public readonly extensions: ExportableExtension[] = [];
@@ -65,7 +67,6 @@ export class Package {
     }
   }
 
-  // TODO: Optimization step: combine ContainsRule and OnlyRule for contained item with one type
   optimize(processor: FHIRProcessor) {
     logger.debug('Optimizing FSH definitions...');
     this.resolveProfileParents(processor);
@@ -78,14 +79,21 @@ export class Package {
     this.removeDefaultSlicingRules();
     this.removeDateRules();
     this.combineContainsRules();
+    this.simplifyFHIROnlyRules();
   }
 
   private resolveProfileParents(processor: FHIRProcessor): void {
     for (const profile of this.profiles) {
       if (profile.parent) {
+        // The parent might be another SD in the processor or a core FHIR resource
         const parentSd = processor.structureDefinitions.find(sd => sd.url === profile.parent);
         if (parentSd?.name) {
           profile.parent = parentSd.name;
+        } else {
+          const fhirMatch = profile.parent.match(FHIR_BASE_URL);
+          if (fhirMatch?.[1]) {
+            profile.parent = fhirMatch[1];
+          }
         }
       }
     }
@@ -410,6 +418,21 @@ export class Package {
         }
       });
       pullAt(sd.rules, rulesToRemove);
+    });
+  }
+
+  private simplifyFHIROnlyRules(): void {
+    [...this.profiles, ...this.extensions].forEach(sd => {
+      sd.rules.forEach(rule => {
+        if (rule instanceof ExportableOnlyRule) {
+          rule.types.forEach(onlyRuleType => {
+            const fhirMatch = onlyRuleType.type.match(FHIR_BASE_URL);
+            if (fhirMatch?.[1]) {
+              onlyRuleType.type = fhirMatch[1];
+            }
+          });
+        }
+      });
     });
   }
 }

--- a/src/processor/Package.ts
+++ b/src/processor/Package.ts
@@ -91,11 +91,12 @@ export class Package {
           resource.parent = parentSd.name;
         } else {
           const fhirMatch = resource.parent.match(FHIR_BASE_URL);
-          if (fhirMatch?.[1]) {
-            // Only change the FHIR url into a name if it won't collide with a local SD
-            if (!processor.structureDefinitions.some(sd => sd.name === fhirMatch[1])) {
-              resource.parent = fhirMatch[1];
-            }
+          // Only change the FHIR url into a name if it won't collide with a local SD
+          if (
+            fhirMatch?.[1] &&
+            !processor.structureDefinitions.some(sd => sd.name === fhirMatch[1])
+          ) {
+            resource.parent = fhirMatch[1];
           }
         }
       }
@@ -435,11 +436,12 @@ export class Package {
               onlyRuleType.type = typeSd.name;
             } else {
               const fhirMatch = onlyRuleType.type.match(FHIR_BASE_URL);
-              if (fhirMatch?.[1]) {
-                // Only change the FHIR url into a name if it won't collide with a local SD
-                if (!processor.structureDefinitions.some(sd => sd.name === fhirMatch[1])) {
-                  onlyRuleType.type = fhirMatch[1];
-                }
+              // Only change the FHIR url into a name if it won't collide with a local SD
+              if (
+                fhirMatch?.[1] &&
+                !processor.structureDefinitions.some(sd => sd.name === fhirMatch[1])
+              ) {
+                onlyRuleType.type = fhirMatch[1];
               }
             }
           });

--- a/src/processor/Package.ts
+++ b/src/processor/Package.ts
@@ -92,7 +92,10 @@ export class Package {
         } else {
           const fhirMatch = resource.parent.match(FHIR_BASE_URL);
           if (fhirMatch?.[1]) {
-            resource.parent = fhirMatch[1];
+            // Only change the FHIR url into a name if it won't collide with a local SD
+            if (!processor.structureDefinitions.some(sd => sd.name === fhirMatch[1])) {
+              resource.parent = fhirMatch[1];
+            }
           }
         }
       }

--- a/test/processor/Package.test.ts
+++ b/test/processor/Package.test.ts
@@ -99,8 +99,9 @@ describe('Package', () => {
 
     beforeAll(() => {
       processor = new FHIRProcessor(new fhirdefs.FHIRDefinitions());
-      // add a StructureDefinition to the processor
+      // add some StructureDefinitions to the processor
       processor.process(path.join(__dirname, 'fixtures', 'small-profile.json'));
+      processor.process(path.join(__dirname, 'fixtures', 'small-extension.json'));
     });
 
     it('should replace a profile parent url with the name of the parent', () => {
@@ -112,6 +113,15 @@ describe('Package', () => {
       expect(profile.parent).toBe('SmallProfile');
     });
 
+    it('should replace an extension parent url with the name of the parent', () => {
+      const extension = new ExportableExtension('ExtraExtension');
+      extension.parent = 'https://demo.org/StructureDefinition/SmallExtension';
+      const myPackage = new Package();
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(extension.parent).toBe('SmallExtension');
+    });
+
     it('should replace a profile parent url with the name of a core FHIR resource', () => {
       const profile = new ExportableProfile('MyObservation');
       profile.parent = 'http://hl7.org/fhir/StructureDefinition/Observation';
@@ -119,6 +129,15 @@ describe('Package', () => {
       myPackage.add(profile);
       myPackage.optimize(processor);
       expect(profile.parent).toBe('Observation');
+    });
+
+    it('should replace an extension parent url with the name of a core FHIR resource', () => {
+      const extension = new ExportableExtension('MyNewExtension');
+      extension.parent = 'http://hl7.org/fhir/StructureDefinition/allergyintolerance-certainty';
+      const myPackage = new Package();
+      myPackage.add(extension);
+      myPackage.optimize(processor);
+      expect(extension.parent).toBe('allergyintolerance-certainty');
     });
 
     it('should not change the profile parent url if the parent is not found', () => {

--- a/test/processor/Package.test.ts
+++ b/test/processor/Package.test.ts
@@ -106,11 +106,11 @@ describe('Package', () => {
 
     it('should replace a profile parent url with the name of the parent', () => {
       const profile = new ExportableProfile('ExtraProfile');
-      profile.parent = 'https://demo.org/StructureDefinition/SmallProfile';
+      profile.parent = 'https://demo.org/StructureDefinition/Patient';
       const myPackage = new Package();
       myPackage.add(profile);
       myPackage.optimize(processor);
-      expect(profile.parent).toBe('SmallProfile');
+      expect(profile.parent).toBe('Patient');
     });
 
     it('should replace an extension parent url with the name of the parent', () => {
@@ -138,6 +138,15 @@ describe('Package', () => {
       myPackage.add(extension);
       myPackage.optimize(processor);
       expect(extension.parent).toBe('allergyintolerance-certainty');
+    });
+
+    it('should not replace a parent url with the name of a core FHIR resource if it shares a name with a local StructureDefinition', () => {
+      const profile = new ExportableProfile('MyPatient');
+      profile.parent = 'http://hl7.org/fhir/StructureDefinition/Patient';
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+      expect(profile.parent).toBe('http://hl7.org/fhir/StructureDefinition/Patient');
     });
 
     it('should not change the profile parent url if the parent is not found', () => {

--- a/test/processor/Package.test.ts
+++ b/test/processor/Package.test.ts
@@ -1290,13 +1290,38 @@ describe('Package', () => {
       expect(profile.rules).toEqual([combinedContainsRule, containsRule3]);
     });
 
-    // simplifyFHIROnlyRules
-    it('should use the name and not full url for FHIR core resources in only rules', () => {
+    // simplifyOnlyRules
+    it('should replace an only rule type url with the name of a local StructureDefinition', () => {
       const profile = new ExportableProfile('MyObservation');
       const onlySubject = new ExportableOnlyRule('subject');
       onlySubject.types = [
         {
-          type: 'http://hl7.org/fhir/StructureDefinition/Patient',
+          type: 'https://demo.org/StructureDefinition/Patient',
+          isReference: true
+        }
+      ];
+
+      profile.rules.push(onlySubject);
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+
+      const expectedSubject = new ExportableOnlyRule('subject');
+      expectedSubject.types = [
+        {
+          type: 'Patient',
+          isReference: true
+        }
+      ];
+      expect(profile.rules).toContainEqual(expectedSubject);
+    });
+
+    it('should replace an only rule type url with the name of a core FHIR resource', () => {
+      const profile = new ExportableProfile('MyObservation');
+      const onlySubject = new ExportableOnlyRule('subject');
+      onlySubject.types = [
+        {
+          type: 'http://hl7.org/fhir/StructureDefinition/Group',
           isReference: true
         }
       ];
@@ -1321,7 +1346,7 @@ describe('Package', () => {
       const expectedSubject = new ExportableOnlyRule('subject');
       expectedSubject.types = [
         {
-          type: 'Patient',
+          type: 'Group',
           isReference: true
         }
       ];
@@ -1339,6 +1364,31 @@ describe('Package', () => {
       ];
       expect(profile.rules).toContainEqual(expectedSubject);
       expect(profile.rules).toContainEqual(expectedValue);
+    });
+
+    it('should not replace an only rule type url with the name of a core FHIR resource if it shares a name with a local StructureDefinition', () => {
+      const profile = new ExportableProfile('MyObservation');
+      const onlySubject = new ExportableOnlyRule('subject');
+      onlySubject.types = [
+        {
+          type: 'http://hl7.org/fhir/StructureDefinition/Patient',
+          isReference: true
+        }
+      ];
+
+      profile.rules.push(onlySubject);
+      const myPackage = new Package();
+      myPackage.add(profile);
+      myPackage.optimize(processor);
+
+      const expectedSubject = new ExportableOnlyRule('subject');
+      expectedSubject.types = [
+        {
+          type: 'http://hl7.org/fhir/StructureDefinition/Patient',
+          isReference: true
+        }
+      ];
+      expect(profile.rules).toContainEqual(expectedSubject);
     });
   });
 });

--- a/test/processor/fixtures/small-extension.json
+++ b/test/processor/fixtures/small-extension.json
@@ -1,0 +1,10 @@
+{
+  "resourceType": "StructureDefinition",
+  "kind": "complex-type",
+  "type": "Extension",
+  "name": "SmallExtension",
+  "url": "https://demo.org/StructureDefinition/SmallExtension",
+  "snapshot": {
+    "element": []
+  }
+}

--- a/test/processor/fixtures/small-profile.json
+++ b/test/processor/fixtures/small-profile.json
@@ -2,8 +2,8 @@
   "resourceType": "StructureDefinition",
   "kind": "resource",
   "type": "Resource",
-  "name": "SmallProfile",
-  "url": "https://demo.org/StructureDefinition/SmallProfile",
+  "name": "Patient",
+  "url": "https://demo.org/StructureDefinition/Patient",
   "snapshot": {
     "element": []
   }


### PR DESCRIPTION
Completes task [CIMPL-488](https://standardhealthrecord.atlassian.net/browse/CIMPL-488).

When a FHIR core resource url is a profile parent or the type in an OnlyRule, it is not necessary to use the full url. The name of the resource is sufficient.