### PR TITLE
Description metadata can be multiline string

### DIFF
--- a/src/exportable/common.ts
+++ b/src/exportable/common.ts
@@ -60,7 +60,13 @@ export function metadataToFSH(
     }
   }
   if (definition.description) {
-    resultLines.push(`Description: "${fshifyString(definition.description)}"`);
+    // Description can be a multiline string.
+    // If it contains newline characters, treat it as a multiline string.
+    if (definition.description.indexOf('\n') > -1) {
+      resultLines.push(`Description: """${definition.description}"""`);
+    } else {
+      resultLines.push(`Description: "${fshifyString(definition.description)}"`);
+    }
   }
   if (definition instanceof ExportableInvariant) {
     if (definition.severity) {

--- a/test/exportable/ExportableCodeSystem.test.ts
+++ b/test/exportable/ExportableCodeSystem.test.ts
@@ -29,13 +29,15 @@ describe('ExportableCodeSystem', () => {
   it('should export a CodeSystem with metadata that contains characters that are escaped in FSH', () => {
     const input = new ExportableCodeSystem('NewlineCodeSystem');
     input.id = 'newline-code-system';
+    input.title = 'This title\nhas a newline in it. Is that \\not allowed\\? Is that "not okay"?';
     input.description =
       'This description\nhas a newline in it. Is that \\not allowed\\? Is that "not okay"?';
 
     const expectedResult = [
       'CodeSystem: NewlineCodeSystem',
       'Id: newline-code-system',
-      'Description: "This description\\nhas a newline in it. Is that \\\\not allowed\\\\? Is that \\"not okay\\"?"'
+      'Title: "This title\\nhas a newline in it. Is that \\\\not allowed\\\\? Is that \\"not okay\\"?"',
+      'Description: """This description\nhas a newline in it. Is that \\not allowed\\? Is that "not okay"?"""'
     ].join(EOL);
     const result = input.toFSH();
     expect(result).toBe(expectedResult);

--- a/test/exportable/ExportableExtension.test.ts
+++ b/test/exportable/ExportableExtension.test.ts
@@ -73,13 +73,15 @@ describe('ExportableExtension', () => {
   it('should export an extension with metadata that contains characters that are escaped in FSH', () => {
     const input = new ExportableExtension('NewlineExtension');
     input.id = 'newline-extension';
+    input.title = 'This title\nhas a newline in it. Is that \\not allowed\\? Is that "not okay"?';
     input.description =
       'This description\nhas a newline in it. Is that \\not allowed\\? Is that "not okay"?';
 
     const expectedResult = [
       'Extension: NewlineExtension',
       'Id: newline-extension',
-      'Description: "This description\\nhas a newline in it. Is that \\\\not allowed\\\\? Is that \\"not okay\\"?"'
+      'Title: "This title\\nhas a newline in it. Is that \\\\not allowed\\\\? Is that \\"not okay\\"?"',
+      'Description: """This description\nhas a newline in it. Is that \\not allowed\\? Is that "not okay"?"""'
     ].join(EOL);
     const result = input.toFSH();
     expect(result).toBe(expectedResult);

--- a/test/exportable/ExportableInvariant.test.ts
+++ b/test/exportable/ExportableInvariant.test.ts
@@ -38,7 +38,7 @@ describe('ExportableInvariant', () => {
 
     const expectedResult = [
       'Invariant: inv-3',
-      'Description: "Please do this.\\nPlease always do this with a \\\\ character."',
+      'Description: """Please do this.\nPlease always do this with a \\ character."""',
       'Severity: #warning',
       'Expression: "requirement.contains(\\"\\\\\\")"',
       'XPath: "f:requirement"'

--- a/test/exportable/ExportableMapping.test.ts
+++ b/test/exportable/ExportableMapping.test.ts
@@ -34,13 +34,15 @@ describe('ExportableMapping', () => {
     const input = new ExportableMapping('NewLineMapping');
     input.id = 'new-line-mapping';
     input.target = 'http://crazy\\url.com';
+    input.title = 'This title\nhas a newline in it. Is that \\not allowed\\? Is that "not okay"?';
     input.description =
       'This description\nhas a newline in it. Is that \\not allowed\\? Is that "not okay"?';
 
     const expectedResult = [
       'Mapping: NewLineMapping',
       'Id: new-line-mapping',
-      'Description: "This description\\nhas a newline in it. Is that \\\\not allowed\\\\? Is that \\"not okay\\"?"',
+      'Title: "This title\\nhas a newline in it. Is that \\\\not allowed\\\\? Is that \\"not okay\\"?"',
+      'Description: """This description\nhas a newline in it. Is that \\not allowed\\? Is that "not okay"?"""',
       'Target: "http://crazy\\\\url.com"'
     ].join(EOL);
     const result = input.toFSH();

--- a/test/exportable/ExportableProfile.test.ts
+++ b/test/exportable/ExportableProfile.test.ts
@@ -37,13 +37,15 @@ describe('ExportableProfile', () => {
   it('should export a profile with metadata that contains characters that are escaped in FSH', () => {
     const input = new ExportableProfile('NewlineProfile');
     input.id = 'newline-profile';
+    input.title = 'This title\nhas a newline in it. Is that \\not allowed\\? Is that "not okay"?';
     input.description =
       'This description\nhas a newline in it. Is that \\not allowed\\? Is that "not okay"?';
 
     const expectedResult = [
       'Profile: NewlineProfile',
       'Id: newline-profile',
-      'Description: "This description\\nhas a newline in it. Is that \\\\not allowed\\\\? Is that \\"not okay\\"?"'
+      'Title: "This title\\nhas a newline in it. Is that \\\\not allowed\\\\? Is that \\"not okay\\"?"',
+      'Description: """This description\nhas a newline in it. Is that \\not allowed\\? Is that "not okay"?"""'
     ].join(EOL);
     const result = input.toFSH();
     expect(result).toBe(expectedResult);

--- a/test/exportable/ExportableValueSet.test.ts
+++ b/test/exportable/ExportableValueSet.test.ts
@@ -29,13 +29,15 @@ describe('ExportableValueSet', () => {
   it('should export a ValueSet with metadata that contains characters that are escaped in FSH', () => {
     const input = new ExportableValueSet('NewlineValueSet');
     input.id = 'newline-value-set';
+    input.title = 'This title\nhas a newline in it. Is that \\not allowed\\? Is that "not okay"?';
     input.description =
       'This description\nhas a newline in it. Is that \\not allowed\\? Is that "not okay"?';
 
     const expectedResult = [
       'ValueSet: NewlineValueSet',
       'Id: newline-value-set',
-      'Description: "This description\\nhas a newline in it. Is that \\\\not allowed\\\\? Is that \\"not okay\\"?"'
+      'Title: "This title\\nhas a newline in it. Is that \\\\not allowed\\\\? Is that \\"not okay\\"?"',
+      'Description: """This description\nhas a newline in it. Is that \\not allowed\\? Is that "not okay"?"""'
     ].join(EOL);
     const result = input.toFSH();
     expect(result).toBe(expectedResult);


### PR DESCRIPTION
Fixes #52 and completes task [CIMPL-613](https://standardhealthrecord.atlassian.net/browse/CIMPL-613)

If the description contains a newline character, treat it as a multiline string instead of a normal FSH string.

Note that this is only for descriptions: the value for an assignment or caret rule can also be a multiline string in FSH, but these are not being changed here.