### PR TITLE
GoFSH API map option is now JSON.stringify-able

### DIFF
--- a/src/api/FhirToFsh.ts
+++ b/src/api/FhirToFsh.ts
@@ -93,14 +93,25 @@ export async function fhirToFsh(
 
 export type fshMap = {
   aliases: string;
-  invariants: Map<string, string>;
-  mappings: Map<string, string>;
-  profiles: Map<string, string>;
-  extensions: Map<string, string>;
-  codeSystems: Map<string, string>;
-  valueSets: Map<string, string>;
-  instances: Map<string, string>;
+  invariants: ResourceMap;
+  mappings: ResourceMap;
+  profiles: ResourceMap;
+  extensions: ResourceMap;
+  codeSystems: ResourceMap;
+  valueSets: ResourceMap;
+  instances: ResourceMap;
 };
+
+// An extended class with a custom toJSON method is needed, as JSON.stringify() cannot serialize regular Maps
+export class ResourceMap extends Map<string, string> {
+  toJSON(): Record<string, any> {
+    const returnObj: { [key: string]: string } = {};
+    this.forEach((value, key) => {
+      returnObj[key] = value;
+    });
+    return returnObj;
+  }
+}
 
 type fhirToFshOptions = {
   dependencies?: string[];

--- a/src/export/FSHExporter.ts
+++ b/src/export/FSHExporter.ts
@@ -15,7 +15,7 @@ import {
 } from '../exportable';
 import { Package } from '../processor';
 import { logger } from '../utils';
-import { fshMap, exportStyle } from '../api';
+import { fshMap, exportStyle, ResourceMap } from '../api';
 
 export class FSHExporter {
   constructor(public readonly fshPackage: Package) {}
@@ -87,13 +87,13 @@ export class FSHExporter {
     } else if (exportType === 'map') {
       const fshMap = {
         aliases: '',
-        invariants: new Map(),
-        mappings: new Map(),
-        profiles: new Map(),
-        extensions: new Map(),
-        codeSystems: new Map(),
-        valueSets: new Map(),
-        instances: new Map()
+        invariants: new ResourceMap(),
+        mappings: new ResourceMap(),
+        profiles: new ResourceMap(),
+        extensions: new ResourceMap(),
+        codeSystems: new ResourceMap(),
+        valueSets: new ResourceMap(),
+        instances: new ResourceMap()
       };
       fshMap.aliases = this.writeExportableGroup(this.fshPackage.aliases);
       for (const invariant of this.fshPackage.invariants) {

--- a/test/api/FhirToFsh.test.ts
+++ b/test/api/FhirToFsh.test.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import * as processing from '../../src/utils/Processing';
 import { fshtypes } from 'fsh-sushi';
 import { logger } from '../../src/utils';
-import { fhirToFsh } from '../../src/api';
+import { fhirToFsh, ResourceMap } from '../../src/api';
 import { loggerSpy } from '../helpers/loggerSpy';
 import { EOL } from 'os';
 describe('fhirToFsh', () => {
@@ -193,17 +193,17 @@ describe('fhirToFsh', () => {
     );
     expect(results.errors).toHaveLength(0);
     expect(results.warnings).toHaveLength(0);
-    const expectedProfileMap = new Map();
+    const expectedProfileMap = new ResourceMap();
     expectedProfileMap.set('Foo', ['Profile: Foo', 'Parent: Patient', 'Id: Foo'].join(EOL));
     expect(results.fsh).toEqual({
       profiles: expectedProfileMap,
       aliases: '',
-      invariants: new Map(),
-      mappings: new Map(),
-      extensions: new Map(),
-      codeSystems: new Map(),
-      valueSets: new Map(),
-      instances: new Map()
+      invariants: new ResourceMap(),
+      mappings: new ResourceMap(),
+      extensions: new ResourceMap(),
+      codeSystems: new ResourceMap(),
+      valueSets: new ResourceMap(),
+      instances: new ResourceMap()
     });
     expect(results.configuration).toEqual(defaultConfig);
   });

--- a/test/export/FSHExporter.test.ts
+++ b/test/export/FSHExporter.test.ts
@@ -662,8 +662,8 @@ describe('FSHExporter', () => {
         '{"aliases":"","invariants":{},"mappings":{},"profiles":{"TestProfile":"Profile: TestProfile\\nId: TestProfile"},"extensions":{},"codeSystems":{},"valueSets":{},"instances":{"TestInstance":"Instance: TestInstance\\nInstanceOf: TestProfile\\nUsage: #example"}}';
       const exportedMap = exporter.apiExport('map');
 
-      expect(JSON.stringify(exportedMap).replace(/(\r\n|\n|\r)/gm, '')).toEqual(
-        serializedString.replace(/(\r\n|\n|\r)/gm, '')
+      expect(JSON.stringify(exportedMap).replace(/(\\r\\n|\\n|\\r)/gm, '')).toEqual(
+        serializedString.replace(/(\\r\\n|\\n|\\r)/gm, '')
       );
     });
   });

--- a/test/export/FSHExporter.test.ts
+++ b/test/export/FSHExporter.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../../src/exportable';
 import { loggerSpy } from '../helpers/loggerSpy';
 import table from 'text-table';
+import { ResourceMap } from '../../src/api';
 
 describe('FSHExporter', () => {
   let exporter: FSHExporter;
@@ -621,34 +622,47 @@ describe('FSHExporter', () => {
 
       expect(exporter.apiExport('map')).toEqual({
         aliases: ['Alias: SomeAlias = http://test.com'].join(''),
-        invariants: new Map().set('SomeInvariant', ['Invariant: SomeInvariant'].join('')),
-        mappings: new Map().set(
+        invariants: new ResourceMap().set('SomeInvariant', ['Invariant: SomeInvariant'].join('')),
+        mappings: new ResourceMap().set(
           'SomeMapping',
           ['Mapping: SomeMapping', EOL, 'Id: SomeMapping'].join('')
         ),
-        profiles: new Map().set(
+        profiles: new ResourceMap().set(
           'SomeProfile',
           ['Profile: SomeProfile', EOL, 'Id: SomeProfile'].join('')
         ),
-        extensions: new Map().set(
+        extensions: new ResourceMap().set(
           'SomeExtension',
           ['Extension: SomeExtension', EOL, 'Id: SomeExtension'].join('')
         ),
-        codeSystems: new Map().set(
+        codeSystems: new ResourceMap().set(
           'SomeCodeSystem',
           ['CodeSystem: SomeCodeSystem', EOL, 'Id: SomeCodeSystem'].join('')
         ),
-        valueSets: new Map().set(
+        valueSets: new ResourceMap().set(
           'SomeValueSet',
           ['ValueSet: SomeValueSet', EOL, 'Id: SomeValueSet'].join('')
         ),
-        instances: new Map().set(
+        instances: new ResourceMap().set(
           'SomeInstance',
           ['Instance: SomeInstance', EOL, 'InstanceOf: SomeProfile', EOL, 'Usage: #example'].join(
             ''
           )
         )
       });
+    });
+
+    it('should export to a map than can be serialized by JSON.stringify()', () => {
+      myPackage.add(new ExportableProfile('TestProfile'));
+      const instance = new ExportableInstance('TestInstance');
+      instance.instanceOf = 'TestProfile';
+      myPackage.add(instance);
+
+      const serializedString =
+        '{"aliases":"","invariants":{},"mappings":{},"profiles":{"TestProfile":"Profile: TestProfile\\nId: TestProfile"},"extensions":{},"codeSystems":{},"valueSets":{},"instances":{"TestInstance":"Instance: TestInstance\\nInstanceOf: TestProfile\\nUsage: #example"}}';
+      const exportedMap = exporter.apiExport('map');
+
+      expect(JSON.stringify(exportedMap)).toEqual(serializedString);
     });
   });
 });

--- a/test/export/FSHExporter.test.ts
+++ b/test/export/FSHExporter.test.ts
@@ -662,8 +662,8 @@ describe('FSHExporter', () => {
         '{"aliases":"","invariants":{},"mappings":{},"profiles":{"TestProfile":"Profile: TestProfile\\nId: TestProfile"},"extensions":{},"codeSystems":{},"valueSets":{},"instances":{"TestInstance":"Instance: TestInstance\\nInstanceOf: TestProfile\\nUsage: #example"}}';
       const exportedMap = exporter.apiExport('map');
 
-      expect(JSON.stringify(exportedMap).replace(/[\n\r]+/g, '')).toEqual(
-        serializedString.replace(/[\n\r]+/g, '')
+      expect(JSON.stringify(exportedMap).replace(/(\r\n|\n|\r)/gm, '')).toEqual(
+        serializedString.replace(/(\r\n|\n|\r)/gm, '')
       );
     });
   });

--- a/test/export/FSHExporter.test.ts
+++ b/test/export/FSHExporter.test.ts
@@ -662,7 +662,9 @@ describe('FSHExporter', () => {
         '{"aliases":"","invariants":{},"mappings":{},"profiles":{"TestProfile":"Profile: TestProfile\\nId: TestProfile"},"extensions":{},"codeSystems":{},"valueSets":{},"instances":{"TestInstance":"Instance: TestInstance\\nInstanceOf: TestProfile\\nUsage: #example"}}';
       const exportedMap = exporter.apiExport('map');
 
-      expect(JSON.stringify(exportedMap)).toEqual(serializedString);
+      expect(JSON.stringify(exportedMap).replace(/[\n\r]+/g, '')).toEqual(
+        serializedString.replace(/[\n\r]+/g, '')
+      );
     });
   });
 });


### PR DESCRIPTION
Addresses [CIMPL-685](https://standardhealthrecord.atlassian.net/browse/CIMPL-685), making it so that the object returned by the `map` option of the GoFSH api can be serialized by the `JSON.stringify()` method. As it turns out, `JSON.stringify` is actually incapable of parsing maps, so this is done by creating a child class of the `Map` interface with a `toJSON` method that basically converts the Map to a regular object (credit to @cmoesel for coming up with the idea to this approach). A simple test case was added to verify that running `JSON.stringify()` does in fact convert each resource's map into a JSON object.