### PR TITLE
Export id rule when instance name does not match instance id

### DIFF
--- a/src/optimizer/plugins/SimplifyInstanceNameOptimizer.ts
+++ b/src/optimizer/plugins/SimplifyInstanceNameOptimizer.ts
@@ -1,5 +1,6 @@
 import { OptimizerPlugin } from '../OptimizerPlugin';
 import { Package } from '../../processor';
+import { ExportableAssignmentRule } from '../../exportable';
 import ResolveInstanceOfURLsOptimizer from './ResolveInstanceOfURLsOptimizer';
 
 export default {
@@ -20,6 +21,13 @@ export default {
           // If the instance name isn't simplified, the InstanceOf information is present
           // If it does not end with the current InstanceOf, an alias was used, and we should use that
           instance.name = `${instance.id}-of-${instance.instanceOf}`;
+        }
+
+        if (instance.id != null && instance.id !== instance.name) {
+          // add a rule to set the id so it is not lost
+          const idRule = new ExportableAssignmentRule('id');
+          idRule.value = instance.id;
+          instance.rules.unshift(idRule);
         }
       });
   }


### PR DESCRIPTION
We need to keep instance names unique, but we also need to keep the original id so that references between instances are maintained.  This updates the `SimplifyInstanceNameOptimizer` to add an `id` rule if the `name` does not match the `id`.

You can witness this in action using US Core 3.1.1.  On master, the round-trip results in 47 different files and the IG Publisher reports 85 errors at the end of its run (many being inter-example references to other example ids that don't exist).  On this branch, the round-trip results in 39 different files and the IG Publisher reports 12 errors at the end of its run.

But I don't expect you to do that.  Instead you can just use the attached project.  Round-trip it on master and notice that examples have different filenames and the contents of the example differ by the id values.  Now round-trip it on this branch and notice that the round-trip is clean!  You can also see the additional `id` rules if you compare the generated FSH.

[Examples.zip](https://github.com/FHIR/GoFSH/files/5960786/Examples.zip)
