### PR TITLE
ExportableInstance test for assignment rules

### DIFF
--- a/test/exportable/ExportableInstance.test.ts
+++ b/test/exportable/ExportableInstance.test.ts
@@ -1,3 +1,4 @@
+import { FshCode } from 'fsh-sushi/dist/fshtypes';
 import { EOL } from 'os';
 import { ExportableInstance, ExportableAssignmentRule } from '../../src/exportable';
 
@@ -33,7 +34,8 @@ describe('ExportableInstance', () => {
     exInstance.instanceOf = 'Observation';
 
     const statusRule = new ExportableAssignmentRule('status');
-    statusRule.value = 'final';
+    const statusCode = new FshCode('final');
+    statusRule.value = statusCode;
     exInstance.rules.push(statusRule);
 
     const dateRule = new ExportableAssignmentRule('effectiveDateTime');
@@ -44,7 +46,7 @@ describe('ExportableInstance', () => {
       'Instance: MyInstance',
       'InstanceOf: Observation',
       'Usage: #example',
-      '* status = "final"',
+      '* status = #final',
       '* effectiveDateTime = "2019-04-01"'
     ].join(EOL);
     expect(exInstance.toFSH()).toBe(expectedResult);

--- a/test/exportable/ExportableInstance.test.ts
+++ b/test/exportable/ExportableInstance.test.ts
@@ -1,5 +1,5 @@
 import { EOL } from 'os';
-import { ExportableInstance } from '../../src/exportable';
+import { ExportableInstance, ExportableAssignmentRule } from '../../src/exportable';
 
 describe('ExportableInstance', () => {
   it('should export the simplest Instance', () => {
@@ -26,5 +26,27 @@ describe('ExportableInstance', () => {
       'Usage: #example'
     ].join(EOL);
     expect(i.toFSH()).toBe(expectedResult);
+  });
+
+  it('should export an instance with assignment rules', () => {
+    const exInstance = new ExportableInstance('MyInstance');
+    exInstance.instanceOf = 'Observation';
+
+    const statusRule = new ExportableAssignmentRule('status');
+    statusRule.value = 'final';
+    exInstance.rules.push(statusRule);
+
+    const dateRule = new ExportableAssignmentRule('effectiveDateTime');
+    dateRule.value = '2019-04-01';
+    exInstance.rules.push(dateRule);
+
+    const expectedResult = [
+      'Instance: MyInstance',
+      'InstanceOf: Observation',
+      'Usage: #example',
+      '* status = "final"',
+      '* effectiveDateTime = "2019-04-01"'
+    ].join(EOL);
+    expect(exInstance.toFSH()).toBe(expectedResult);
   });
 });

--- a/test/exportable/ExportableInstance.test.ts
+++ b/test/exportable/ExportableInstance.test.ts
@@ -1,4 +1,4 @@
-import { FshCode } from 'fsh-sushi/dist/fshtypes';
+import { fshtypes } from 'fsh-sushi';
 import { EOL } from 'os';
 import { ExportableInstance, ExportableAssignmentRule } from '../../src/exportable';
 
@@ -34,7 +34,7 @@ describe('ExportableInstance', () => {
     exInstance.instanceOf = 'Observation';
 
     const statusRule = new ExportableAssignmentRule('status');
-    const statusCode = new FshCode('final');
+    const statusCode = new fshtypes.FshCode('final');
     statusRule.value = statusCode;
     exInstance.rules.push(statusRule);
 


### PR DESCRIPTION
@ngfreiter had actually included code implementing the actual writing of FixedValueRules on ExportableInstances in PR #33, so this PR only includes a unit test which tests that writing assignment rules is supported.