### PR TITLE
Fix null dereference

### DIFF
--- a/src/optimizer/utils.ts
+++ b/src/optimizer/utils.ts
@@ -55,7 +55,7 @@ export function resolveURL(
   // NOTE: Testing against a regex from FHIR because some FHIR core definitions have names that are
   // invalid against the spec!  Good heavens!
   if (
-    def?.name.match(/^[A-Z]([A-Za-z0-9_]){0,254}$/) &&
+    def?.name?.match(/^[A-Z]([A-Za-z0-9_]){0,254}$/) &&
     fisher.fishForMetadata(def.name, ...types).url === url
   ) {
     return def.name;


### PR DESCRIPTION
This fixes and issue that was reported as part of #75 (it's not the original issue, but an issue that came up when attempting the provided workaround).  Basically GoFSH was crashing, and it turns out it was crashing because we tried to access a property on a variable that was null.

If you really want to reproduce:
* Clone [dk-core](https://github.com/hl7dk/dk-core)
* Run the IG publisher on it (`java -jar publisher.jar -ig ig.ini`)
* Run GoFSH on the resulting `output` directory

If you don't want to reproduce, I think that's probably OK -- because no matter how you look at it, `def?.name.match` is definitely a bug.