### PR TITLE
Url-setting CaretValueRules now included on SDs, CSs, and VSs

### DIFF
--- a/src/extractor/CaretValueRuleExtractor.ts
+++ b/src/extractor/CaretValueRuleExtractor.ts
@@ -111,10 +111,8 @@ export class CaretValueRuleExtractor {
     const flatParent = getPathValuePairs(parent);
     Object.keys(flatSD).forEach(key => {
       if (flatParent[key] == null || !isEqual(flatSD[key], flatParent[key])) {
-        if (key === 'url') {
-          const existingUrl = input.url;
-          const generatedUrl = `${config.canonical}/StructureDefinition/${input.id}`;
-          if (existingUrl === generatedUrl) return;
+        if (key === 'url' && this.isStandardURL('StructureDefinition', config, input)) {
+          return;
         }
         const caretValueRule = new ExportableCaretValueRule('');
         caretValueRule.caretPath = key;
@@ -142,10 +140,8 @@ export class CaretValueRuleExtractor {
           )
       )
       .forEach(key => {
-        if (key === 'url') {
-          const existingUrl = input.url;
-          const generatedUrl = `${config.canonical}/${resourceType}/${input.id}`;
-          if (existingUrl === generatedUrl) return;
+        if (key === 'url' && this.isStandardURL(resourceType, config, input)) {
+          return;
         }
         const caretValueRule = new ExportableCaretValueRule('');
         caretValueRule.caretPath = key;
@@ -153,6 +149,10 @@ export class CaretValueRuleExtractor {
         caretValueRules.push(caretValueRule);
       });
     return caretValueRules;
+  }
+
+  static isStandardURL(resourceType: string, config: fshtypes.Configuration, input: any): boolean {
+    return input.url == `${config.canonical}/${resourceType}/${input.id}`;
   }
 }
 

--- a/src/extractor/CaretValueRuleExtractor.ts
+++ b/src/extractor/CaretValueRuleExtractor.ts
@@ -1,4 +1,4 @@
-import { utils } from 'fsh-sushi';
+import { fshtypes, utils } from 'fsh-sushi';
 import { cloneDeep, isEqual, differenceWith } from 'lodash';
 import { ProcessableElementDefinition } from '../processor';
 import { ExportableCaretValueRule } from '../exportable';
@@ -27,7 +27,8 @@ export class CaretValueRuleExtractor {
 
   static processStructureDefinition(
     input: any,
-    fisher: utils.Fishable
+    fisher: utils.Fishable,
+    config: fshtypes.Configuration
   ): ExportableCaretValueRule[] {
     // Clone the input so we can modify it for simpler comparison
     const sd = cloneDeep(input);
@@ -110,6 +111,11 @@ export class CaretValueRuleExtractor {
     const flatParent = getPathValuePairs(parent);
     Object.keys(flatSD).forEach(key => {
       if (flatParent[key] == null || !isEqual(flatSD[key], flatParent[key])) {
+        if (key === 'url') {
+          const existingUrl = input.url;
+          const generatedUrl = `${config.canonical}/StructureDefinition/${input.id}`;
+          if (existingUrl === generatedUrl) return;
+        }
         const caretValueRule = new ExportableCaretValueRule('');
         caretValueRule.caretPath = key;
         caretValueRule.value = getFSHValue(key, flatSD, 'StructureDefinition', fisher);
@@ -123,7 +129,8 @@ export class CaretValueRuleExtractor {
   static processResource(
     input: any,
     fisher: utils.Fishable,
-    resourceType: 'ValueSet' | 'CodeSystem'
+    resourceType: 'ValueSet' | 'CodeSystem',
+    config: fshtypes.Configuration
   ): ExportableCaretValueRule[] {
     const caretValueRules: ExportableCaretValueRule[] = [];
     const flatVS = getPathValuePairs(input);
@@ -135,6 +142,11 @@ export class CaretValueRuleExtractor {
           )
       )
       .forEach(key => {
+        if (key === 'url') {
+          const existingUrl = input.url;
+          const generatedUrl = `${config.canonical}/${resourceType}/${input.id}`;
+          if (existingUrl === generatedUrl) return;
+        }
         const caretValueRule = new ExportableCaretValueRule('');
         caretValueRule.caretPath = key;
         caretValueRule.value = getFSHValue(key, flatVS, resourceType, fisher);
@@ -148,18 +160,16 @@ const RESOURCE_IGNORED_PROPERTIES = {
   ValueSet: [
     'resourceType',
     'id',
-    'url',
     'name',
     'title',
     'description',
     'compose.include',
     'compose.exclude'
   ],
-  CodeSystem: ['resourceType', 'id', 'url', 'name', 'title', 'description', 'concept'],
+  CodeSystem: ['resourceType', 'id', 'name', 'title', 'description', 'concept'],
   StructureDefinition: [
     'resourceType',
     'id',
-    'url', // NOTE: For now, we assume URL matches canonical and is generated
     'name',
     'title',
     'description',

--- a/src/processor/FHIRProcessor.ts
+++ b/src/processor/FHIRProcessor.ts
@@ -102,6 +102,7 @@ export class FHIRProcessor {
         StructureDefinitionProcessor.process(
           wild.content,
           this.fisher,
+          config.config,
           resources.invariants
         ).forEach(resource => {
           resources.add(resource);
@@ -115,7 +116,7 @@ export class FHIRProcessor {
     if (codeSystems.length > 0) logger.info('Processing CodeSystems...');
     codeSystems.forEach((wild, index) => {
       try {
-        resources.add(CodeSystemProcessor.process(wild.content, this.fisher));
+        resources.add(CodeSystemProcessor.process(wild.content, this.fisher, config.config));
         this.outputCount(codeSystems, index, 'CodeSystem');
       } catch (ex) {
         logger.error(`Could not process CodeSystem at ${wild.path}: ${ex.message}`);
@@ -125,7 +126,7 @@ export class FHIRProcessor {
     if (valueSets.length > 0) logger.info('Processing ValueSets...');
     valueSets.forEach((wild, index) => {
       try {
-        resources.add(ValueSetProcessor.process(wild.content, this.fisher));
+        resources.add(ValueSetProcessor.process(wild.content, this.fisher, config.config));
         this.outputCount(valueSets, index, 'ValueSet');
       } catch (ex) {
         logger.error(`Could not process ValueSet at ${wild.path}: ${ex.message}`);

--- a/src/processor/StructureDefinitionProcessor.ts
+++ b/src/processor/StructureDefinitionProcessor.ts
@@ -1,5 +1,5 @@
 import compact from 'lodash/compact';
-import { fhirtypes, utils } from 'fsh-sushi';
+import { fhirtypes, utils, fshtypes } from 'fsh-sushi';
 import {
   ExportableSdRule,
   ExportableInvariant,
@@ -26,6 +26,7 @@ export class StructureDefinitionProcessor {
   static process(
     input: any,
     fisher: utils.Fishable,
+    config: fshtypes.Configuration,
     existingInvariants: ExportableInvariant[] = []
   ):
     | [ExportableProfile | ExportableExtension, ...(ExportableInvariant | ExportableMapping)[]]
@@ -47,7 +48,7 @@ export class StructureDefinitionProcessor {
         existingInvariants
       );
       const mappings = StructureDefinitionProcessor.extractMappings(elements, input, fisher);
-      StructureDefinitionProcessor.extractRules(input, elements, sd, fisher);
+      StructureDefinitionProcessor.extractRules(input, elements, sd, fisher, config);
       // TODO: Destructuring an array with invariants and mappings is required for TypeScript 3.0
       // With TypeScript 4.0, we should update to return the following line, which is more clear:
       // return [sd, ...invariants, ...mappings];
@@ -77,11 +78,12 @@ export class StructureDefinitionProcessor {
     input: ProcessableStructureDefinition,
     elements: ProcessableElementDefinition[],
     target: ConstrainableEntity,
-    fisher: utils.Fishable
+    fisher: utils.Fishable,
+    config: fshtypes.Configuration
   ): void {
     const newRules: ExportableSdRule[] = [];
     // First extract the top-level caret rules from the StructureDefinition
-    newRules.push(...CaretValueRuleExtractor.processStructureDefinition(input, fisher));
+    newRules.push(...CaretValueRuleExtractor.processStructureDefinition(input, fisher, config));
     // Then extract rules based on the differential elements
     elements.forEach(element => {
       const ancestorSliceDefinition = getAncestorSliceDefinition(element, input, fisher);

--- a/test/extractor/CaretValueRuleExtractor.test.ts
+++ b/test/extractor/CaretValueRuleExtractor.test.ts
@@ -46,6 +46,7 @@ describe('CaretValueRuleExtractor', () => {
       const caretRules = CaretValueRuleExtractor.processStructureDefinition(urlSD, defs, config);
       expect(caretRules).toHaveLength(1);
       expect(caretRules[0].caretPath).toEqual('url');
+      expect(caretRules[0].value).toEqual('http://diferenturl.com');
     });
 
     it('should extract a single top-level caret value rule', () => {
@@ -451,6 +452,7 @@ describe('CaretValueRuleExtractor', () => {
       );
       expect(caretRules).toHaveLength(1);
       expect(caretRules[0].caretPath).toEqual('url');
+      expect(caretRules[0].value).toEqual('http://diferenturl.com');
     });
 
     it('should extract ValueSet caret rules when non keyword-based properties have changed', () => {
@@ -497,6 +499,7 @@ describe('CaretValueRuleExtractor', () => {
       );
       expect(caretRules).toHaveLength(1);
       expect(caretRules[0].caretPath).toEqual('url');
+      expect(caretRules[0].value).toEqual('http://diferenturl.com');
     });
 
     it('should extract CodeSystem caret rules when non keyword-based properties have changed', () => {

--- a/test/extractor/CaretValueRuleExtractor.test.ts
+++ b/test/extractor/CaretValueRuleExtractor.test.ts
@@ -12,10 +12,15 @@ describe('CaretValueRuleExtractor', () => {
   let looseSD: any;
   let looseVS: any;
   let looseCS: any;
+  let config: fshtypes.Configuration;
   let defs: fhirdefs.FHIRDefinitions;
 
   beforeAll(() => {
     defs = loadTestDefinitions();
+    config = {
+      canonical: 'http://hl7.org/fhir/sushi-test',
+      fhirVersion: ['4.0.1']
+    };
     looseSD = JSON.parse(
       fs.readFileSync(path.join(__dirname, 'fixtures', 'caret-value-profile.json'), 'utf-8').trim()
     );
@@ -31,14 +36,22 @@ describe('CaretValueRuleExtractor', () => {
 
   describe('StructureDefinition', () => {
     it('should not extract any SD caret rules when only keyword-based properties have changed', () => {
-      const caretRules = CaretValueRuleExtractor.processStructureDefinition(looseSD, defs);
+      const caretRules = CaretValueRuleExtractor.processStructureDefinition(looseSD, defs, config);
       expect(caretRules).toEqual<ExportableCaretValueRule[]>([]);
+    });
+
+    it('should extract a url-setting caret rules when a non-standard url is included on a StructureDefinition', () => {
+      const urlSD = cloneDeep(looseSD);
+      urlSD.url = 'http://diferenturl.com';
+      const caretRules = CaretValueRuleExtractor.processStructureDefinition(urlSD, defs, config);
+      expect(caretRules).toHaveLength(1);
+      expect(caretRules[0].caretPath).toEqual('url');
     });
 
     it('should extract a single top-level caret value rule', () => {
       const sd = cloneDeep(looseSD);
       sd.version = '1.2.3';
-      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs);
+      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs, config);
       const expectedRule = new ExportableCaretValueRule('');
       expectedRule.caretPath = 'version';
       expectedRule.value = '1.2.3';
@@ -49,7 +62,7 @@ describe('CaretValueRuleExtractor', () => {
       const sd = cloneDeep(looseSD);
       sd.version = '1.2.3';
       sd.experimental = true;
-      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs);
+      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs, config);
       const expectedRule1 = new ExportableCaretValueRule('');
       expectedRule1.caretPath = 'version';
       expectedRule1.value = '1.2.3';
@@ -65,7 +78,7 @@ describe('CaretValueRuleExtractor', () => {
     it('should extract array caret value rules', () => {
       const sd = cloneDeep(looseSD);
       sd.contextInvariant = ['foo-1', 'foo-2'];
-      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs);
+      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs, config);
       const expectedRule1 = new ExportableCaretValueRule('');
       expectedRule1.caretPath = 'contextInvariant[0]';
       expectedRule1.value = 'foo-1';
@@ -87,7 +100,7 @@ describe('CaretValueRuleExtractor', () => {
           value: 'baz'
         }
       ];
-      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs);
+      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs, config);
       const expectedRule1 = new ExportableCaretValueRule('');
       expectedRule1.caretPath = 'identifier[0].system';
       expectedRule1.value = 'http://foo.org/ids';
@@ -111,7 +124,7 @@ describe('CaretValueRuleExtractor', () => {
     it('should convert a FHIR code string to a FSH code when extracting', () => {
       const sd = cloneDeep(looseSD);
       sd.status = 'draft';
-      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs);
+      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs, config);
       const expectedRule = new ExportableCaretValueRule('');
       expectedRule.caretPath = 'status';
       expectedRule.value = new fshtypes.FshCode('draft');
@@ -134,7 +147,7 @@ describe('CaretValueRuleExtractor', () => {
           expression: 'Baz'
         }
       ];
-      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs);
+      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs, config);
       expect(caretRules).toEqual<ExportableCaretValueRule[]>([]);
     });
 
@@ -151,7 +164,7 @@ describe('CaretValueRuleExtractor', () => {
           expression: 'Baz'
         }
       ];
-      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs);
+      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs, config);
       expect(caretRules).toEqual<ExportableCaretValueRule[]>([]);
     });
 
@@ -175,7 +188,7 @@ describe('CaretValueRuleExtractor', () => {
           expression: 'SomethingFancyAndNew'
         }
       ];
-      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs);
+      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs, config);
       const expectedRule1 = new ExportableCaretValueRule('');
       expectedRule1.caretPath = 'context[3].type';
       expectedRule1.value = new fshtypes.FshCode('element');
@@ -201,7 +214,7 @@ describe('CaretValueRuleExtractor', () => {
           expression: 'Baz'
         }
       ];
-      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs);
+      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs, config);
       const expectedRule1 = new ExportableCaretValueRule('');
       expectedRule1.caretPath = 'context[1].type';
       expectedRule1.value = new fshtypes.FshCode('fhirpath');
@@ -240,7 +253,7 @@ describe('CaretValueRuleExtractor', () => {
           valueCode: 'bar'
         }
       ];
-      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs);
+      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs, config);
       const expectedRules: ExportableCaretValueRule[] = [];
       let n = -1;
       // extension[0]
@@ -328,7 +341,7 @@ describe('CaretValueRuleExtractor', () => {
           valueCode: 'oo'
         }
       ];
-      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs);
+      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs, config);
       const expectedRules: ExportableCaretValueRule[] = [];
       let n = -1;
       // extension[0]
@@ -387,14 +400,14 @@ describe('CaretValueRuleExtractor', () => {
         status: 'generated',
         div: '<div>Foo!</div'
       };
-      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs);
+      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs, config);
       expect(caretRules).toEqual<ExportableCaretValueRule[]>([]);
     });
 
     it('should export a caret rule for "cleared" properties, even if it is the same as the parent', () => {
       const sd = cloneDeep(looseSD);
       sd.publisher = 'Health Level Seven International (Orders and Observations)';
-      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs);
+      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs, config);
       const expectedRule = new ExportableCaretValueRule('');
       expectedRule.caretPath = 'publisher';
       expectedRule.value = 'Health Level Seven International (Orders and Observations)';
@@ -405,7 +418,7 @@ describe('CaretValueRuleExtractor', () => {
       const sd = cloneDeep(looseSD);
       sd.baseDefinition = 'http://i.dont.exist.org/';
       sd.publisher = 'Acme, Inc.';
-      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs);
+      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs, config);
       expect(loggerSpy.getLastMessage('warn')).toMatch(
         /Cannot reliably export .* ObservationWithCaret .* http:\/\/i\.dont\.exist\.org\//
       );
@@ -421,9 +434,23 @@ describe('CaretValueRuleExtractor', () => {
       const caretRules = CaretValueRuleExtractor.processResource(
         looseVS,
         defs,
-        looseVS.resourceType
+        looseVS.resourceType,
+        config
       );
       expect(caretRules).toEqual<ExportableCaretValueRule[]>([]);
+    });
+
+    it('should extract a url-setting caret rule when a non-standard url is included on a ValueSet', () => {
+      const urlVS = cloneDeep(looseVS);
+      urlVS.url = 'http://diferenturl.com';
+      const caretRules = CaretValueRuleExtractor.processResource(
+        urlVS,
+        defs,
+        urlVS.resourceType,
+        config
+      );
+      expect(caretRules).toHaveLength(1);
+      expect(caretRules[0].caretPath).toEqual('url');
     });
 
     it('should extract ValueSet caret rules when non keyword-based properties have changed', () => {
@@ -431,7 +458,7 @@ describe('CaretValueRuleExtractor', () => {
       vs.status = 'active';
       vs.compose.inactive = true;
       vs.identifier = { value: 'foo' };
-      const caretRules = CaretValueRuleExtractor.processResource(vs, defs, vs.resourceType);
+      const caretRules = CaretValueRuleExtractor.processResource(vs, defs, vs.resourceType, config);
       const expectedRule1 = new ExportableCaretValueRule('');
       expectedRule1.caretPath = 'status';
       expectedRule1.value = new fshtypes.FshCode('active');
@@ -453,9 +480,23 @@ describe('CaretValueRuleExtractor', () => {
       const caretRules = CaretValueRuleExtractor.processResource(
         looseCS,
         defs,
-        looseCS.resourceType
+        looseCS.resourceType,
+        config
       );
       expect(caretRules).toEqual<ExportableCaretValueRule[]>([]);
+    });
+
+    it('should extract a url-setting caret rule when a non-standard url is included on a CodeSystem', () => {
+      const urlCS = cloneDeep(looseCS);
+      urlCS.url = 'http://diferenturl.com';
+      const caretRules = CaretValueRuleExtractor.processResource(
+        urlCS,
+        defs,
+        urlCS.resourceType,
+        config
+      );
+      expect(caretRules).toHaveLength(1);
+      expect(caretRules[0].caretPath).toEqual('url');
     });
 
     it('should extract CodeSystem caret rules when non keyword-based properties have changed', () => {
@@ -463,7 +504,7 @@ describe('CaretValueRuleExtractor', () => {
       cs.status = 'active';
       cs.experimental = true;
       cs.identifier = { value: 'foo' };
-      const caretRules = CaretValueRuleExtractor.processResource(cs, defs, cs.resourceType);
+      const caretRules = CaretValueRuleExtractor.processResource(cs, defs, cs.resourceType, config);
       const expectedRule1 = new ExportableCaretValueRule('');
       expectedRule1.caretPath = 'status';
       expectedRule1.value = new fshtypes.FshCode('active');

--- a/test/extractor/fixtures/caret-value-profile.json
+++ b/test/extractor/fixtures/caret-value-profile.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "StructureDefinition",
-  "id": "observation-with-caret",
+  "id": "observation-with-caret-plain",
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-category",
@@ -89,7 +89,10 @@
       {
         "id": "Observation.category",
         "path": "Observation.category",
-        "alias": ["foo", "bar"]
+        "alias": [
+          "foo",
+          "bar"
+        ]
       },
       {
         "id": "Observation.code",

--- a/test/processor/CodeSystemProcessor.test.ts
+++ b/test/processor/CodeSystemProcessor.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs-extra';
-import { fhirdefs } from 'fsh-sushi';
+import { fhirdefs, fshtypes } from 'fsh-sushi';
 import { CodeSystemProcessor } from '../../src/processor';
 import {
   ExportableCodeSystem,
@@ -11,16 +11,21 @@ import { loadTestDefinitions } from '../helpers/loadTestDefinitions';
 
 describe('CodeSystemProcessor', () => {
   let defs: fhirdefs.FHIRDefinitions;
+  let config: fshtypes.Configuration;
 
   beforeAll(() => {
     defs = loadTestDefinitions();
+    config = {
+      canonical: 'http://example.org/tests',
+      fhirVersion: ['4.0.1']
+    };
   });
   describe('#process', () => {
     it('should convert the simplest CodeSystem', () => {
       const input = JSON.parse(
         fs.readFileSync(path.join(__dirname, 'fixtures', 'simple-codesystem.json'), 'utf-8')
       );
-      const result = CodeSystemProcessor.process(input, defs);
+      const result = CodeSystemProcessor.process(input, defs, config);
       expect(result).toBeInstanceOf(ExportableCodeSystem);
       expect(result.name).toBe('SimpleCodeSystem');
     });
@@ -29,7 +34,7 @@ describe('CodeSystemProcessor', () => {
       const input = JSON.parse(
         fs.readFileSync(path.join(__dirname, 'fixtures', 'nameless-codesystem.json'), 'utf-8')
       );
-      const result = CodeSystemProcessor.process(input, defs);
+      const result = CodeSystemProcessor.process(input, defs, config);
       expect(result).toBeUndefined();
     });
 
@@ -40,7 +45,7 @@ describe('CodeSystemProcessor', () => {
           'utf-8'
         )
       );
-      const result = CodeSystemProcessor.process(input, defs);
+      const result = CodeSystemProcessor.process(input, defs, config);
       expect(result).toBeInstanceOf(ExportableCodeSystem);
       expect(result.name).toBe('MyCodeSystem');
       expect(result.id).toBe('my.code-system');
@@ -54,7 +59,7 @@ describe('CodeSystemProcessor', () => {
         language: 'fr',
         value: 'diner-dangereux'
       };
-      const result = CodeSystemProcessor.process(input, defs);
+      const result = CodeSystemProcessor.process(input, defs, config);
       expect(result).toBeUndefined();
     });
 
@@ -66,7 +71,7 @@ describe('CodeSystemProcessor', () => {
         code: 'healthy',
         valueCode: 'sometimes'
       };
-      const result = CodeSystemProcessor.process(input, defs);
+      const result = CodeSystemProcessor.process(input, defs, config);
       expect(result).toBeUndefined();
     });
 
@@ -78,7 +83,7 @@ describe('CodeSystemProcessor', () => {
         code: 'breakfast2',
         display: 'Second breakfast'
       };
-      const result = CodeSystemProcessor.process(input, defs);
+      const result = CodeSystemProcessor.process(input, defs, config);
       expect(result).toBeUndefined();
     });
   });
@@ -103,7 +108,7 @@ describe('CodeSystemProcessor', () => {
         fs.readFileSync(path.join(__dirname, 'fixtures', 'concept-codesystem.json'), 'utf-8')
       );
       const workingCodeSystem = new ExportableCodeSystem('MyCodeSystem');
-      CodeSystemProcessor.extractRules(input, workingCodeSystem, defs);
+      CodeSystemProcessor.extractRules(input, workingCodeSystem, defs, config);
       expect(workingCodeSystem.rules).toHaveLength(4);
       expect(workingCodeSystem.rules).toEqual(
         expect.arrayContaining([
@@ -125,11 +130,11 @@ describe('CodeSystemProcessor', () => {
       );
 
       const targetCodeSystem = new ExportableCodeSystem('MyValueSet');
-      CodeSystemProcessor.extractRules(input, targetCodeSystem, defs);
+      CodeSystemProcessor.extractRules(input, targetCodeSystem, defs, config);
       expect(targetCodeSystem.rules).toHaveLength(0);
 
       input.experimental = true;
-      CodeSystemProcessor.extractRules(input, targetCodeSystem, defs);
+      CodeSystemProcessor.extractRules(input, targetCodeSystem, defs, config);
       const experimentalRule = new ExportableCaretValueRule('');
       experimentalRule.caretPath = 'experimental';
       experimentalRule.value = true;

--- a/test/processor/StructureDefinitionProcessor.test.ts
+++ b/test/processor/StructureDefinitionProcessor.test.ts
@@ -22,6 +22,7 @@ import { ContainsRuleExtractor } from '../../src/extractor';
 
 describe('StructureDefinitionProcessor', () => {
   let defs: fhirdefs.FHIRDefinitions;
+  let config: fshtypes.Configuration;
 
   beforeAll(() => {
     defs = loadTestDefinitions();
@@ -30,6 +31,10 @@ describe('StructureDefinitionProcessor', () => {
         fs.readFileSync(path.join(__dirname, 'fixtures', 'parent-observation.json'), 'utf-8')
       )
     );
+    config = {
+      canonical: 'http://hl7.org/fhir/sushi-test',
+      fhirVersion: ['4.0.1']
+    };
   });
 
   describe('#process', () => {
@@ -37,7 +42,7 @@ describe('StructureDefinitionProcessor', () => {
       const input = JSON.parse(
         fs.readFileSync(path.join(__dirname, 'fixtures', 'simple-profile.json'), 'utf-8')
       );
-      const result = StructureDefinitionProcessor.process(input, defs);
+      const result = StructureDefinitionProcessor.process(input, defs, config);
 
       expect(result).toHaveLength(1);
       expect(result[0]).toBeInstanceOf(ExportableProfile);
@@ -49,7 +54,7 @@ describe('StructureDefinitionProcessor', () => {
       const input = JSON.parse(
         fs.readFileSync(path.join(__dirname, 'fixtures', 'child-observation.json'), 'utf-8')
       );
-      const result = StructureDefinitionProcessor.process(input, defs);
+      const result = StructureDefinitionProcessor.process(input, defs, config);
 
       expect(result).toHaveLength(1);
       expect(result[0]).toBeInstanceOf(ExportableProfile);
@@ -80,7 +85,7 @@ describe('StructureDefinitionProcessor', () => {
       const input = JSON.parse(
         fs.readFileSync(path.join(__dirname, 'fixtures', 'simple-extension.json'), 'utf-8')
       );
-      const result = StructureDefinitionProcessor.process(input, defs);
+      const result = StructureDefinitionProcessor.process(input, defs, config);
 
       expect(result).toHaveLength(1);
       expect(result[0]).toBeInstanceOf(ExportableExtension);
@@ -92,7 +97,7 @@ describe('StructureDefinitionProcessor', () => {
       const input = JSON.parse(
         fs.readFileSync(path.join(__dirname, 'fixtures', 'big-profile.json'), 'utf-8')
       );
-      const [profile] = StructureDefinitionProcessor.process(input, defs);
+      const [profile] = StructureDefinitionProcessor.process(input, defs, config);
 
       expect(profile).toBeInstanceOf(ExportableProfile);
       expect(profile.name).toBe('BigProfile');
@@ -103,7 +108,7 @@ describe('StructureDefinitionProcessor', () => {
       const input = JSON.parse(
         fs.readFileSync(path.join(__dirname, 'fixtures', 'rules-profile.json'), 'utf-8')
       );
-      const result = StructureDefinitionProcessor.process(input, defs);
+      const result = StructureDefinitionProcessor.process(input, defs, config);
       const profiles = result.filter(resource => resource instanceof ExportableProfile);
       const invariants = result.filter(resource => resource instanceof ExportableInvariant);
 
@@ -115,7 +120,7 @@ describe('StructureDefinitionProcessor', () => {
       const input = JSON.parse(
         fs.readFileSync(path.join(__dirname, 'fixtures', 'reused-invariant-profile.json'), 'utf-8')
       );
-      const result = StructureDefinitionProcessor.process(input, defs);
+      const result = StructureDefinitionProcessor.process(input, defs, config);
       const invariants = result.filter(resource => resource instanceof ExportableInvariant);
       const profile = result.find(
         resource => resource instanceof ExportableProfile
@@ -144,7 +149,7 @@ describe('StructureDefinitionProcessor', () => {
       const input = JSON.parse(
         fs.readFileSync(path.join(__dirname, 'fixtures', 'nameless-profile.json'), 'utf-8')
       );
-      const result = StructureDefinitionProcessor.process(input, defs);
+      const result = StructureDefinitionProcessor.process(input, defs, config);
 
       expect(result).toHaveLength(0);
     });
@@ -153,7 +158,7 @@ describe('StructureDefinitionProcessor', () => {
       const input = JSON.parse(
         fs.readFileSync(path.join(__dirname, 'fixtures', 'nameless-extension.json'), 'utf-8')
       );
-      const result = StructureDefinitionProcessor.process(input, defs);
+      const result = StructureDefinitionProcessor.process(input, defs, config);
 
       expect(result).toHaveLength(0);
     });
@@ -216,7 +221,7 @@ describe('StructureDefinitionProcessor', () => {
         'mapping[0].language'
       );
       const workingProfile = new ExportableProfile('MyObservation');
-      StructureDefinitionProcessor.extractRules(input, elements, workingProfile, defs);
+      StructureDefinitionProcessor.extractRules(input, elements, workingProfile, defs, config);
       const cardRule = new ExportableCardRule('valueString');
       cardRule.min = 1;
       const assignmentRule = new ExportableAssignmentRule('valueString');
@@ -243,7 +248,7 @@ describe('StructureDefinitionProcessor', () => {
           return ProcessableElementDefinition.fromJSON(rawElement, false);
         }) ?? [];
       const workingExtension = new ExportableExtension('MyExtension');
-      StructureDefinitionProcessor.extractRules(input, elements, workingExtension, defs);
+      StructureDefinitionProcessor.extractRules(input, elements, workingExtension, defs, config);
       const assignmentRule = new ExportableAssignmentRule('url');
       assignmentRule.value = 'https://go.fsh/StructureDefinition/my-extension';
       assignmentRule.exactly = true;
@@ -261,7 +266,7 @@ describe('StructureDefinitionProcessor', () => {
           return ProcessableElementDefinition.fromJSON(rawElement, false);
         }) ?? [];
       const workingProfile = new ExportableProfile('MyObservation');
-      StructureDefinitionProcessor.extractRules(input, elements, workingProfile, defs);
+      StructureDefinitionProcessor.extractRules(input, elements, workingProfile, defs, config);
       const containsRule = new ExportableContainsRule('category');
       containsRule.items = [{ name: 'Foo' }];
       const cardRule = new ExportableCardRule('category[Foo]');
@@ -281,7 +286,7 @@ describe('StructureDefinitionProcessor', () => {
           return ProcessableElementDefinition.fromJSON(rawElement, false);
         }) ?? [];
       const workingProfile = new ExportableProfile('MyObservation');
-      StructureDefinitionProcessor.extractRules(input, elements, workingProfile, defs);
+      StructureDefinitionProcessor.extractRules(input, elements, workingProfile, defs, config);
       const cardRule = new ExportableCardRule('category[VSCat]');
       cardRule.min = 1;
       cardRule.max = '1';

--- a/test/processor/fixtures/rules-codesystem.json
+++ b/test/processor/fixtures/rules-codesystem.json
@@ -1,7 +1,7 @@
 {
   "resourceType": "CodeSystem",
   "id": "codesystem-with-caret",
-  "url": "http://hl7.org/fhir/sushi-test/CodeSystem/codesystem-with-caret",
+  "url": "http://example.org/tests/CodeSystem/codesystem-with-caret",
   "name": "CodeSystemWithCaret",
   "title": "CodeSystem with Caret",
   "description": "A CodeSystem for testing caret rules",


### PR DESCRIPTION
Fixes #68 and addresses [CIMPL-656](https://standardhealthrecord.atlassian.net/browse/CIMPL-656), including CaretValueRules setting the `url` property of StructureDefinitions, ValueSets, and CodeSystems when the pre-existing url is different than the url that sushi would generate automatically. 