### PR TITLE
Dependencies are now extracted from IGs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -943,6 +943,11 @@
       "integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
       "dev": true
     },
+    "@types/semver": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ=="
+    },
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -946,7 +946,8 @@
     "@types/semver": {
       "version": "7.3.4",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.4.tgz",
-      "integrity": "sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ=="
+      "integrity": "sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ==",
+      "dev": true
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -5625,8 +5626,7 @@
     "semver": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-      "dev": true
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
     },
     "set-blocking": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/jest": "^25.1.4",
     "@types/lodash": "^4.14.159",
     "@types/node": "^12.12.34",
+    "@types/semver": "^7.3.4",
     "@types/temp": "^0.8.34",
     "@types/toposort": "^2.0.3",
     "@typescript-eslint/eslint-plugin": "^2.26.0",
@@ -52,7 +53,6 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
-    "@types/semver": "^7.3.4",
     "chalk": "^4.1.0",
     "commander": "^6.0.0",
     "flat": "^5.0.2",
@@ -60,6 +60,7 @@
     "fsh-sushi": "^1.0.0",
     "ini": "^1.3.5",
     "lodash": "^4.17.19",
+    "semver": "^7.3.2",
     "temp": "^0.9.1",
     "toposort": "^2.0.2",
     "winston": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
+    "@types/semver": "^7.3.4",
     "chalk": "^4.1.0",
     "commander": "^6.0.0",
     "flat": "^5.0.2",

--- a/src/app.ts
+++ b/src/app.ts
@@ -65,7 +65,7 @@ async function app() {
   const defs = new fhirdefs.FHIRDefinitions();
 
   // Trim empty spaces from command line dependencies
-  const dependencies = program.dependencies?.map((dep: string) => dep.trim());
+  const dependencies = program.dependency?.map((dep: string) => dep.trim());
 
   // Load FhirProcessor and config object
   const processor = getFhirProcessor(inDir, defs);

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,10 +7,10 @@ import { fhirdefs, utils } from 'fsh-sushi';
 
 import {
   ensureOutputDir,
+  getIGDependencies,
   getInputDir,
   getResources,
   loadExternalDependencies,
-  getIGDependencies,
   writeFSH
 } from './utils/Processing';
 import { logger, stats } from './utils';
@@ -64,12 +64,12 @@ async function app() {
   // Load dependencies
   const defs = new fhirdefs.FHIRDefinitions();
   const dependencies = program.dependency;
-  
+
   // Fetch dependencies from included IG
   const igDependencies = getIGDependencies(inDir);
   const allDependencies = dependencies.concat(igDependencies);
   const dependencyDefs = loadExternalDependencies(defs, allDependencies);
-  
+
   let outDir: string;
   try {
     outDir = ensureOutputDir(program.out);

--- a/src/app.ts
+++ b/src/app.ts
@@ -89,8 +89,7 @@ async function app() {
 
   let resources: Package;
   try {
-    resources = await getResources(processor);
-    resources.add(config);
+    resources = await getResources(processor, config);
   } catch (err) {
     logger.error(`Could not use input directory: ${err.message}`);
     process.exit(1);

--- a/src/app.ts
+++ b/src/app.ts
@@ -65,10 +65,11 @@ async function app() {
   const defs = new fhirdefs.FHIRDefinitions();
   const dependencies = program.dependency;
 
-  // Fetch dependencies from included IG
-  const igDependencies = getIGDependencies(inDir);
-  const allDependencies = dependencies.concat(igDependencies);
-  const dependencyDefs = loadExternalDependencies(defs, allDependencies);
+  // Fetch dependencies from included IG(s)
+  const dependencyDefs = loadExternalDependencies(defs, [
+    ...(dependencies ?? []),
+    ...getIGDependencies(inDir)
+  ]);
 
   let outDir: string;
   try {

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,7 @@ import {
   getInputDir,
   getResources,
   loadExternalDependencies,
+  getIGDependencies,
   writeFSH
 } from './utils/Processing';
 import { logger, stats } from './utils';
@@ -58,12 +59,17 @@ async function app() {
 
   logger.info(`Starting ${getVersion()}`);
 
+  inDir = getInputDir(inDir);
+
   // Load dependencies
   const defs = new fhirdefs.FHIRDefinitions();
   const dependencies = program.dependency;
-  const dependencyDefs = loadExternalDependencies(defs, dependencies);
-
-  inDir = getInputDir(inDir);
+  
+  // Fetch dependencies from included IG
+  const igDependencies = getIGDependencies(inDir);
+  const allDependencies = dependencies.concat(igDependencies);
+  const dependencyDefs = loadExternalDependencies(defs, allDependencies);
+  
   let outDir: string;
   try {
     outDir = ensureOutputDir(program.out);

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,7 +13,7 @@ import {
   loadExternalDependencies,
   writeFSH
 } from './utils/Processing';
-import { getConfig, logger, stats } from './utils';
+import { logger, stats } from './utils';
 import { Package } from './processor';
 
 const FSH_VERSION = '0.13.x';
@@ -63,19 +63,18 @@ async function app() {
 
   // Load dependencies
   const defs = new fhirdefs.FHIRDefinitions();
-  let dependencies = program.dependency;
 
-  // Trim empty spaces from commad line dependencies
-  dependencies = dependencies?.map((dep: string) => dep.trim());
+  // Trim empty spaces from command line dependencies
+  const dependencies = program.dependencies?.map((dep: string) => dep.trim());
 
-  const processor = await getFhirProcessor(inDir, defs);
-  const config = await getConfig(processor, dependencies);
+  // Load FhirProcessor and config object
+  const processor = getFhirProcessor(inDir, defs);
+  const config = processor.processConfig(dependencies);
 
+  // Load dependencies from config for GoFSH processing
   const allDependencies = config.config.dependencies?.map(
     (dep: fhirtypes.ImplementationGuideDependsOn) => `${dep.packageId}@${dep.version}`
   );
-
-  // Load dependencies from config for GoFSH processing
   const dependencyDefs = loadExternalDependencies(defs, allDependencies);
 
   let outDir: string;

--- a/src/exportable/ExportableConfiguration.ts
+++ b/src/exportable/ExportableConfiguration.ts
@@ -1,6 +1,7 @@
 import YAML from 'yaml';
 import { fshtypes } from 'fsh-sushi';
 import { Exportable } from '.';
+import { ImplementationGuideDependsOn } from 'fsh-sushi/dist/fhirtypes';
 
 export class ExportableConfiguration implements Exportable {
   constructor(public config: fshtypes.Configuration) {}
@@ -13,7 +14,7 @@ export class ExportableConfiguration implements Exportable {
       fhirVersion: this.config.fhirVersion[0],
       FSHOnly: this.config.FSHOnly
     });
-    // id, name, status, and version are the optional configuration properties.
+    // id, name, status, version, and dependencies are the optional configuration properties.
     if (this.config.id) {
       yaml.contents.add({ key: 'id', value: this.config.id });
     }
@@ -25,6 +26,16 @@ export class ExportableConfiguration implements Exportable {
     }
     if (this.config.version) {
       yaml.contents.add({ key: 'version', value: this.config.version });
+    }
+    if (this.config.dependencies) {
+      const fshDependencies: any[] = [];
+      this.config.dependencies.forEach((dependency: ImplementationGuideDependsOn) => {
+        fshDependencies.push({
+          [dependency.packageId]: dependency.version
+        });
+      });
+
+      yaml.contents.add({ key: 'dependencies', value: fshDependencies });
     }
     return yaml.toString();
   }

--- a/src/exportable/ExportableConfiguration.ts
+++ b/src/exportable/ExportableConfiguration.ts
@@ -1,7 +1,6 @@
 import YAML from 'yaml';
-import { fshtypes } from 'fsh-sushi';
+import { fshtypes, fhirtypes } from 'fsh-sushi';
 import { Exportable } from '.';
-import { ImplementationGuideDependsOn } from 'fsh-sushi/dist/fhirtypes';
 
 export class ExportableConfiguration implements Exportable {
   constructor(public config: fshtypes.Configuration) {}
@@ -28,13 +27,18 @@ export class ExportableConfiguration implements Exportable {
       yaml.contents.add({ key: 'version', value: this.config.version });
     }
     if (this.config.dependencies) {
-      const fshDependencies: any[] = [];
-      this.config.dependencies.forEach((dependency: ImplementationGuideDependsOn) => {
-        fshDependencies.push({
-          [dependency.packageId]: dependency.version
-        });
+      const fshDependencies: any = {};
+      this.config.dependencies.forEach((dependency: fhirtypes.ImplementationGuideDependsOn) => {
+        if (dependency.id) {
+          fshDependencies[dependency.packageId] = {
+            version: dependency.version,
+            uri: dependency.uri,
+            id: dependency.id
+          };
+        } else {
+          fshDependencies[dependency.packageId] = dependency.version;
+        }
       });
-
       yaml.contents.add({ key: 'dependencies', value: fshDependencies });
     }
     return yaml.toString();

--- a/src/processor/ConfigurationProcessor.ts
+++ b/src/processor/ConfigurationProcessor.ts
@@ -26,11 +26,13 @@ export class ConfigurationProcessor {
       fhirVersion: input.fhirVersion,
       FSHOnly: true
     };
-    // id, name, status, and version are the optional configuration properties.
+    // id, name, status, version, and dependencies are the optional configuration properties.
     config.id = input.id;
     config.name = input.name;
     config.status = input.status;
     config.version = input.version;
+    config.dependencies = input.dependsOn;
+
     return new ExportableConfiguration(config);
   }
 }

--- a/src/processor/FHIRProcessor.ts
+++ b/src/processor/FHIRProcessor.ts
@@ -68,11 +68,12 @@ export class FHIRProcessor {
     return config;
   }
 
-  process(): Package {
+  process(config: ExportableConfiguration): Package {
     const resources = new Package();
     const igForConfig =
       this.lake.getAllImplementationGuides().find(doc => doc.path === this.igPath) ??
       this.lake.getAllImplementationGuides()[0];
+    resources.add(config);
     this.lake.getAllStructureDefinitions().forEach(wild => {
       try {
         StructureDefinitionProcessor.process(

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -7,6 +7,7 @@ import { Package, FHIRProcessor, LakeOfFHIR, WildFHIR } from '../processor';
 import { FSHExporter } from '../export/FSHExporter';
 import { loadOptimizers } from '../optimizer';
 import { MasterFisher } from '../utils';
+import { ExportableConfiguration } from '../exportable';
 
 export function getInputDir(input = '.'): string {
   // default to current directory
@@ -28,9 +29,12 @@ export function getFhirProcessor(inDir: string, defs: fhirdefs.FHIRDefinitions) 
   return new FHIRProcessor(lake, fisher, igIniIgPath);
 }
 
-export async function getResources(processor: FHIRProcessor): Promise<Package> {
+export async function getResources(
+  processor: FHIRProcessor,
+  config: ExportableConfiguration
+): Promise<Package> {
   const fisher = processor.getFisher();
-  const resources = processor.process();
+  const resources = processor.process(config);
   // Dynamically load and run the optimizers
   const optimizers = await loadOptimizers();
   optimizers.forEach(opt => {

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -22,15 +22,16 @@ export function ensureOutputDir(output = path.join('.', 'gofsh')): string {
   logger.info(`Using output directory: ${output}`);
   return output;
 }
-
-export async function getResources(
-  inDir: string,
-  defs: fhirdefs.FHIRDefinitions
-): Promise<Package> {
+export async function getFhirProcessor(inDir: string, defs: fhirdefs.FHIRDefinitions) {
   const lake = getLakeOfFHIR(inDir);
   const igIniIgPath = getIgPathFromIgIni(inDir);
   const fisher = new MasterFisher(lake, defs);
   const processor = new FHIRProcessor(lake, fisher, igIniIgPath);
+  return processor;
+}
+
+export async function getResources(processor: FHIRProcessor): Promise<Package> {
+  const fisher = processor.getFisher();
   const resources = processor.process();
   // Dynamically load and run the optimizers
   const optimizers = await loadOptimizers();
@@ -42,14 +43,9 @@ export async function getResources(
 }
 
 export async function getConfig(
-  inDir: string,
-  defs: fhirdefs.FHIRDefinitions,
+  processor: FHIRProcessor,
   externalDeps: string[]
 ): Promise<ExportableConfiguration> {
-  const lake = getLakeOfFHIR(inDir);
-  const igIniIgPath = getIgPathFromIgIni(inDir);
-  const fisher = new MasterFisher(lake, defs);
-  const processor = new FHIRProcessor(lake, fisher, igIniIgPath);
   const config = processor.processConfig(externalDeps);
   return config;
 }

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -94,7 +94,7 @@ export function loadExternalDependencies(
 }
 
 export function getIGDependencies(inDir: string): string[] {
-  const inputFiles = getFilesRecursive(inDir);
+  const inputFiles = getFilesRecursive(inDir).filter(file => file.endsWith('.json'));
   const igDeps: string[] = [];
   inputFiles.forEach(file => {
     try {

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -7,7 +7,6 @@ import { Package, FHIRProcessor, LakeOfFHIR, WildFHIR } from '../processor';
 import { FSHExporter } from '../export/FSHExporter';
 import { loadOptimizers } from '../optimizer';
 import { MasterFisher } from '../utils';
-import { ExportableConfiguration } from '../exportable';
 
 export function getInputDir(input = '.'): string {
   // default to current directory
@@ -22,12 +21,11 @@ export function ensureOutputDir(output = path.join('.', 'gofsh')): string {
   logger.info(`Using output directory: ${output}`);
   return output;
 }
-export async function getFhirProcessor(inDir: string, defs: fhirdefs.FHIRDefinitions) {
+export function getFhirProcessor(inDir: string, defs: fhirdefs.FHIRDefinitions) {
   const lake = getLakeOfFHIR(inDir);
   const igIniIgPath = getIgPathFromIgIni(inDir);
   const fisher = new MasterFisher(lake, defs);
-  const processor = new FHIRProcessor(lake, fisher, igIniIgPath);
-  return processor;
+  return new FHIRProcessor(lake, fisher, igIniIgPath);
 }
 
 export async function getResources(processor: FHIRProcessor): Promise<Package> {
@@ -40,14 +38,6 @@ export async function getResources(processor: FHIRProcessor): Promise<Package> {
     opt.optimize(resources, fisher);
   });
   return resources;
-}
-
-export async function getConfig(
-  processor: FHIRProcessor,
-  externalDeps: string[]
-): Promise<ExportableConfiguration> {
-  const config = processor.processConfig(externalDeps);
-  return config;
 }
 
 export function writeFSH(resources: Package, outDir: string): void {

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import ini from 'ini';
-import { fhirdefs } from 'fsh-sushi';
+import { fhirdefs, fhirtypes } from 'fsh-sushi';
 import { logger } from './GoFSHLogger';
 import { Package, FHIRProcessor, LakeOfFHIR, WildFHIR } from '../processor';
 import { FSHExporter } from '../export/FSHExporter';
@@ -91,6 +91,23 @@ export function loadExternalDependencies(
     );
   }
   return dependencyDefs;
+}
+
+export function getIGDependencies(inDir: string): string[] {
+  const igFiles = getFilesRecursive(inDir).filter(file =>
+    file.startsWith(inDir + '/ImplementationGuide')
+  );
+  const igDeps: string[] = [];
+  igFiles.forEach(file => {
+    const igContent = fs.readJSONSync(file);
+    if (igContent.dependsOn) {
+      igContent.dependsOn.forEach((dependency: fhirtypes.ImplementationGuideDependsOn) => {
+        const depString = dependency.packageId + '@' + dependency.version;
+        igDeps.push(depString);
+      });
+    }
+  });
+  return igDeps;
 }
 
 function getLakeOfFHIR(inDir: string): LakeOfFHIR {

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -94,17 +94,21 @@ export function loadExternalDependencies(
 }
 
 export function getIGDependencies(inDir: string): string[] {
-  const igFiles = getFilesRecursive(inDir).filter(file =>
-    file.startsWith(inDir + '/ImplementationGuide')
-  );
+  const inputFiles = getFilesRecursive(inDir);
   const igDeps: string[] = [];
-  igFiles.forEach(file => {
-    const igContent = fs.readJSONSync(file);
-    if (igContent.dependsOn) {
-      igContent.dependsOn.forEach((dependency: fhirtypes.ImplementationGuideDependsOn) => {
-        const depString = dependency.packageId + '@' + dependency.version;
-        igDeps.push(depString);
-      });
+  inputFiles.forEach(file => {
+    try {
+      const content = fs.readJSONSync(file);
+      if (content.resourceType === 'ImplementationGuide') {
+        if (content.dependsOn) {
+          content.dependsOn.forEach((dependency: fhirtypes.ImplementationGuideDependsOn) => {
+            const depString = dependency.packageId + '@' + dependency.version;
+            igDeps.push(depString);
+          });
+        }
+      }
+    } catch (error) {
+      logger.error(`Could not read ${file}: ${error.message}`);
     }
   });
   return igDeps;

--- a/test/exportable/ExportableConfiguration.test.ts
+++ b/test/exportable/ExportableConfiguration.test.ts
@@ -44,7 +44,19 @@ describe('ExportableConfiguration', () => {
         id: 'a.special.package',
         name: 'SpecialTestPackage',
         status: 'active',
-        version: '0.13.0'
+        version: '0.13.0',
+        dependencies: [
+          {
+            version: '3.1.0',
+            packageId: 'hl7.fhir.us.core',
+            uri: 'http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core'
+          },
+          {
+            version: '1.0.0',
+            packageId: 'hl7.fhir.us.mcode',
+            uri: 'http://hl7.org/fhir/us/mcode/ImplementationGuide/hl7.fhir.us.mcode'
+          }
+        ]
       });
       result = config.toFSH();
     });
@@ -64,5 +76,10 @@ describe('ExportableConfiguration', () => {
     it('should include the version when present', () => {
       expect(result).toMatch(/^version: 0\.13.0/m);
     });
+
+    // TODO: I know that I need another test case here, but the regex confused me
+    // it('should include the dependencies when present', () => {
+    //   expect(result).toMatch(/^dependencies: /m);
+    // });
   });
 });

--- a/test/exportable/ExportableConfiguration.test.ts
+++ b/test/exportable/ExportableConfiguration.test.ts
@@ -79,8 +79,8 @@ describe('ExportableConfiguration', () => {
 
     it('should include the dependencies when present', () => {
       expect(result).toMatch(/^dependencies:/m);
-      expect(result).toMatch(/hl7\.fhir\.us\.core: 3\.1\.0/m);
-      expect(result).toMatch(/hl7\.fhir\.us\.mcode: 1\.0\.0/m);
+      expect(result).toMatch(/^\s+hl7\.fhir\.us\.core: 3\.1\.0$/m);
+      expect(result).toMatch(/^\s+hl7\.fhir\.us\.mcode: 1\.0\.0$/m);
     });
   });
 });

--- a/test/exportable/ExportableConfiguration.test.ts
+++ b/test/exportable/ExportableConfiguration.test.ts
@@ -77,9 +77,10 @@ describe('ExportableConfiguration', () => {
       expect(result).toMatch(/^version: 0\.13.0/m);
     });
 
-    // TODO: I know that I need another test case here, but the regex confused me
-    // it('should include the dependencies when present', () => {
-    //   expect(result).toMatch(/^dependencies: /m);
-    // });
+    it('should include the dependencies when present', () => {
+      expect(result).toMatch(/^dependencies:/m);
+      expect(result).toMatch(/- hl7\.fhir\.us\.core: 3\.1\.0/m);
+      expect(result).toMatch(/- hl7\.fhir\.us\.mcode: 1\.0\.0/m);
+    });
   });
 });

--- a/test/exportable/ExportableConfiguration.test.ts
+++ b/test/exportable/ExportableConfiguration.test.ts
@@ -79,8 +79,8 @@ describe('ExportableConfiguration', () => {
 
     it('should include the dependencies when present', () => {
       expect(result).toMatch(/^dependencies:/m);
-      expect(result).toMatch(/- hl7\.fhir\.us\.core: 3\.1\.0/m);
-      expect(result).toMatch(/- hl7\.fhir\.us\.mcode: 1\.0\.0/m);
+      expect(result).toMatch(/hl7\.fhir\.us\.core: 3\.1\.0/m);
+      expect(result).toMatch(/hl7\.fhir\.us\.mcode: 1\.0\.0/m);
     });
   });
 });

--- a/test/processor/ConfigurationProcessor.test.ts
+++ b/test/processor/ConfigurationProcessor.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs-extra';
 import { ConfigurationProcessor } from '../../src/processor/ConfigurationProcessor';
 import { ExportableConfiguration } from '../../src/exportable';
 import { loggerSpy } from '../helpers/loggerSpy';
+import { ImplementationGuideDependsOn } from 'fsh-sushi/dist/fhirtypes';
 
 describe('ConfigurationProcessor', () => {
   it('should create a Configuration from an ImplementationGuide with url and fhirVersion properties', () => {
@@ -42,6 +43,20 @@ describe('ConfigurationProcessor', () => {
     const input = JSON.parse(
       fs.readFileSync(path.join(__dirname, 'fixtures', 'bigger-ig.json'), 'utf-8')
     );
+
+    const testDependencies: ImplementationGuideDependsOn[] = [
+      {
+        version: '3.1.0',
+        packageId: 'hl7.fhir.us.core',
+        uri: 'http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core'
+      },
+      {
+        version: '1.0.0',
+        packageId: 'hl7.fhir.us.mcode',
+        uri: 'http://hl7.org/fhir/us/mcode/ImplementationGuide/hl7.fhir.us.mcode'
+      }
+    ];
+
     const result = ConfigurationProcessor.process(input);
     expect(result).toBeInstanceOf(ExportableConfiguration);
     expect(result.config.canonical).toBe('http://example.org/tests');
@@ -50,5 +65,6 @@ describe('ConfigurationProcessor', () => {
     expect(result.config.name).toBe('BiggerImplementationGuideForTesting');
     expect(result.config.status).toBe('active');
     expect(result.config.version).toBe('0.12');
+    expect(result.config.dependencies).toEqual(testDependencies);
   });
 });

--- a/test/processor/FHIRProcessor.test.ts
+++ b/test/processor/FHIRProcessor.test.ts
@@ -40,10 +40,25 @@ describe('FHIRProcessor', () => {
 
   it('should try to process an ImplementationGuide with the ConfigurationProcessor', () => {
     restockLake(lake, path.join(__dirname, 'fixtures', 'simple-ig.json'));
-    processor.process();
+    processor.processConfig();
     expect(configurationSpy).toHaveBeenCalledTimes(1);
     const simpleIgContent = fs.readJsonSync(path.join(__dirname, 'fixtures', 'simple-ig.json'));
     expect(configurationSpy).toHaveBeenCalledWith(simpleIgContent); // Uses first and only IG in lake if no path provided
+  });
+
+  it('should resolve version numbers between command lines deps and ImplementationGuide deps', () => {
+    restockLake(lake, path.join(__dirname, 'fixtures', 'bigger-ig.json'));
+    const config = processor.processConfig(['hl7.fhir.us.core@2.1.0']);
+    expect(configurationSpy).toHaveBeenCalledTimes(1);
+    const biggerIgContent = fs.readJsonSync(path.join(__dirname, 'fixtures', 'bigger-ig.json'));
+    expect(configurationSpy).toHaveBeenCalledWith(biggerIgContent); // Uses first and only IG in lake if no path provided
+    expect(config.config.dependencies[0].version).toEqual('3.1.0');
+  });
+
+  it('should export a config file with command line dependencies', () => {
+    restockLake(lake, path.join(__dirname, 'fixtures', 'bigger-ig.json'));
+    const config = processor.processConfig(['hl7.fhir.ha.haha@2.1.0']);
+    expect(config.config.dependencies[2].packageId).toEqual('hl7.fhir.ha.haha');
   });
 
   it('should try to process a provided ImplementationGuide with the ConfigurationProcessor', () => {
@@ -57,7 +72,7 @@ describe('FHIRProcessor', () => {
       null,
       path.join(__dirname, 'fixtures', 'bigger-ig.json')
     );
-    processorWithIg.process();
+    processorWithIg.processConfig();
     expect(configurationSpy).toHaveBeenCalledTimes(1);
     const biggerIgContent = fs.readJsonSync(path.join(__dirname, 'fixtures', 'bigger-ig.json'));
     expect(configurationSpy).toHaveBeenCalledWith(biggerIgContent); // Uses path provided instead of first IG in lake

--- a/test/processor/FHIRProcessor.test.ts
+++ b/test/processor/FHIRProcessor.test.ts
@@ -80,39 +80,45 @@ describe('FHIRProcessor', () => {
 
   it('should try to process a Profile with the StructureDefinitionProcessor', () => {
     restockLake(lake, path.join(__dirname, 'fixtures', 'simple-profile.json'));
-    processor.process();
+    const config = processor.processConfig();
+    processor.process(config);
     expect(structureDefinitionSpy).toHaveBeenCalledTimes(1);
   });
 
   it('should try to process an Extension with the StructureDefinitionProcessor', () => {
     restockLake(lake, path.join(__dirname, 'fixtures', 'simple-extension.json'));
-    processor.process();
+    const config = processor.processConfig();
+    processor.process(config);
     expect(structureDefinitionSpy).toHaveBeenCalledTimes(1);
   });
 
   it('should try to process a CodeSystem with the CodeSystemProcessor', () => {
     restockLake(lake, path.join(__dirname, 'fixtures', 'simple-codesystem.json'));
-    processor.process();
+    const config = processor.processConfig();
+    processor.process(config);
     expect(codeSystemSpy).toHaveBeenCalledTimes(1);
   });
 
   it('should try to process a supported ValueSet with the ValueSetProcessor', () => {
     restockLake(lake, path.join(__dirname, 'fixtures', 'simple-valueset.json'));
-    processor.process();
+    const config = processor.processConfig();
+    processor.process(config);
     expect(valueSetSpy).toHaveBeenCalledTimes(1);
     expect(instanceSpy).not.toHaveBeenCalled();
   });
 
   it('should try to process a non-IG/SD/VS/CS Instance with the InstanceProcessor', () => {
     restockLake(lake, path.join(__dirname, 'fixtures', 'simple-patient.json'));
-    processor.process();
+    const config = processor.processConfig();
+    processor.process(config);
     expect(instanceSpy).toHaveBeenCalledTimes(1);
     expect(valueSetSpy).not.toHaveBeenCalled();
   });
 
   it('should try to process an unsupported ValueSet with the InstanceProcessor', () => {
     restockLake(lake, path.join(__dirname, 'fixtures', 'unsupported-valueset.json'));
-    processor.process();
+    const config = processor.processConfig();
+    processor.process(config);
     expect(instanceSpy).toHaveBeenCalledTimes(1);
     expect(valueSetSpy).not.toHaveBeenCalled();
   });

--- a/test/processor/fixtures/bigger-ig.json
+++ b/test/processor/fixtures/bigger-ig.json
@@ -5,5 +5,17 @@
   "id": "bigger.ig",
   "name": "BiggerImplementationGuideForTesting",
   "status": "active",
-  "version": "0.12"
+  "version": "0.12",
+  "dependsOn": [
+    {
+      "uri": "http://hl7.org/fhir/us/core/ImplementationGuide/hl7.fhir.us.core",
+      "packageId": "hl7.fhir.us.core",
+      "version": "3.1.0"
+    },
+    {
+      "uri": "http://hl7.org/fhir/us/mcode/ImplementationGuide/hl7.fhir.us.mcode",
+      "packageId": "hl7.fhir.us.mcode",
+      "version": "1.0.0"
+    }
+  ]
 }

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -75,7 +75,8 @@ describe('Processing', () => {
     it('should try to register each json file in the directory and its subdirectories when given a path to a directory', async () => {
       const inDir = path.join(__dirname, 'fixtures', 'all-good');
       const processor = await getFhirProcessor(inDir, undefined);
-      const result = await getResources(processor);
+      const config = processor.processConfig();
+      const result = await getResources(processor, config);
       expect(result.profiles).toHaveLength(1);
       expect(result.codeSystems).toHaveLength(1);
       expect(result.valueSets).toHaveLength(1);
@@ -88,7 +89,8 @@ describe('Processing', () => {
     it('should register the specified file when given a path to a file', async () => {
       const inDir = path.join(__dirname, 'fixtures', 'all-good', 'simple-profile.json');
       const processor = await getFhirProcessor(inDir, undefined);
-      const result = await getResources(processor);
+      const config = processor.processConfig();
+      const result = await getResources(processor, config);
       expect(result.profiles).toHaveLength(1);
       expect(result.codeSystems).toHaveLength(0);
       expect(result.valueSets).toHaveLength(0);
@@ -101,7 +103,8 @@ describe('Processing', () => {
     it('should log an error when an input file is not valid JSON', async () => {
       const inDir = path.join(__dirname, 'fixtures', 'one-bad');
       const processor = await getFhirProcessor(inDir, undefined);
-      const result = await getResources(processor);
+      const config = processor.processConfig();
+      const result = await getResources(processor, config);
       expect(loggerSpy.getLastMessage('error')).toMatch(/Could not load .*invalid-profile\.json/);
       expect(result.profiles).toHaveLength(1);
       expect(result.codeSystems).toHaveLength(0);
@@ -115,7 +118,8 @@ describe('Processing', () => {
     it('should log debug statements for valid JSON that is not a valid FHIR resource', async () => {
       const inDir = path.join(__dirname, 'fixtures', 'some-non-fhir');
       const processor = await getFhirProcessor(inDir, undefined);
-      const result = await getResources(processor);
+      const config = processor.processConfig();
+      const result = await getResources(processor, config);
       expect(loggerSpy.getMessageAtIndex(0, 'debug')).toMatch(
         /Skipping non-FHIR JSON file: .*non-fhir\.json/
       );

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -9,7 +9,8 @@ import {
   getResources,
   loadExternalDependencies,
   writeFSH,
-  getIgPathFromIgIni
+  getIgPathFromIgIni,
+  getFhirProcessor
 } from '../../src/utils/Processing';
 import { Package } from '../../src/processor';
 import { ExportableConfiguration } from '../../src/exportable';
@@ -73,7 +74,8 @@ describe('Processing', () => {
 
     it('should try to register each json file in the directory and its subdirectories when given a path to a directory', async () => {
       const inDir = path.join(__dirname, 'fixtures', 'all-good');
-      const result = await getResources(inDir, undefined);
+      const processor = await getFhirProcessor(inDir, undefined);
+      const result = await getResources(processor);
       expect(result.profiles).toHaveLength(1);
       expect(result.codeSystems).toHaveLength(1);
       expect(result.valueSets).toHaveLength(1);
@@ -85,7 +87,8 @@ describe('Processing', () => {
 
     it('should register the specified file when given a path to a file', async () => {
       const inDir = path.join(__dirname, 'fixtures', 'all-good', 'simple-profile.json');
-      const result = await getResources(inDir, undefined);
+      const processor = await getFhirProcessor(inDir, undefined);
+      const result = await getResources(processor);
       expect(result.profiles).toHaveLength(1);
       expect(result.codeSystems).toHaveLength(0);
       expect(result.valueSets).toHaveLength(0);
@@ -97,7 +100,8 @@ describe('Processing', () => {
 
     it('should log an error when an input file is not valid JSON', async () => {
       const inDir = path.join(__dirname, 'fixtures', 'one-bad');
-      const result = await getResources(inDir, undefined);
+      const processor = await getFhirProcessor(inDir, undefined);
+      const result = await getResources(processor);
       expect(loggerSpy.getLastMessage('error')).toMatch(/Could not load .*invalid-profile\.json/);
       expect(result.profiles).toHaveLength(1);
       expect(result.codeSystems).toHaveLength(0);
@@ -110,7 +114,8 @@ describe('Processing', () => {
 
     it('should log debug statements for valid JSON that is not a valid FHIR resource', async () => {
       const inDir = path.join(__dirname, 'fixtures', 'some-non-fhir');
-      const result = await getResources(inDir, undefined);
+      const processor = await getFhirProcessor(inDir, undefined);
+      const result = await getResources(processor);
       expect(loggerSpy.getMessageAtIndex(0, 'debug')).toMatch(
         /Skipping non-FHIR JSON file: .*non-fhir\.json/
       );
@@ -130,7 +135,7 @@ describe('Processing', () => {
       expect.assertions(1);
       const inDir = path.join(__dirname, 'wrong-fixtures');
       try {
-        await getResources(inDir, undefined);
+        await getFhirProcessor(inDir, undefined);
       } catch (e) {
         expect(e.message).toMatch('no such file or directory');
       }


### PR DESCRIPTION
This addresses [CIMPL-577](https://standardhealthrecord.atlassian.net/browse/CIMPL-577), exporting dependencies from an IG file and including them in a generated config.yaml (using the abbreviated syntax with just the packageID and version number). One more test case is still needed within the `ExportableConfiguration.test.ts` file, that will be added shortly.