### PR TITLE
Refactor for FSHOnline

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,4 @@
 export * as gofshClient from './api';
+export * as gofshExport from './export';
+export * as processor from './processor';
+export * as utils from './utils';

--- a/src/optimizer/loadOptimizers.ts
+++ b/src/optimizer/loadOptimizers.ts
@@ -21,6 +21,7 @@ export async function loadOptimizers(
   }
 
   // Import optimizers from the specified folder
+  // relativePath is placed in a dynamic string to allow for FSHOnline compatibility
   const Optimizers: { property: OptimizerPlugin } = await import(`${relativePath}`);
 
   const optimizers = Object.values(Optimizers).filter(

--- a/src/optimizer/loadOptimizers.ts
+++ b/src/optimizer/loadOptimizers.ts
@@ -20,7 +20,9 @@ export async function loadOptimizers(
     relativePath = `./${relativePath}`;
   }
 
+  // Import optimizers from the specified folder
   const Optimizers: { property: OptimizerPlugin } = await import(relativePath);
+
   const optimizers = Object.values(Optimizers).filter(
     // Remove non-optimizers
     o =>
@@ -28,7 +30,7 @@ export async function loadOptimizers(
       typeof o?.description === 'string' &&
       typeof o?.optimize === 'function'
   );
-  logger.debug(`Loaded ${optimizers.length} optimizers`);
+  logger.debug(`Loaded ${optimizers.length} optimizers from ${path.join(__dirname, 'plugins')}`);
   // Sort them using a topological sort to get them in dependency order
   // See: https://www.npmjs.com/package/toposort#sorting-dependencies
   const nodes: string[] = [];

--- a/src/optimizer/loadOptimizers.ts
+++ b/src/optimizer/loadOptimizers.ts
@@ -21,7 +21,7 @@ export async function loadOptimizers(
   }
 
   // Import optimizers from the specified folder
-  const Optimizers: { property: OptimizerPlugin } = await import(relativePath);
+  const Optimizers: { property: OptimizerPlugin } = await import(`${relativePath}`);
 
   const optimizers = Object.values(Optimizers).filter(
     // Remove non-optimizers

--- a/src/optimizer/loadOptimizers.ts
+++ b/src/optimizer/loadOptimizers.ts
@@ -1,8 +1,5 @@
 import { OptimizerPlugin } from './OptimizerPlugin';
-
-import fs from 'fs-extra';
 import path from 'path';
-import { uniq } from 'lodash';
 import toposort from 'toposort';
 import { logger } from '../utils/GoFSHLogger';
 
@@ -23,30 +20,15 @@ export async function loadOptimizers(
     relativePath = `./${relativePath}`;
   }
 
-  // read the plugins folder, filter to only .ts/.js files, and map to unique module paths (without extensions)
-  const optimizerModules = uniq(
-    fs
-      .readdirSync(folder, { withFileTypes: true })
-      .filter(f => f.isFile() && /^[^.]+.*\.(t|j)s$/.test(f.name))
-      .map(f => `${relativePath}/${f.name.match(/^([^.]+)/)[1]}`)
-  );
-
-  const optimizers = (
-    await Promise.all(
-      // map to a set of promises that each resolve to the default export of the dynamically imported module
-      optimizerModules.map(async m => {
-        return (await import(m))?.default as OptimizerPlugin;
-      })
-    )
-  ).filter(
+  const Optimizers: { property: OptimizerPlugin } = await import(relativePath);
+  const optimizers = Object.values(Optimizers).filter(
     // Remove non-optimizers
     o =>
       typeof o?.name === 'string' &&
       typeof o?.description === 'string' &&
       typeof o?.optimize === 'function'
   );
-  logger.debug(`Loaded ${optimizers.length} optimizers from ${path.join(__dirname, 'plugins')}`);
-
+  logger.debug(`Loaded ${optimizers.length} optimizers`);
   // Sort them using a topological sort to get them in dependency order
   // See: https://www.npmjs.com/package/toposort#sorting-dependencies
   const nodes: string[] = [];

--- a/src/optimizer/plugins/index.ts
+++ b/src/optimizer/plugins/index.ts
@@ -1,0 +1,43 @@
+import CombineCardAndFlagRulesOptimizer from './CombineCardAndFlagRulesOptimizer';
+import CombineCodingAndQuantityValuesOptimizer from './CombineCodingAndQuantityValuesOptimizer';
+import CombineContainsRulesOptimizer from './CombineContainsRulesOptimizer';
+import ConstructInlineInstanceOptimizer from './ConstructInlineInstanceOptimizer';
+import ConstructNamedExtensionContainsRulesOptimizer from './ConstructNamedExtensionContainsRulesOptimizer';
+import RemoveChoiceSlicingRulesOptimizer from './RemoveChoiceSlicingRulesOptimizer';
+import RemoveDefaultExtensionContextRulesOptimizer from './RemoveDefaultExtensionContextRulesOptimizer';
+import RemoveExtensionSlicingRulesOptimizer from './RemoveExtensionSlicingRulesOptimizer';
+import RemoveExtensionURLAssignmentRules from './RemoveExtensionURLAssignmentRules';
+import RemoveGeneratedTextRulesOptimizer from './RemoveGeneratedTextRulesOptimizer';
+import RemoveImpliedZeroZeroCardRulesOptimize from './RemoveImpliedZeroZeroCardRulesOptimizer';
+import RemovePublisherDerivedDateRulesOptimizer from './RemovePublisherDerivedDateRulesOptimizer';
+import ResolveBindingRuleURLsOptimizer from './ResolveBindingRuleURLsOptimizer';
+import ResolveInstanceOfURLsOptimizer from './ResolveInstanceOfURLsOptimizer';
+import ResolveOnlyRuleURLsOptimizer from './ResolveOnlyRuleURLsOptimizer';
+import ResolveParentURLsOptimizer from './ResolveParentURLsOptimizer';
+import ResolveValueRuleURLsOptimizer from './ResolveValueRuleURLsOptimizer';
+import ResolveValueSetComponentRuleURLsOptimizer from './ResolveValueSetComponentRuleURLsOptimizer';
+import SimplifyInstanceNameOptimizer from './SimplifyInstanceNameOptimizer';
+import SimplifyMappingNamesOptimizer from './SimplifyMappingNamesOptimizer';
+
+export {
+  CombineCardAndFlagRulesOptimizer,
+  CombineCodingAndQuantityValuesOptimizer,
+  CombineContainsRulesOptimizer,
+  ConstructInlineInstanceOptimizer,
+  ConstructNamedExtensionContainsRulesOptimizer,
+  RemoveChoiceSlicingRulesOptimizer,
+  RemoveDefaultExtensionContextRulesOptimizer,
+  RemoveExtensionSlicingRulesOptimizer,
+  RemoveExtensionURLAssignmentRules,
+  RemoveGeneratedTextRulesOptimizer,
+  RemoveImpliedZeroZeroCardRulesOptimize,
+  RemovePublisherDerivedDateRulesOptimizer,
+  ResolveBindingRuleURLsOptimizer,
+  ResolveInstanceOfURLsOptimizer,
+  ResolveOnlyRuleURLsOptimizer,
+  ResolveParentURLsOptimizer,
+  ResolveValueRuleURLsOptimizer,
+  ResolveValueSetComponentRuleURLsOptimizer,
+  SimplifyInstanceNameOptimizer,
+  SimplifyMappingNamesOptimizer
+};

--- a/test/optimizer/fixtures/circular-optimizers/index.ts
+++ b/test/optimizer/fixtures/circular-optimizers/index.ts
@@ -1,0 +1,7 @@
+import AOptimizer from './AOptimizer';
+import BOptimizer from './BOptimizer';
+import COptimizer from './COptimizer';
+import DOptimizer from './DOptimizer';
+import EOptimizer from './EOptimizer';
+
+export { AOptimizer, BOptimizer, COptimizer, DOptimizer, EOptimizer };

--- a/test/optimizer/fixtures/custom-optimizers/index.ts
+++ b/test/optimizer/fixtures/custom-optimizers/index.ts
@@ -1,0 +1,7 @@
+import AOptimizer from './AOptimizer';
+import BOptimizer from './BOptimizer';
+import COptimizer from './COptimizer';
+import DOptimizer from './DOptimizer';
+import EOptimizer from './EOptimizer';
+
+export { AOptimizer, BOptimizer, COptimizer, DOptimizer, EOptimizer };

--- a/test/optimizer/fixtures/missing-dependency-optimizers/index.ts
+++ b/test/optimizer/fixtures/missing-dependency-optimizers/index.ts
@@ -1,0 +1,7 @@
+import AOptimizer from './AOptimizer';
+import BOptimizer from './BOptimizer';
+import COptimizer from './COptimizer';
+import DOptimizer from './DOptimizer';
+import EOptimizer from './EOptimizer';
+
+export { AOptimizer, BOptimizer, COptimizer, DOptimizer, EOptimizer };

--- a/test/optimizer/fixtures/with-non-optimizers/index.ts
+++ b/test/optimizer/fixtures/with-non-optimizers/index.ts
@@ -1,0 +1,6 @@
+import AOptimizer from './AOptimizer';
+import BOptimizer from './BOptimizer';
+import COptimizer from './COptimizer';
+import NotAnOptimizer from './NotAnOptimizer';
+
+export { AOptimizer, BOptimizer, COptimizer, NotAnOptimizer };


### PR DESCRIPTION
Addresses [CIMPL-673](https://standardhealthrecord.atlassian.net/secure/RapidBoard.jspa?rapidView=9&modal=detail&selectedIssue=CIMPL-673&assignee=5f7dc49c287870006a40b275), removing uses of the `fs` module in the `loadOptimizers` function and also adding requisite exports to `src/index.ts` for use in FSHOnline. @jafeltra will be testing this out as she implements GoFSH in the browser, but this can also be tested by just ensuring that the optimizers and GoFSH as a whole still work as expected. 