### PR TITLE
Updated output style

### DIFF
--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -53,7 +53,7 @@ export function writeFSH(resources: Package, outDir: string): void {
       logger.info(`Wrote config to ${configPath}.`);
     }
   } catch (error) {
-    logger.error(`Could not load output direcotry: ${error.message}`);
+    logger.error(`Could not write to output directory: ${error.message}`);
     process.exit(1);
   }
 }

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -43,12 +43,13 @@ export async function getResources(
 export function writeFSH(resources: Package, outDir: string): void {
   const exporter = new FSHExporter(resources);
   try {
-    const resourceDir = ensureOutputDir(path.join(outDir, 'input', 'fsh'));
+    const resourceDir = path.join(outDir, 'input', 'fsh');
+    fs.ensureDirSync(resourceDir);
     const outputPath = path.join(resourceDir, 'resources.fsh');
     fs.writeFileSync(outputPath, exporter.export());
     logger.info(`Wrote fsh to ${outputPath}.`);
     if (resources.configuration) {
-      const configPath = path.join(outDir, 'config.yaml');
+      const configPath = path.join(outDir, 'sushi-config.yaml');
       fs.writeFileSync(configPath, resources.configuration.toFSH());
       logger.info(`Wrote config to ${configPath}.`);
     }

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -42,13 +42,19 @@ export async function getResources(
 
 export function writeFSH(resources: Package, outDir: string): void {
   const exporter = new FSHExporter(resources);
-  const outputPath = path.join(outDir, 'resources.fsh');
-  fs.writeFileSync(outputPath, exporter.export());
-  logger.info(`Wrote fsh to ${outputPath}.`);
-  if (resources.configuration) {
-    const configPath = path.join(outDir, 'config.yaml');
-    fs.writeFileSync(configPath, resources.configuration.toFSH());
-    logger.info(`Wrote config to ${configPath}.`);
+  try {
+    const resourceDir = ensureOutputDir(path.join(outDir, 'input', 'fsh'));
+    const outputPath = path.join(resourceDir, 'resources.fsh');
+    fs.writeFileSync(outputPath, exporter.export());
+    logger.info(`Wrote fsh to ${outputPath}.`);
+    if (resources.configuration) {
+      const configPath = path.join(outDir, 'config.yaml');
+      fs.writeFileSync(configPath, resources.configuration.toFSH());
+      logger.info(`Wrote config to ${configPath}.`);
+    }
+  } catch (error) {
+    logger.error(`Could not load output direcotry: ${error.message}`);
+    process.exit(1);
   }
 }
 

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -150,7 +150,7 @@ describe('Processing', () => {
     it('should write output to a file named resources.fsh in the output directory', () => {
       const resources = new Package();
       writeFSH(resources, tempRoot);
-      expect(fs.existsSync(path.join(tempRoot, 'resources.fsh'))).toBeTruthy();
+      expect(fs.existsSync(path.join(tempRoot, 'input', 'fsh', 'resources.fsh'))).toBeTruthy();
     });
   });
 

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -12,6 +12,7 @@ import {
   getIgPathFromIgIni
 } from '../../src/utils/Processing';
 import { Package } from '../../src/processor';
+import { ExportableConfiguration } from '../../src/exportable';
 
 describe('Processing', () => {
   temp.track();
@@ -151,6 +152,14 @@ describe('Processing', () => {
       const resources = new Package();
       writeFSH(resources, tempRoot);
       expect(fs.existsSync(path.join(tempRoot, 'input', 'fsh', 'resources.fsh'))).toBeTruthy();
+    });
+
+    it('should write configuration details to a file named sushi-config.yaml in the output directory', () => {
+      const resources = new Package();
+      const config = new ExportableConfiguration({ canonical: 'fakeCanonical', fhirVersion: [] });
+      resources.add(config);
+      writeFSH(resources, tempRoot);
+      expect(fs.existsSync(path.join(tempRoot, 'sushi-config.yaml'))).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
Addresses [CIMPL-594](https://standardhealthrecord.atlassian.net/browse/CIMPL-594). 

Updates GoFSH to output in a Sushi 1.0.0 project structure. 