### PR TITLE
Remove whitespace from entity names

### DIFF
--- a/src/processor/CodeSystemProcessor.ts
+++ b/src/processor/CodeSystemProcessor.ts
@@ -3,6 +3,7 @@ import { flatten } from 'flat';
 import { utils, fhirtypes, fshtypes } from 'fsh-sushi';
 import { ExportableCodeSystem, ExportableConceptRule } from '../exportable';
 import { CaretValueRuleExtractor } from '../extractor';
+import { makeNameSushiSafe } from './common';
 
 const SUPPORTED_CONCEPT_PATHS = ['code', 'display', 'definition'];
 
@@ -47,6 +48,7 @@ export class CodeSystemProcessor {
       const codeSystem = new ExportableCodeSystem(name);
       CodeSystemProcessor.extractKeywords(input, codeSystem);
       CodeSystemProcessor.extractRules(input, codeSystem, fisher, config);
+      makeNameSushiSafe(codeSystem);
       return codeSystem;
     }
   }

--- a/src/processor/StructureDefinitionProcessor.ts
+++ b/src/processor/StructureDefinitionProcessor.ts
@@ -19,7 +19,7 @@ import {
   InvariantExtractor,
   MappingExtractor
 } from '../extractor';
-import { ProcessableElementDefinition, switchQuantityRules } from '.';
+import { ProcessableElementDefinition, switchQuantityRules, makeNameSushiSafe } from '.';
 import { getAncestorSliceDefinition } from '../utils';
 
 export class StructureDefinitionProcessor {
@@ -50,6 +50,7 @@ export class StructureDefinitionProcessor {
       );
       const mappings = StructureDefinitionProcessor.extractMappings(elements, input, fisher);
       StructureDefinitionProcessor.extractRules(input, elements, sd, fisher, config);
+      makeNameSushiSafe(sd);
       // TODO: Destructuring an array with invariants and mappings is required for TypeScript 3.0
       // With TypeScript 4.0, we should update to return the following line, which is more clear:
       // return [sd, ...invariants, ...mappings];

--- a/src/processor/ValueSetProcessor.ts
+++ b/src/processor/ValueSetProcessor.ts
@@ -7,6 +7,7 @@ import {
   ValueSetFilterComponentRuleExtractor,
   CaretValueRuleExtractor
 } from '../extractor';
+import { makeNameSushiSafe } from './common';
 
 const SUPPORTED_COMPONENT_PATHS = [
   'system',
@@ -69,6 +70,7 @@ export class ValueSetProcessor {
       const valueSet = new ExportableValueSet(name);
       ValueSetProcessor.extractKeywords(input, valueSet);
       ValueSetProcessor.extractRules(input, valueSet, fisher, config);
+      makeNameSushiSafe(valueSet);
       return valueSet;
     }
   }

--- a/test/processor/StructureDefinitionProcessor.test.ts
+++ b/test/processor/StructureDefinitionProcessor.test.ts
@@ -16,7 +16,7 @@ import {
   ExportableContainsRule,
   ExportableInvariant
 } from '../../src/exportable';
-import '../helpers/loggerSpy'; // suppresses console logging
+import { loggerSpy } from '../helpers/loggerSpy';
 import { loadTestDefinitions } from '../helpers/loadTestDefinitions';
 import { ContainsRuleExtractor } from '../../src/extractor';
 
@@ -35,6 +35,10 @@ describe('StructureDefinitionProcessor', () => {
       canonical: 'http://hl7.org/fhir/sushi-test',
       fhirVersion: ['4.0.1']
     };
+  });
+
+  beforeEach(() => {
+    loggerSpy.reset();
   });
 
   describe('#process', () => {
@@ -164,6 +168,26 @@ describe('StructureDefinitionProcessor', () => {
       const result = StructureDefinitionProcessor.process(input, defs, config);
 
       expect(result).toHaveLength(0);
+    });
+
+    it('should convert a Profile whose name includes whitespace', () => {
+      const input = JSON.parse(
+        fs.readFileSync(path.join(__dirname, 'fixtures', 'simple-profile.json'), 'utf-8')
+      );
+      input.name = 'Simple Profile';
+      const result = StructureDefinitionProcessor.process(input, defs, config);
+
+      const expectedNameRule = new ExportableCaretValueRule('');
+      expectedNameRule.caretPath = 'name';
+      expectedNameRule.value = 'Simple Profile';
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBeInstanceOf(ExportableProfile);
+      expect(result[0].name).toBe('Simple_Profile');
+      expect(result[0].rules).toContainEqual(expectedNameRule);
+      expect(loggerSpy.getLastMessage('warn')).toMatch(
+        'StructureDefinition with id simple.profile has name with whitespace. Converting whitespace to underscores.'
+      );
     });
   });
 


### PR DESCRIPTION
Fixes #94 and completes task [CIMPL-664](https://standardhealthrecord.atlassian.net/browse/CIMPL-664)

An entity name in FSH cannot contain whitespace. Substitute whitespace with underscore characters so that the generated FSH is syntactically correct. When this substitution occurs, add a caret value rule to preserve the original name. Warn the user about these events.