### PR TITLE
Use diff2html-cli

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -114,7 +114,7 @@ async function app() {
   logger.info('Thank you for using goFSH.');
 
   if (program.fshingTrip) {
-    fshingTrip(inDir, outDir, program.installedSushi);
+    await fshingTrip(inDir, outDir, program.installedSushi);
   }
 
   process.exit(0);

--- a/src/app.ts
+++ b/src/app.ts
@@ -114,7 +114,7 @@ async function app() {
   logger.info('Thank you for using goFSH.');
 
   if (program.fshingTrip) {
-    await fshingTrip(inDir, outDir, program.installedSushi);
+    fshingTrip(inDir, outDir, program.installedSushi);
   }
 
   process.exit(0);

--- a/src/utils/fshingTrip.ts
+++ b/src/utils/fshingTrip.ts
@@ -1,19 +1,14 @@
 import path from 'path';
 import chalk from 'chalk';
 import { createTwoFilesPatch } from 'diff';
-import { execSync, execFile } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import temp from 'temp';
 import { cloneDeep, isEqual, union } from 'lodash';
 import fs from 'fs-extra';
 
 import { getFilesRecursive, logger } from '.';
-import util from 'util';
 
-export async function fshingTrip(
-  inDir: string,
-  outDir: string,
-  useLocalSUSHI: boolean
-): Promise<void> {
+export function fshingTrip(inDir: string, outDir: string, useLocalSUSHI: boolean) {
   // Make a pretty box to let the user know we are going into SUSHI mode
   // NOTE: If we add a box to the end of GoFSH output, it may make sense to modify this
   // so we don't have double boxes
@@ -106,7 +101,7 @@ export async function fshingTrip(
     fs.appendFileSync(diffFile.fd, patch, { encoding: 'utf8' });
   });
   try {
-    await util.promisify(execFile)(
+    execFileSync(
       'npx',
       [
         'diff2html-cli',

--- a/test/utils/fshingTrip.test.ts
+++ b/test/utils/fshingTrip.test.ts
@@ -7,6 +7,7 @@ import { fshingTrip } from '../../src/utils';
 
 describe('fshingTrip', () => {
   let execSyncSpy: jest.SpyInstance;
+  let execFileSyncSpy: jest.SpyInstance;
   let consoleSpy: jest.SpyInstance;
   let trackSpy: jest.SpyInstance;
   let openSyncSpy: jest.SpyInstance;
@@ -14,6 +15,7 @@ describe('fshingTrip', () => {
 
   beforeAll(() => {
     execSyncSpy = jest.spyOn(childProcess, 'execSync').mockImplementation();
+    execFileSyncSpy = jest.spyOn(childProcess, 'execFileSync').mockImplementation();
     consoleSpy = jest.spyOn(console, 'log').mockImplementation();
     trackSpy = jest.spyOn(temp, 'track').mockImplementation();
     openSyncSpy = jest.spyOn(temp, 'openSync').mockImplementation(() => {
@@ -24,6 +26,7 @@ describe('fshingTrip', () => {
 
   beforeEach(() => {
     execSyncSpy.mockClear();
+    execFileSyncSpy.mockClear();
     consoleSpy.mockClear();
     trackSpy.mockClear();
     openSyncSpy.mockClear();
@@ -36,7 +39,7 @@ describe('fshingTrip', () => {
       path.join(__dirname, 'fixtures', 'fshing-trip-output'),
       false
     );
-    expect(execSyncSpy).toHaveBeenCalledTimes(2);
+    expect(execSyncSpy).toHaveBeenCalledTimes(1);
     expect(execSyncSpy.mock.calls[0][0]).toBe(
       `npx sushi ${path.join(__dirname, 'fixtures', 'fshing-trip-output')}`
     );
@@ -48,7 +51,7 @@ describe('fshingTrip', () => {
       path.join(__dirname, 'fixtures', 'fshing-trip-output'),
       true
     );
-    expect(execSyncSpy).toHaveBeenCalledTimes(2);
+    expect(execSyncSpy).toHaveBeenCalledTimes(1);
     expect(execSyncSpy.mock.calls[0][0]).toBe(
       `sushi ${path.join(__dirname, 'fixtures', 'fshing-trip-output')}`
     );
@@ -60,7 +63,7 @@ describe('fshingTrip', () => {
       path.join(__dirname, 'fixtures', 'fshing-trip-output'),
       false
     );
-    expect(execSyncSpy).toHaveBeenCalledTimes(2);
+    expect(execSyncSpy).toHaveBeenCalledTimes(1);
     expect(execSyncSpy.mock.calls[0][0]).toBe(
       `npx sushi ${path.join(__dirname, 'fixtures', 'fshing-trip-output')}`
     );
@@ -71,15 +74,23 @@ describe('fshingTrip', () => {
     expect(appendFileSyncSpy.mock.calls[0][1]).toMatch(/observation\.json/);
     expect(appendFileSyncSpy.mock.calls[1][1]).toMatch(/profiled-patient.*different-profile/s);
     expect(appendFileSyncSpy.mock.calls[2][1]).toMatch(/practitioner\.json/);
-    expect(execSyncSpy.mock.calls[1][0]).toBe(
-      `npx diff2html -i file -s side -F fshing-trip-comparison.html --hwt ${path.join(
-        __dirname,
-        '..',
-        '..',
-        'src',
-        'utils',
-        'template.html'
-      )} -- foo.diff`
-    );
+    expect(execFileSyncSpy).toHaveBeenCalledTimes(1);
+    expect(execFileSyncSpy.mock.calls[0]).toEqual([
+      'npx',
+      [
+        'diff2html-cli',
+        '-i',
+        'file',
+        '-s',
+        'side',
+        '-F',
+        'fshing-trip-comparison.html',
+        '--hwt',
+        path.join(__dirname, '..', '..', 'src', 'utils', 'template.html'),
+        '--',
+        'foo.diff'
+      ],
+      { cwd: path.join(__dirname, 'fixtures', 'fshing-trip-output'), shell: true }
+    ]);
   });
 });


### PR DESCRIPTION
For some reason, using `diff2html-cli` instead of `diff2html` is necessary to make fshing-trip work correctly on my system. I don't understand it, but here we are.

Since there are no test cases for this, I ask that folks try running fshing-trip to make sure that this change doesn't cause it to stop working on your systems.