### PR TITLE
Bump SUSHI to 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2907,9 +2907,9 @@
       "optional": true
     },
     "fsh-sushi": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-1.1.0.tgz",
-      "integrity": "sha512-0R+jT3vwxiXxyZ4gaH5E0liUf56edgQm+gmCIHO4TzAA/YYeu6IlWhVS+mu3yP1Fi8JJMkERRwnMYrfBI5K2CQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-1.2.0.tgz",
+      "integrity": "sha512-3jnKoGrXFixskcXjxJlAw3bdTP97UzVdNQ8MihGrQJ/TwKbu0emt8SC0Fadp5Ob+ztEMixqzB6cqfIHwHpARPg==",
       "requires": {
         "antlr4": "~4.8.0",
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "fhir": "^4.8.2",
     "flat": "^5.0.2",
     "fs-extra": "^9.0.1",
-    "fsh-sushi": "^1.1.0",
+    "fsh-sushi": "^1.2.0",
     "ini": "^1.3.5",
     "lodash": "^4.17.19",
     "readline-sync": "^1.4.10",


### PR DESCRIPTION
Bumps SUSHI to v1.2.0.

In the process of testing this, I ran into two bugs, but I don't think either one is related to SUSHI 1.2.0.