### PR TITLE
Update fsh-sushi dependency to ^1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2623,9 +2623,9 @@
       "optional": true
     },
     "fsh-sushi": {
-      "version": "1.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-1.0.0-beta.1.tgz",
-      "integrity": "sha512-IF/kGWBn7lj4fLs3vZhkhnJouF6xoH/ocPDRJWoFQJ0tJQtaSe5yPvXxjtdKAkw8xBjWSVuZ6QXnJr1Ix32cQA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-1.0.1.tgz",
+      "integrity": "sha512-9rNFr2KNDvETBnAWICMklaZSkqnoy374ryskO7x+6dqS9NgukbcWzWQu01i7M37IWAMREIC852tNdzMSZPIBWw==",
       "requires": {
         "@types/antlr4": "^4.7.1",
         "antlr4": "^4.8.0",
@@ -6433,9 +6433,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.11.1",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.1.tgz",
-      "integrity": "sha512-OApPSuJcxcnewwjSGGfWOjx3oix5XpmrK9Z2j0fTRlHGoZ49IU6kExfZTM0++fCArOOCet+vIfWwFHbvWqwp6g=="
+      "version": "3.11.6",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.11.6.tgz",
+      "integrity": "sha512-oASI1FOJ7BBFkSCNDZ446EgkSuHkOZBuqRFrwXIKWCoXw8ZXQETooTQjkAcBS03Acab7ubCKsXnwuV2svy061g=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "commander": "^6.0.0",
     "flat": "^5.0.2",
     "fs-extra": "^9.0.1",
-    "fsh-sushi": "^1.0.0-beta.1",
+    "fsh-sushi": "^1.0.0",
     "ini": "^1.3.5",
     "lodash": "^4.17.19",
     "temp": "^0.9.1",


### PR DESCRIPTION
Completes task INT-893.

Because the dependency was previously on a beta version of 1.0.0, no further code changes were necessary to support this dependency.