### PR TITLE
Fshify strings in ConceptRules

### DIFF
--- a/src/exportable/ExportableConceptRule.ts
+++ b/src/exportable/ExportableConceptRule.ts
@@ -1,4 +1,5 @@
 import { fshrules } from 'fsh-sushi';
+import { fshifyString } from './common';
 import { ExportableRule } from '.';
 
 export class ExportableConceptRule extends fshrules.ConceptRule implements ExportableRule {
@@ -9,13 +10,13 @@ export class ExportableConceptRule extends fshrules.ConceptRule implements Expor
   toFSH(): string {
     let line = `* #${this.code}`;
     if (this.display) {
-      line += ` "${this.display}"`;
+      line += ` "${fshifyString(this.display)}"`;
     }
     if (this.definition) {
       // If there is no display, a definition must be specified with triple quotes
       // so that it is correctly differentiated from a display by sushi
       const quotes = this.display ? '"' : '"""';
-      line += ` ${quotes}${this.definition}${quotes}`;
+      line += ` ${quotes}${fshifyString(this.definition)}${quotes}`;
     }
     return line;
   }

--- a/test/exportable/ExportableConceptRule.test.ts
+++ b/test/exportable/ExportableConceptRule.test.ts
@@ -36,4 +36,15 @@ describe('ExportableConceptRule', () => {
     const result = rule.toFSH();
     expect(result).toBe(expectedResult);
   });
+
+  it('should export a ConceptRule with display and definition that contain characters that are escaped in FSH', () => {
+    const rule = new ExportableConceptRule('foo');
+    rule.display = 'bar is "important" \\really\\';
+    rule.definition = 'baz is "pretend" \\but not really\\';
+
+    const expectedResult =
+      '* #foo "bar is \\"important\\" \\\\really\\\\" "baz is \\"pretend\\" \\\\but not really\\\\"';
+    const result = rule.toFSH();
+    expect(result).toBe(expectedResult);
+  });
 });


### PR DESCRIPTION
This PR fixes #95 by properly fshifying strings in Concept Rules. The issue has an example that shows quotes are not properly escaped on master. If you use that example on this branch, the quotes (and other FSH escaped characters) are properly escaped.