### PR TITLE
If an element references an undefined mapping, create it

### DIFF
--- a/src/exportable/ExportableCaretValueRule.ts
+++ b/src/exportable/ExportableCaretValueRule.ts
@@ -3,7 +3,8 @@ import { EOL } from 'os';
 import { ExportableRule } from '.';
 
 export class ExportableCaretValueRule extends fshrules.CaretValueRule implements ExportableRule {
-  comment: string;
+  fshComment: string;
+
   constructor(path: string) {
     super(path);
   }
@@ -26,8 +27,8 @@ export class ExportableCaretValueRule extends fshrules.CaretValueRule implements
       value = this.isInstance ? this.value : `"${this.value}"`;
     }
     const lines: string[] = [];
-    if (this.comment) {
-      lines.push(...this.comment.split('\n').map(c => `// ${c}`));
+    if (this.fshComment) {
+      lines.push(...this.fshComment.split('\n').map(c => `// ${c}`));
     }
     lines.push(`* ${this.path !== '' ? this.path + ' ' : ''}^${this.caretPath} = ${value}`);
     return lines.join(EOL);

--- a/src/exportable/ExportableMapping.ts
+++ b/src/exportable/ExportableMapping.ts
@@ -4,6 +4,7 @@ import { Exportable, ExportableMappingRule, ExportableInsertRule } from '.';
 import { metadataToFSH } from './common';
 
 export class ExportableMapping extends fshtypes.Mapping implements Exportable {
+  fshComment: string;
   rules: (ExportableMappingRule | ExportableInsertRule)[];
 
   constructor(name: string) {
@@ -11,8 +12,16 @@ export class ExportableMapping extends fshtypes.Mapping implements Exportable {
   }
 
   toFSH(): string {
+    let fshComments = '';
+    if (this.fshComment) {
+      fshComments =
+        this.fshComment
+          .split('\n')
+          .map(c => `// ${c}`)
+          .join(EOL) + EOL;
+    }
     const metadataFSH = metadataToFSH(this);
     const rulesFSH = this.rules.map(r => r.toFSH()).join(EOL);
-    return `${metadataFSH}${rulesFSH.length ? EOL + rulesFSH : ''}`;
+    return `${fshComments}${metadataFSH}${rulesFSH.length ? EOL + rulesFSH : ''}`;
   }
 }

--- a/src/extractor/CaretValueRuleExtractor.ts
+++ b/src/extractor/CaretValueRuleExtractor.ts
@@ -39,7 +39,7 @@ export class CaretValueRuleExtractor {
         if (newIndex != null) {
           caretValueRule.caretPath = key.replace(constraintMatch[0], `constraint[${newIndex}]`);
         } else {
-          caretValueRule.comment =
+          caretValueRule.fshComment =
             `WARNING: The constraint index in the following rule (e.g., ${constraintMatch[0]}) may be incorrect.\n` +
             "Please compare with the constraint array in the original definition's snapshot and adjust as necessary.";
           logger.warn(
@@ -64,7 +64,7 @@ export class CaretValueRuleExtractor {
         if (newIndex != null) {
           caretValueRule.caretPath = key.replace(mappingMatch[0], `mapping[${newIndex}]`);
         } else {
-          caretValueRule.comment =
+          caretValueRule.fshComment =
             `WARNING: The mapping index in the following rule (e.g., ${mappingMatch[0]}) may be incorrect.\n` +
             "Please compare with the mapping array in the original definition's snapshot and adjust as necessary.";
           logger.warn(

--- a/src/extractor/MappingExtractor.ts
+++ b/src/extractor/MappingExtractor.ts
@@ -64,7 +64,6 @@ export class MappingExtractor {
       const mapping = new ExportableMapping(`${m.identity}-for-${sd.name}`);
       mapping.id = m.identity;
       mapping.source = sd.name;
-      mapping.name = `${mapping.id}-for-${mapping.source}`;
       if (m.name) mapping.title = m.name;
       if (m.uri) mapping.target = m.uri;
       if (m.comment) mapping.description = m.comment;

--- a/src/extractor/MappingExtractor.ts
+++ b/src/extractor/MappingExtractor.ts
@@ -6,7 +6,7 @@ import {
   ProcessableStructureDefinition,
   StructureDefinitionProcessor
 } from '../processor';
-import { getPath } from '../utils';
+import { getPath, logger } from '../utils';
 
 export class MappingExtractor {
   static process(
@@ -37,7 +37,7 @@ export class MappingExtractor {
         return ProcessableElementDefinition.fromJSON(rawElement, false);
       }) ?? [];
 
-    const parentMappings = this.extractMappings(parent, parentSDElements);
+    const parentMappings = this.extractMappings(parent, parentSDElements, true);
 
     // Only return mappings that are new to the profile or inherited mappings with new MappingRules
     const newMappings: ExportableMapping[] = [];
@@ -57,10 +57,12 @@ export class MappingExtractor {
 
   static extractMappings(
     sd: ProcessableStructureDefinition,
-    elements: ProcessableElementDefinition[]
+    elements: ProcessableElementDefinition[],
+    processingParent = false
   ): ExportableMapping[] {
     const mappings = (sd.mapping || []).map(m => {
-      const mapping = new ExportableMapping(m.identity);
+      const mapping = new ExportableMapping(`${m.identity}-for-${sd.name}`);
+      mapping.id = m.identity;
       mapping.source = sd.name;
       mapping.name = `${mapping.id}-for-${mapping.source}`;
       if (m.name) mapping.title = m.name;
@@ -69,16 +71,39 @@ export class MappingExtractor {
       return mapping;
     });
     elements.forEach(element => {
-      this.extractRules(element, mappings);
+      this.extractRules(element, sd, mappings, processingParent);
     });
     return mappings;
   }
 
-  static extractRules(element: ProcessableElementDefinition, mappings: ExportableMapping[]) {
+  static extractRules(
+    element: ProcessableElementDefinition,
+    sd: ProcessableStructureDefinition,
+    mappings: ExportableMapping[],
+    processingParent = false
+  ) {
     element.mapping?.forEach((mapping, i) => {
-      // Mappings are created at SD, so should always find a match at this point
-      const matchingMapping = mappings.find(m => m.id === mapping.identity);
-      matchingMapping?.rules.push(this.processMappingRule(element, mapping, i));
+      let matchingMapping = mappings.find(m => m.id === mapping.identity);
+      if (matchingMapping == null) {
+        // There should always be a matching mapping, but some IGs seem to be missing some top-level mappings
+        // (I'm looking at you US Core 3.1.1).  When a mapping is missing, create one on the fly, but log
+        // a warning and write a comment.
+        matchingMapping = new ExportableMapping(`${mapping.identity}-for-${sd.name}`);
+        matchingMapping.id = mapping.identity;
+        matchingMapping.source = sd.name;
+        if (!processingParent) {
+          matchingMapping.fshComment =
+            `WARNING: The following Mapping may be incomplete since the original ${sd.name}\n` +
+            `StructureDefinition was missing the mapping entry for ${matchingMapping.id}.\n` +
+            'Please review this and add the following properties as necessary: Target, Title, Description';
+          logger.warn(
+            `Element in ${sd.name} references undefined SD-level mapping: ${matchingMapping.id}.  GoFSH has created a new Mapping named ` +
+              `${matchingMapping.name}. Please review and edit the Mapping in your FSH files to provide additional information.`
+          );
+        }
+        mappings.push(matchingMapping);
+      }
+      matchingMapping.rules.push(this.processMappingRule(element, mapping, i));
     });
   }
 

--- a/test/exportable/ExportableCaretValueRule.test.ts
+++ b/test/exportable/ExportableCaretValueRule.test.ts
@@ -13,7 +13,7 @@ describe('ExportableCaretValueRule', () => {
 
   it('should export a caret rule with comments', () => {
     const rule = new ExportableCaretValueRule('');
-    rule.comment = 'I have something really important to tell you...\nJust kidding!';
+    rule.fshComment = 'I have something really important to tell you...\nJust kidding!';
     rule.caretPath = 'short';
     rule.value = 'Important summary';
 

--- a/test/exportable/ExportableMapping.test.ts
+++ b/test/exportable/ExportableMapping.test.ts
@@ -10,6 +10,20 @@ describe('ExportableMapping', () => {
     expect(result).toBe(expectedResult);
   });
 
+  it('should export a Mapping with comments', () => {
+    const input = new ExportableMapping('SimpleMapping');
+    input.fshComment = 'I have something really important to tell you...\nGot you again!';
+
+    const expectedResult = [
+      '// I have something really important to tell you...',
+      '// Got you again!',
+      'Mapping: SimpleMapping',
+      'Id: SimpleMapping'
+    ].join(EOL);
+    const result = input.toFSH();
+    expect(result).toBe(expectedResult);
+  });
+
   it('should export a Mapping with additional metadata', () => {
     const input = new ExportableMapping('MetaMapping');
     input.id = 'meta-mapping';

--- a/test/extractor/CaretValueRuleExtractor.test.ts
+++ b/test/extractor/CaretValueRuleExtractor.test.ts
@@ -657,7 +657,7 @@ describe('CaretValueRuleExtractor', () => {
       const expectedRule = new ExportableCaretValueRule('referenceRange');
       expectedRule.caretPath = 'constraint[0].id';
       expectedRule.value = 'yesconstraintscanhaveids';
-      expectedRule.comment =
+      expectedRule.fshComment =
         'WARNING: The constraint index in the following rule (e.g., constraint[0]) may be incorrect.\n' +
         "Please compare with the constraint array in the original definition's snapshot and adjust as necessary.";
       // The other constraint properties (key, severity, etc) will create rules too, but they'd
@@ -714,7 +714,7 @@ describe('CaretValueRuleExtractor', () => {
       const expectedRule = new ExportableCaretValueRule('hasMember');
       expectedRule.caretPath = 'mapping[1].id';
       expectedRule.value = 'inthewardrobe';
-      expectedRule.comment =
+      expectedRule.fshComment =
         'WARNING: The mapping index in the following rule (e.g., mapping[1]) may be incorrect.\n' +
         "Please compare with the mapping array in the original definition's snapshot and adjust as necessary.";
       // The other constraint properties (identity, map, etc) will create rules too, but they'd

--- a/test/extractor/fixtures/mapping-profile.json
+++ b/test/extractor/fixtures/mapping-profile.json
@@ -127,13 +127,7 @@
       },
       {
         "id": "Observation.status",
-        "path": "Observation.status",
-        "mapping": [
-          {
-            "identity": "RogueMapping",
-            "map": "Observation.notReal"
-          }
-        ]
+        "path": "Observation.status"
       },
       {
         "id": "Observation.note",


### PR DESCRIPTION
Although it's likely not valid, at least one IG (*ahem*, US Core) contains some elements with `mapping.identity` values that don't match a top-level mapping defined in the SD.  Rather than ignore them or create caret rules, create a top-level Mapping placeholder, log a warning, and write a comment.  That way the user can correct the obviously wrong mistake.  This also avoids some other issues we can run into when expressing all the mappings as caret rules.

If you'd like to test this w/ a real IG, try, oh I don't know, US Core 3.1.1?  On `master`, you'll notice that it creates a bunch of caret rules for mappings on `USCorePatient`.  You'll also notice if you round trip that in `USCorePatient`, the `mapping` array for `Patient.extension:birthsex` is messed up (actually due to another slightly incorrect thing about US Core -- but exacerbated by the mapping caret rules).

Or if you'd like to test is against a simple SD, you can try this one:
```
{
  "resourceType": "StructureDefinition",
  "id": "my-observation",
  "extension": [
    {
      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-category",
      "valueString": "Clinical.Diagnostics"
    },
    {
      "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-security-category",
      "valueCode": "patient"
    }
  ],
  "url": "http://sample.org/StructureDefinition/my-observation",
  "name": "MyObservation",
  "status": "active",
  "fhirVersion": "4.0.1",
  "mapping": [
    {
      "identity": "workflow",
      "uri": "http://hl7.org/fhir/workflow",
      "name": "Workflow Pattern"
    },
    {
      "identity": "sct-concept",
      "uri": "http://snomed.info/conceptdomain",
      "name": "SNOMED CT Concept Domain Binding"
    },
    {
      "identity": "v2",
      "uri": "http://hl7.org/v2",
      "name": "HL7 v2 Mapping"
    },
    {
      "identity": "rim",
      "uri": "http://hl7.org/v3",
      "name": "RIM Mapping"
    },
    {
      "identity": "w5",
      "uri": "http://hl7.org/fhir/fivews",
      "name": "FiveWs Pattern Mapping"
    },
    {
      "identity": "sct-attr",
      "uri": "http://snomed.org/attributebinding",
      "name": "SNOMED CT Attribute Binding"
    }
  ],
  "kind": "resource",
  "abstract": false,
  "type": "Observation",
  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Observation",
  "derivation": "constraint",
  "differential": {
    "element": [
      {
        "id": "Observation.category",
        "path": "Observation.category",
        "mapping": [
          {
            "identity": "SomeRogueMapping",
            "map": "SomeRogueThing"
          }
        ]
      },
      {
        "id": "Observation.focus",
        "path": "Observation.focus",
        "mapping": [
          {
            "identity": "SomeRogueMapping",
            "map": "SomeOtherRogueThing"
          }
        ]
      }
    ]
  }
}
```

On master, it will create some warnings about mapping indices and you'll see caret rules for mappings in the rules.  On this branch, you'll see a warning about creating a missing mapping, along with a comment telling the author to update it.