### PR TITLE
Fix npm pack with FSHing Trip

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "types": "dist/app.d.ts",
   "files": [
-    "dist/**/*.{js,json,d.ts}"
+    "dist/**/*.{js,json,d.ts}",
+    "dist/utils/template.html"
   ],
   "contributors": [
     "Julia Afeltra <jafeltra@mitre.org>",


### PR DESCRIPTION
FSHing trip was not working correctly when `npm pack`ed, because the `template.html` file was not packaged. This should fix that.