### PR TITLE
Support alternate id syntax for choices when looking for matching id in snapshot

### DIFF
--- a/test/extractor/fixtures/caret-value-profile.json
+++ b/test/extractor/fixtures/caret-value-profile.json
@@ -165,6 +165,18 @@
             "map" : "lamppost"
           }
         ]
+      },
+      {
+        "id": "Observation.component.valueQuantity",
+        "path": "Observation.component.valueQuantity",
+        "constraint": [
+          {
+            "id": "yesconstraintscanhaveids",
+            "key" : "foo-3",
+            "severity" : "error",
+            "human" : "It must choose to foo"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
It turns out that the code I wrote in #89 didn't take into account the fact that choices allow for an alternate `id` and `path` syntax in the differential.  For example, an element with id `Observation.valueQuantity` in the differential actually matches the element with id `Observation.value[x]:valueQuantity` in the snapshot.  Now we take that into account when looking for the matching snapshot element to fix constraint and mapping ids.

You can test this by running GoFSH on the attached StructureDefinition.  On master, you'll see two warnings because it couldn't find the snapshot element (even though it _is_ there) -- and the round-trip is dirty.  On this branch, the warnings go away (and round-trip is clean).

[StructureDefinition-my-profile.json.zip](https://github.com/FHIR/GoFSH/files/5956078/StructureDefinition-my-profile.json.zip)