### PR TITLE
Process unsupported ValueSets as Instances

### DIFF
--- a/src/processor/FHIRProcessor.ts
+++ b/src/processor/FHIRProcessor.ts
@@ -62,14 +62,14 @@ export class FHIRProcessor {
         logger.error(`Could not process CodeSystem at ${wild.path}: ${ex.message}`);
       }
     });
-    this.lake.getAllValueSets().forEach(wild => {
+    this.lake.getAllValueSets(false).forEach(wild => {
       try {
         resources.add(ValueSetProcessor.process(wild.content, this.fisher));
       } catch (ex) {
         logger.error(`Could not process ValueSet at ${wild.path}: ${ex.message}`);
       }
     });
-    this.lake.getAllInstances().forEach(wild => {
+    this.lake.getAllInstances(true).forEach(wild => {
       try {
         resources.add(InstanceProcessor.process(wild.content, igForConfig?.content));
       } catch (ex) {

--- a/test/processor/FHIRProcessor.test.ts
+++ b/test/processor/FHIRProcessor.test.ts
@@ -81,15 +81,24 @@ describe('FHIRProcessor', () => {
     expect(codeSystemSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('should try to process a ValueSet with the ValueSetProcessor', () => {
+  it('should try to process a supported ValueSet with the ValueSetProcessor', () => {
     restockLake(lake, path.join(__dirname, 'fixtures', 'simple-valueset.json'));
     processor.process();
     expect(valueSetSpy).toHaveBeenCalledTimes(1);
+    expect(instanceSpy).not.toHaveBeenCalled();
   });
 
-  it('should try to process an Instance with the InstanceProcessor', () => {
+  it('should try to process a non-IG/SD/VS/CS Instance with the InstanceProcessor', () => {
     restockLake(lake, path.join(__dirname, 'fixtures', 'simple-patient.json'));
     processor.process();
     expect(instanceSpy).toHaveBeenCalledTimes(1);
+    expect(valueSetSpy).not.toHaveBeenCalled();
+  });
+
+  it('should try to process an unsupported ValueSet with the InstanceProcessor', () => {
+    restockLake(lake, path.join(__dirname, 'fixtures', 'unsupported-valueset.json'));
+    processor.process();
+    expect(instanceSpy).toHaveBeenCalledTimes(1);
+    expect(valueSetSpy).not.toHaveBeenCalled();
   });
 });

--- a/test/processor/ValueSetProcessor.test.ts
+++ b/test/processor/ValueSetProcessor.test.ts
@@ -35,6 +35,48 @@ describe('ValueSetProcessor', () => {
       expect(result).toBeUndefined();
     });
 
+    it('should not convert a ValueSet with an included concept designation', () => {
+      const input = JSON.parse(
+        fs.readFileSync(path.join(__dirname, 'fixtures', 'composed-valueset.json'), 'utf-8')
+      );
+      input.compose.include[0].concept[0].designation = {
+        value: 'ourse'
+      };
+      const result = ValueSetProcessor.process(input, defs);
+      expect(result).toBeUndefined();
+    });
+
+    it('should not convert a ValueSet with an excluded concept designation', () => {
+      const input = JSON.parse(
+        fs.readFileSync(path.join(__dirname, 'fixtures', 'composed-valueset.json'), 'utf-8')
+      );
+      input.compose.exclude[0].concept[0].designation = {
+        value: 'chatte'
+      };
+      const result = ValueSetProcessor.process(input, defs);
+      expect(result).toBeUndefined();
+    });
+
+    it('should not convert a ValueSet with a compose.include id', () => {
+      const input = JSON.parse(
+        fs.readFileSync(path.join(__dirname, 'fixtures', 'composed-valueset.json'), 'utf-8')
+      );
+      input.compose.include[0].id = 'some-id';
+      const result = ValueSetProcessor.process(input, defs);
+      expect(result).toBeUndefined();
+    });
+
+    it('should not convert a ValueSet with a compose.include.system extension', () => {
+      const input = JSON.parse(
+        fs.readFileSync(path.join(__dirname, 'fixtures', 'composed-valueset.json'), 'utf-8')
+      );
+      input.compose.include[0]._system = {
+        extension: {}
+      };
+      const result = ValueSetProcessor.process(input, defs);
+      expect(result).toBeUndefined();
+    });
+
     it('should convert a ValueSet without a name but with an id', () => {
       const input = JSON.parse(
         fs.readFileSync(path.join(__dirname, 'fixtures', 'nameless-valueset-with-id.json'), 'utf-8')

--- a/test/processor/fixtures/unsupported-valueset.json
+++ b/test/processor/fixtures/unsupported-valueset.json
@@ -1,0 +1,96 @@
+{
+  "resourceType": "ValueSet",
+  "name": "UnsupportedValueSet",
+  "id": "unsupported.valueset",
+  "title": "Unsupported ValueSet",
+  "description": "This value set is not supported by ValueSet FSH syntax because it has a concept designation.",
+  "compose": {
+    "include": [
+      {
+        "system": "http://example.org/zoo",
+        "concept": [
+          {
+            "code": "BEAR",
+            "display": "Bear",
+            "designation": {
+              "language": "fr",
+              "value": "ourse"
+            }
+          },
+          {
+            "code": "PEL",
+            "display": "Pelican"
+          }
+        ]
+      },
+      {
+        "system": "http://example.org/aquarium",
+        "valueSet": ["http://example.org/mammals"],
+        "concept": [
+          {
+            "code": "SEAL",
+            "display": "Seal"
+          }
+        ]
+      },
+      {
+        "system": "http://example.org/ghost-house"
+      },
+      {
+        "system": "http://example.org/planetarium",
+        "filter": [
+          {
+            "property": "gaseous",
+            "op": "=",
+            "value": "true"
+          }
+        ]
+      },
+      {
+        "system": "http://example.org/eatery",
+        "filter": [
+          {
+            "property": "species",
+            "op": "is-a",
+            "value": "fish"
+          }
+        ]
+      }
+    ],
+    "exclude": [
+      {
+        "system": "http://example.org/zoo",
+        "concept": [
+          {
+            "code": "CAT",
+            "display": "Cat"
+          }
+        ]
+      },
+      {
+        "system": "http://example.org/aquarium",
+        "valueSet": ["http://example.org/mollusks", "http://example.org/invertebrates"],
+        "concept": [
+          {
+            "code": "BARN",
+            "display": "Barnacle"
+          },
+          {
+            "code": "CLAM",
+            "display": "Clam"
+          }
+        ]
+      },
+      {
+        "system": "http://example.org/eatery",
+        "filter": [
+          {
+            "property": "tastiness",
+            "op": "exists",
+            "value": "true"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
If a ValueSet uses paths that cannot easily be represented using FSH VS syntax, process it as an Instance instead.

The tests demonstrate it, but if you want to manually test it, find an existing project of FHIR definitions and modify one of the ValueSets so that one of its `compose.include` components has an id or extension or concept designation somewhere inside it.  With master, it will generate it as a `ValueSet`.  With this PR, it will generate it as an `Instance`.

NOTE: Instance processing is not complete in `master` yet.  Currently it only exports Instance keywords.