### PR TITLE
Support new quantity syntax

### DIFF
--- a/src/optimizer/plugins/CombineCodingAndQuantityValuesOptimizer.ts
+++ b/src/optimizer/plugins/CombineCodingAndQuantityValuesOptimizer.ts
@@ -85,6 +85,10 @@ export default {
                 new FshCode(rule.value.code, 'http://unitsofmeasure.org')
               );
               rulesToRemove.push(rules.indexOf(valueSibling), rules.indexOf(systemSibling));
+              if (unitSibling) {
+                rule.value.unit.display = unitSibling.value as string;
+                rulesToRemove.push(rules.indexOf(unitSibling));
+              }
             } else if (unitSibling) {
               rule.caretPath = basePath;
               rule.value.display = unitSibling.value.toString();
@@ -155,6 +159,10 @@ export default {
                 instance.rules.indexOf(valueSibling),
                 instance.rules.indexOf(systemSibling)
               );
+              if (unitSibling) {
+                rule.value.unit.display = unitSibling.value as string;
+                rulesToRemove.push(instance.rules.indexOf(unitSibling));
+              }
             } else if (unitSibling) {
               rule.path = basePath;
               rule.value.display = unitSibling.value.toString();

--- a/test/optimizer/plugins/CombineCodingAndQuantityValuesOptimizer.test.ts
+++ b/test/optimizer/plugins/CombineCodingAndQuantityValuesOptimizer.test.ts
@@ -341,7 +341,7 @@ describe('optimizer', () => {
         expect(extension.rules).toContainEqual(valueRule);
       });
 
-      it('should prefer combining code, system, and value, even when unit is available, if system is http://unitsofmeasure.org', () => {
+      it('should combine code, system, unit, and value, if system is http://unitsofmeasure.org', () => {
         const extension = new ExportableExtension('MyExtension');
         const codeRule = new ExportableCaretValueRule('');
         codeRule.caretPath = 'extension[0].valueQuantity.code';
@@ -361,11 +361,13 @@ describe('optimizer', () => {
 
         const expectedRule = new ExportableCaretValueRule('');
         expectedRule.caretPath = 'extension[0].valueQuantity';
-        expectedRule.value = new FshQuantity(1.21, new FshCode('GW', 'http://unitsofmeasure.org'));
+        expectedRule.value = new FshQuantity(
+          1.21,
+          new FshCode('GW', 'http://unitsofmeasure.org', 'Gigawatts')
+        );
         optimizer.optimize(myPackage, fisher);
-        expect(extension.rules.length).toBe(2);
+        expect(extension.rules.length).toBe(1);
         expect(extension.rules).toContainEqual(expectedRule);
-        expect(extension.rules).toContainEqual(unitRule);
       });
 
       it('should combine rules on code, system, and unit when value is available, but system is not http://unitsofmeasure.org', () => {
@@ -710,7 +712,7 @@ describe('optimizer', () => {
         expect(instance.rules).toContainEqual(valueRule);
       });
 
-      it('should prefer combining code, system, and value, even when unit is available, if system is http://unitsofmeasure.org', () => {
+      it('should combine code, system, unit, and value, if system is http://unitsofmeasure.org', () => {
         const instance = new ExportableInstance('MyProfile');
         instance.instanceOf = 'Observation';
         const codeRule = new ExportableAssignmentRule('referenceRange.low.code');
@@ -726,11 +728,13 @@ describe('optimizer', () => {
         myPackage.add(instance);
 
         const expectedRule = new ExportableAssignmentRule('referenceRange.low');
-        expectedRule.value = new FshQuantity(6, new FshCode('Cal', 'http://unitsofmeasure.org'));
+        expectedRule.value = new FshQuantity(
+          6,
+          new FshCode('Cal', 'http://unitsofmeasure.org', 'nutrition label Calories')
+        );
         optimizer.optimize(myPackage, fisher);
-        expect(instance.rules.length).toBe(2);
+        expect(instance.rules.length).toBe(1);
         expect(instance.rules).toContainEqual(expectedRule);
-        expect(instance.rules).toContainEqual(unitRule);
       });
 
       it('should combine rules on code, system, and unit when value is available, but system is not http://unitsofmeasure.org', () => {


### PR DESCRIPTION
Completes task [CIMPL-606](https://standardhealthrecord.atlassian.net/browse/CIMPL-606).

Updates to the FSH syntax for specifying a quantity now allow an optional unit string at the end. When combining rules on a quantity element, add in this string if it exists.

This is a FSH STU2 feature, and as such is targeting the `stu2-features` branch.