### PR TITLE
Mapping bug fixes

### DIFF
--- a/src/exportable/common.ts
+++ b/src/exportable/common.ts
@@ -70,7 +70,7 @@ export function metadataToFSH(
       resultLines.push(`Source: ${definition.source}`);
     }
     if (definition.target) {
-      resultLines.push(`Target: ${definition.target}`);
+      resultLines.push(`Target: "${definition.target}"`);
     }
   }
   return resultLines.join(EOL);

--- a/src/processor/Package.ts
+++ b/src/processor/Package.ts
@@ -85,6 +85,7 @@ export class Package {
     this.removeDateRules();
     this.combineContainsRules();
     this.simplifyOnlyRules(processor);
+    this.makeMappingNamesUnique();
   }
 
   private resolveProfileParents(processor: FHIRProcessor): void {
@@ -460,6 +461,15 @@ export class Package {
           });
         }
       });
+    });
+  }
+
+  private makeMappingNamesUnique(): void {
+    this.mappings.forEach((mapping, index) => {
+      // If the mapping has the same name as any other mapping, use the source to make the name unique
+      if (this.mappings.find((m, i) => m.id === mapping.id && i !== index)) {
+        mapping.name = `${mapping.name}-for-${mapping.source}`;
+      }
     });
   }
 }

--- a/test/exportable/ExportableMapping.test.ts
+++ b/test/exportable/ExportableMapping.test.ts
@@ -24,7 +24,7 @@ describe('ExportableMapping', () => {
       'Title: "Meta Mapping"',
       'Description: "This is a Mapping with some metadata"',
       'Source: ProfiledPatient',
-      'Target: http://example.org'
+      'Target: "http://example.org"'
     ].join(EOL);
     const result = input.toFSH();
     expect(result).toBe(expectedResult);

--- a/test/processor/Package.test.ts
+++ b/test/processor/Package.test.ts
@@ -1397,5 +1397,27 @@ describe('Package', () => {
       ];
       expect(profile.rules).toContainEqual(expectedSubject);
     });
+
+    it('should make mapping names unique', () => {
+      const mapping1 = new ExportableMapping('MyMapping');
+      mapping1.source = 'MyPatient';
+      const mapping2 = new ExportableMapping('MyMapping');
+      mapping2.source = 'MyObservation';
+      const mapping3 = new ExportableMapping('OtherMapping');
+      const myPackage = new Package();
+      myPackage.add(mapping1);
+      myPackage.add(mapping2);
+      myPackage.add(mapping3);
+      myPackage.optimize(processor);
+
+      const expectedMapping1 = new ExportableMapping('MyMapping');
+      expectedMapping1.source = 'MyPatient';
+      expectedMapping1.name = 'MyMapping-for-MyPatient';
+      const expectedMapping2 = new ExportableMapping('MyMapping');
+      expectedMapping2.source = 'MyObservation';
+      expectedMapping2.name = 'MyMapping-for-MyObservation';
+      const expectedMapping3 = new ExportableMapping('OtherMapping'); // No name rename since it didn't conflict with any other mappings
+      expect(myPackage.mappings).toEqual([expectedMapping1, expectedMapping2, expectedMapping3]);
+    });
   });
 });


### PR DESCRIPTION
This PR fixes two bugs with the Mapping extraction.

1. When writing Mapping metadata, the `Target` is now a string, as it should be.
2. After all Mappings are processed, the name is renamed to make it unique. If there are any other mappings in the list that have the same id (which will be the same as the name at this point), it will append the `source` to the mapping name. This results in Mappings in the generated FSH with a name like `argonaut-dq-dstu2-for-USCoreCondition`. Since the Mapping `name` is never added to the FHIR resource in SUSHI, this name will not appear in the StructureDefinitions that SUSHI will generated using this FSH.