### PR TITLE
Add Optimizers to use Reference Keyword where appropriate

### DIFF
--- a/src/optimizer/plugins/AddReferenceKeywordOptimizer.ts
+++ b/src/optimizer/plugins/AddReferenceKeywordOptimizer.ts
@@ -1,0 +1,49 @@
+import { fhirtypes, fshtypes } from 'fsh-sushi';
+import { OptimizerPlugin } from '../OptimizerPlugin';
+import { Package } from '../../processor';
+import { ExportableAssignmentRule } from '../../exportable';
+import { MasterFisher } from '../../utils';
+import { splitOnPathPeriods } from 'fsh-sushi/dist/fhirtypes/common';
+import { pullAt } from 'lodash';
+
+export default {
+  name: 'add_reference_keyword_optimizer',
+  description: 'Adds the "Reference" keyword to instances where applicable',
+
+  optimize(pkg: Package, fisher: MasterFisher): void {
+    let sd: fhirtypes.StructureDefinition;
+    pkg.instances.forEach(instance => {
+      const rulesToRemove: number[] = [];
+
+      instance.rules
+        .filter(rule => rule instanceof ExportableAssignmentRule)
+        .forEach((rule: ExportableAssignmentRule, i: number) => {
+          // Since looking up the type takes some time, only do it when it is plausible
+          // that the type of the element is Reference
+          if (rule.path.endsWith('reference') && typeof rule.value === 'string') {
+            sd = sd ?? fisher.fishForStructureDefinition(instance.instanceOf);
+            // We search for the path of the parent, without numerical indices, since
+            // findElementByPath does not handle numerical indices
+            const parentPath = splitOnPathPeriods(rule.path).slice(0, -1).join('.');
+            const searchablePath = parentPath.replace(/\[\d+\]/g, '');
+            if (sd?.findElementByPath(searchablePath, fisher)?.type?.[0]?.code === 'Reference') {
+              const reference = new fshtypes.FshReference(rule.value);
+              // If we are converting the reference, look for a matching display rule, using the
+              // original numerical parent path
+              const matchingDisplayRuleIndex = instance.rules
+                .filter(rule => rule instanceof ExportableAssignmentRule)
+                .findIndex(otherRule => otherRule.path === `${parentPath}.display`);
+              if (matchingDisplayRuleIndex >= 0) {
+                rulesToRemove.push(matchingDisplayRuleIndex);
+                reference.display = (instance.rules[
+                  matchingDisplayRuleIndex
+                ] as ExportableAssignmentRule).value as string;
+              }
+              (instance.rules[i] as ExportableAssignmentRule).value = reference;
+            }
+          }
+        });
+      pullAt(instance.rules, rulesToRemove);
+    });
+  }
+} as OptimizerPlugin;

--- a/src/optimizer/plugins/AddReferenceKeywordOptimizer.ts
+++ b/src/optimizer/plugins/AddReferenceKeywordOptimizer.ts
@@ -11,9 +11,9 @@ export default {
   description: 'Adds the "Reference" keyword to instances where applicable',
 
   optimize(pkg: Package, fisher: MasterFisher): void {
-    let sd: fhirtypes.StructureDefinition;
     pkg.instances.forEach(instance => {
       const rulesToRemove: number[] = [];
+      let sd: fhirtypes.StructureDefinition;
 
       instance.rules
         .filter(rule => rule instanceof ExportableAssignmentRule)
@@ -39,7 +39,9 @@ export default {
                   matchingDisplayRuleIndex
                 ] as ExportableAssignmentRule).value as string;
               }
-              (instance.rules[i] as ExportableAssignmentRule).value = reference;
+              const newReferenceRule = new ExportableAssignmentRule(parentPath);
+              newReferenceRule.value = reference;
+              instance.rules[i] = newReferenceRule;
             }
           }
         });

--- a/src/optimizer/plugins/ResolveReferenceAssignmentsOptimizer.ts
+++ b/src/optimizer/plugins/ResolveReferenceAssignmentsOptimizer.ts
@@ -1,0 +1,38 @@
+import { fshtypes } from 'fsh-sushi';
+import { OptimizerPlugin } from '../OptimizerPlugin';
+import { Package } from '../../processor';
+import { ExportableAssignmentRule } from '../../exportable';
+import { MasterFisher } from '../../utils';
+import AddReferenceKeywordOptimizer from './AddReferenceKeywordOptimizer';
+
+export default {
+  name: 'resolve_reference_assignments_optimizer',
+  description: 'Resolves values in reference assignment rules if possible',
+  runAfter: [AddReferenceKeywordOptimizer.name],
+
+  optimize(pkg: Package, fisher: MasterFisher): void {
+    pkg.instances.forEach(instance => {
+      instance.rules
+        .filter(
+          rule =>
+            rule instanceof ExportableAssignmentRule && rule.value instanceof fshtypes.FshReference
+        )
+        .forEach((rule: ExportableAssignmentRule) => {
+          const reference = rule.value as fshtypes.FshReference;
+          const splitReference = reference.reference.split('/');
+          if (splitReference.length === 2) {
+            const [resourceType, name] = splitReference;
+            const matchingInstances = pkg.instances.filter(i => {
+              return (
+                i.name === name &&
+                fisher.fishForStructureDefinition(i.instanceOf)?.type === resourceType
+              );
+            });
+            if (matchingInstances.length === 1) {
+              reference.reference = name;
+            }
+          }
+        });
+    });
+  }
+} as OptimizerPlugin;

--- a/src/optimizer/plugins/index.ts
+++ b/src/optimizer/plugins/index.ts
@@ -15,6 +15,7 @@ import ResolveBindingRuleURLsOptimizer from './ResolveBindingRuleURLsOptimizer';
 import ResolveInstanceOfURLsOptimizer from './ResolveInstanceOfURLsOptimizer';
 import ResolveOnlyRuleURLsOptimizer from './ResolveOnlyRuleURLsOptimizer';
 import ResolveParentURLsOptimizer from './ResolveParentURLsOptimizer';
+import ResolveReferenceAssignmentsOptimizer from './ResolveReferenceAssignmentsOptimizer';
 import ResolveValueRuleURLsOptimizer from './ResolveValueRuleURLsOptimizer';
 import ResolveValueSetComponentRuleURLsOptimizer from './ResolveValueSetComponentRuleURLsOptimizer';
 import SimplifyInstanceNameOptimizer from './SimplifyInstanceNameOptimizer';
@@ -38,6 +39,7 @@ export {
   ResolveInstanceOfURLsOptimizer,
   ResolveOnlyRuleURLsOptimizer,
   ResolveParentURLsOptimizer,
+  ResolveReferenceAssignmentsOptimizer,
   ResolveValueRuleURLsOptimizer,
   ResolveValueSetComponentRuleURLsOptimizer,
   SimplifyInstanceNameOptimizer,

--- a/src/optimizer/plugins/index.ts
+++ b/src/optimizer/plugins/index.ts
@@ -1,3 +1,4 @@
+import AddReferenceKeywordOptimizer from './AddReferenceKeywordOptimizer';
 import CombineCardAndFlagRulesOptimizer from './CombineCardAndFlagRulesOptimizer';
 import CombineCodingAndQuantityValuesOptimizer from './CombineCodingAndQuantityValuesOptimizer';
 import CombineContainsRulesOptimizer from './CombineContainsRulesOptimizer';
@@ -20,6 +21,7 @@ import SimplifyInstanceNameOptimizer from './SimplifyInstanceNameOptimizer';
 import SimplifyMappingNamesOptimizer from './SimplifyMappingNamesOptimizer';
 
 export {
+  AddReferenceKeywordOptimizer,
   CombineCardAndFlagRulesOptimizer,
   CombineCodingAndQuantityValuesOptimizer,
   CombineContainsRulesOptimizer,

--- a/src/utils/MasterFisher.ts
+++ b/src/utils/MasterFisher.ts
@@ -21,7 +21,11 @@ export class MasterFisher implements utils.Fishable {
       utils.Type.Type
     );
     if (json) {
-      return fhirtypes.StructureDefinition.fromJSON(json);
+      // It is possible we can't parse the json, most likely if it doesn't have a snapshot
+      // if that is the case we don't want actual errors, just return nothing
+      try {
+        return fhirtypes.StructureDefinition.fromJSON(json);
+      } catch {}
     }
   }
 

--- a/src/utils/MasterFisher.ts
+++ b/src/utils/MasterFisher.ts
@@ -1,4 +1,4 @@
-import { utils, fhirdefs } from 'fsh-sushi';
+import { utils, fhirdefs, fhirtypes } from 'fsh-sushi';
 import { LakeOfFHIR } from '../processor';
 
 /**
@@ -11,6 +11,19 @@ export class MasterFisher implements utils.Fishable {
     public lakeOfFHIR = new LakeOfFHIR([]),
     public external = new fhirdefs.FHIRDefinitions()
   ) {}
+
+  fishForStructureDefinition(item: string) {
+    const json = this.fishForFHIR(
+      item,
+      utils.Type.Resource,
+      utils.Type.Profile,
+      utils.Type.Extension,
+      utils.Type.Type
+    );
+    if (json) {
+      return fhirtypes.StructureDefinition.fromJSON(json);
+    }
+  }
 
   fishForFHIR(item: string, ...types: utils.Type[]) {
     return this.lakeOfFHIR.fishForFHIR(item, ...types) ?? this.external.fishForFHIR(item, ...types);

--- a/test/optimizer/plugins/AddReferenceKeywordOptimizer.test.ts
+++ b/test/optimizer/plugins/AddReferenceKeywordOptimizer.test.ts
@@ -1,0 +1,124 @@
+import path from 'path';
+import { cloneDeep } from 'lodash';
+import '../../helpers/loggerSpy'; // side-effect: suppresses logs
+import { Package } from '../../../src/processor';
+import { ExportableAssignmentRule, ExportableInstance } from '../../../src/exportable';
+import optimizer from '../../../src/optimizer/plugins/AddReferenceKeywordOptimizer';
+import { loadTestDefinitions, stockLake } from '../../helpers';
+import { MasterFisher } from '../../../src/utils';
+import { fshtypes } from 'fsh-sushi';
+
+describe('optimizer', () => {
+  describe('#add_reference_keyword_optimizer', () => {
+    let fisher: MasterFisher;
+
+    beforeAll(() => {
+      const defs = loadTestDefinitions();
+      const lake = stockLake();
+      fisher = new MasterFisher(lake, defs);
+    });
+
+    it('should have appropriate metadata', () => {
+      expect(optimizer.name).toBe('add_reference_keyword_optimizer');
+      expect(optimizer.description).toBeDefined();
+      expect(optimizer.runBefore).toBeUndefined();
+      expect(optimizer.runAfter).toBeUndefined();
+    });
+
+    it('add the Reference keyword on a reference rule', () => {
+      const instance = new ExportableInstance('Foo');
+      instance.instanceOf = 'Patient';
+      const referenceRule = new ExportableAssignmentRule('generalPractitioner.reference');
+      referenceRule.value = 'Practitioner/Bar';
+      instance.rules = [referenceRule];
+      const myPackage = new Package();
+      myPackage.add(instance);
+      optimizer.optimize(myPackage, fisher);
+
+      const expectedRule = cloneDeep(referenceRule);
+      expectedRule.value = new fshtypes.FshReference('Practitioner/Bar');
+      expect(instance.rules).toEqual([expectedRule]);
+    });
+
+    it('add the Reference keyword on a reference rule and find a corresponding display', () => {
+      const instance = new ExportableInstance('Foo');
+      instance.instanceOf = 'Patient';
+      const referenceRule = new ExportableAssignmentRule('generalPractitioner.reference');
+      referenceRule.value = 'Practitioner/Bar';
+      const displayRule = new ExportableAssignmentRule('generalPractitioner.display');
+      displayRule.value = 'Display value';
+      instance.rules = [referenceRule, displayRule];
+      const myPackage = new Package();
+      myPackage.add(instance);
+      optimizer.optimize(myPackage, fisher);
+
+      const expectedRule = cloneDeep(referenceRule);
+      expectedRule.value = new fshtypes.FshReference('Practitioner/Bar');
+      expectedRule.value.display = 'Display value';
+      // Note the display rule is removed
+      expect(instance.rules).toEqual([expectedRule]);
+    });
+
+    it('add the Reference keyword on multiple reference rules and find the corresponding displays', () => {
+      const instance = new ExportableInstance('Foo');
+
+      instance.instanceOf = 'Patient';
+      const referenceRule1 = new ExportableAssignmentRule('generalPractitioner[0].reference');
+      referenceRule1.value = 'Practitioner/Bar1';
+      const displayRule1 = new ExportableAssignmentRule('generalPractitioner[0].display');
+      displayRule1.value = 'Display value 1';
+
+      const referenceRule2 = new ExportableAssignmentRule('generalPractitioner[1].reference');
+      referenceRule2.value = 'Practitioner/Bar2';
+      const displayRule2 = new ExportableAssignmentRule('generalPractitioner[1].display');
+      displayRule2.value = 'Display value 2';
+
+      // Throw another rule in there to make sure the right rules are being removed
+      const nameRule = new ExportableAssignmentRule('name.family');
+      nameRule.value = 'FooPerson';
+
+      instance.rules = [referenceRule1, displayRule1, nameRule, displayRule2, referenceRule2];
+      const myPackage = new Package();
+      myPackage.add(instance);
+      optimizer.optimize(myPackage, fisher);
+
+      const expectedRule1 = cloneDeep(referenceRule1);
+      expectedRule1.value = new fshtypes.FshReference('Practitioner/Bar1');
+      expectedRule1.value.display = 'Display value 1';
+
+      const expectedRule2 = cloneDeep(referenceRule2);
+      expectedRule2.value = new fshtypes.FshReference('Practitioner/Bar2');
+      expectedRule2.value.display = 'Display value 2';
+
+      expect(instance.rules).toEqual([expectedRule1, nameRule, expectedRule2]);
+    });
+
+    it('not add the Reference keyword on a reference rule when the instanceOf type cannot be found', () => {
+      const instance = new ExportableInstance('Foo');
+      instance.instanceOf = 'http://example.org/StructureDefinition/my-patient-profile';
+      const referenceRule = new ExportableAssignmentRule('generalPractitioner.reference');
+      referenceRule.value = 'Practitioner/Bar';
+      instance.rules = [referenceRule];
+      const myPackage = new Package();
+      myPackage.add(instance);
+      optimizer.optimize(myPackage, fisher);
+
+      // Rule is unchanged
+      expect(instance.rules).toEqual([referenceRule]);
+    });
+
+    it('not add the Reference keyword on a reference rule when the type cannot be verified', () => {
+      const instance = new ExportableInstance('Foo');
+      instance.instanceOf = 'Patient';
+      const referenceRule = new ExportableAssignmentRule('nonsense.reference');
+      referenceRule.value = 'Practitioner/Bar';
+      instance.rules = [referenceRule];
+      const myPackage = new Package();
+      myPackage.add(instance);
+      optimizer.optimize(myPackage, fisher);
+
+      // Rule is unchanged
+      expect(instance.rules).toEqual([referenceRule]);
+    });
+  });
+});

--- a/test/optimizer/plugins/AddReferenceKeywordOptimizer.test.ts
+++ b/test/optimizer/plugins/AddReferenceKeywordOptimizer.test.ts
@@ -1,5 +1,3 @@
-import path from 'path';
-import { cloneDeep } from 'lodash';
 import '../../helpers/loggerSpy'; // side-effect: suppresses logs
 import { Package } from '../../../src/processor';
 import { ExportableAssignmentRule, ExportableInstance } from '../../../src/exportable';
@@ -25,7 +23,7 @@ describe('optimizer', () => {
       expect(optimizer.runAfter).toBeUndefined();
     });
 
-    it('add the Reference keyword on a reference rule', () => {
+    it('should add the Reference keyword on a reference rule', () => {
       const instance = new ExportableInstance('Foo');
       instance.instanceOf = 'Patient';
       const referenceRule = new ExportableAssignmentRule('generalPractitioner.reference');
@@ -35,12 +33,12 @@ describe('optimizer', () => {
       myPackage.add(instance);
       optimizer.optimize(myPackage, fisher);
 
-      const expectedRule = cloneDeep(referenceRule);
+      const expectedRule = new ExportableAssignmentRule('generalPractitioner');
       expectedRule.value = new fshtypes.FshReference('Practitioner/Bar');
       expect(instance.rules).toEqual([expectedRule]);
     });
 
-    it('add the Reference keyword on a reference rule and find a corresponding display', () => {
+    it('should add the Reference keyword on a reference rule and find a corresponding display', () => {
       const instance = new ExportableInstance('Foo');
       instance.instanceOf = 'Patient';
       const referenceRule = new ExportableAssignmentRule('generalPractitioner.reference');
@@ -52,14 +50,14 @@ describe('optimizer', () => {
       myPackage.add(instance);
       optimizer.optimize(myPackage, fisher);
 
-      const expectedRule = cloneDeep(referenceRule);
+      const expectedRule = new ExportableAssignmentRule('generalPractitioner');
       expectedRule.value = new fshtypes.FshReference('Practitioner/Bar');
       expectedRule.value.display = 'Display value';
       // Note the display rule is removed
       expect(instance.rules).toEqual([expectedRule]);
     });
 
-    it('add the Reference keyword on multiple reference rules and find the corresponding displays', () => {
+    it('should add the Reference keyword on multiple reference rules and find the corresponding displays', () => {
       const instance = new ExportableInstance('Foo');
 
       instance.instanceOf = 'Patient';
@@ -82,18 +80,18 @@ describe('optimizer', () => {
       myPackage.add(instance);
       optimizer.optimize(myPackage, fisher);
 
-      const expectedRule1 = cloneDeep(referenceRule1);
+      const expectedRule1 = new ExportableAssignmentRule('generalPractitioner[0]');
       expectedRule1.value = new fshtypes.FshReference('Practitioner/Bar1');
       expectedRule1.value.display = 'Display value 1';
 
-      const expectedRule2 = cloneDeep(referenceRule2);
+      const expectedRule2 = new ExportableAssignmentRule('generalPractitioner[1]');
       expectedRule2.value = new fshtypes.FshReference('Practitioner/Bar2');
       expectedRule2.value.display = 'Display value 2';
 
       expect(instance.rules).toEqual([expectedRule1, nameRule, expectedRule2]);
     });
 
-    it('not add the Reference keyword on a reference rule when the instanceOf type cannot be found', () => {
+    it('should not add the Reference keyword on a reference rule when the instanceOf type cannot be found', () => {
       const instance = new ExportableInstance('Foo');
       instance.instanceOf = 'http://example.org/StructureDefinition/my-patient-profile';
       const referenceRule = new ExportableAssignmentRule('generalPractitioner.reference');
@@ -107,7 +105,7 @@ describe('optimizer', () => {
       expect(instance.rules).toEqual([referenceRule]);
     });
 
-    it('not add the Reference keyword on a reference rule when the type cannot be verified', () => {
+    it('should not add the Reference keyword on a reference rule when the type cannot be verified', () => {
       const instance = new ExportableInstance('Foo');
       instance.instanceOf = 'Patient';
       const referenceRule = new ExportableAssignmentRule('nonsense.reference');

--- a/test/optimizer/plugins/ResolveReferenceAssignmentsOptimizer.test.ts
+++ b/test/optimizer/plugins/ResolveReferenceAssignmentsOptimizer.test.ts
@@ -1,0 +1,113 @@
+import '../../helpers/loggerSpy'; // side-effect: suppresses logs
+import { Package } from '../../../src/processor';
+import { ExportableAssignmentRule, ExportableInstance } from '../../../src/exportable';
+import optimizer from '../../../src/optimizer/plugins/ResolveReferenceAssignmentsOptimizer';
+import { AddReferenceKeywordOptimizer } from '../../../src/optimizer/plugins';
+import { loadTestDefinitions, stockLake } from '../../helpers';
+import { MasterFisher } from '../../../src/utils';
+import { fshtypes } from 'fsh-sushi';
+
+describe('optimizer', () => {
+  describe('#resolve_reference_assignments_optimizer', () => {
+    let fisher: MasterFisher;
+
+    beforeAll(() => {
+      const defs = loadTestDefinitions();
+      const lake = stockLake();
+      fisher = new MasterFisher(lake, defs);
+    });
+
+    it('should have appropriate metadata', () => {
+      expect(optimizer.name).toBe('resolve_reference_assignments_optimizer');
+      expect(optimizer.description).toBeDefined();
+      expect(optimizer.runBefore).toBeUndefined();
+      expect(optimizer.runAfter).toEqual([AddReferenceKeywordOptimizer.name]);
+    });
+
+    it('should resolve a reference to another instance', () => {
+      const instance = new ExportableInstance('Foo');
+      instance.instanceOf = 'Observation';
+      const referenceRule = new ExportableAssignmentRule('subject');
+      referenceRule.value = new fshtypes.FshReference('Patient/Bar');
+      instance.rules = [referenceRule];
+
+      const referencedInstance = new ExportableInstance('Bar');
+      referencedInstance.instanceOf = 'Patient';
+      const myPackage = new Package();
+      myPackage.add(instance);
+      myPackage.add(referencedInstance);
+      optimizer.optimize(myPackage, fisher);
+
+      const expectedRule = new ExportableAssignmentRule('subject');
+      expectedRule.value = new fshtypes.FshReference('Bar');
+      expect(instance.rules).toEqual([expectedRule]);
+    });
+
+    it('should not resolve a reference that is not of the form <resourceType>/<id>', () => {
+      const instance = new ExportableInstance('Foo');
+      instance.instanceOf = 'Observation';
+      const referenceRule = new ExportableAssignmentRule('subject');
+      referenceRule.value = new fshtypes.FshReference('Patient/1/Bar');
+      instance.rules = [referenceRule];
+
+      const referencedInstance = new ExportableInstance('Bar');
+      referencedInstance.instanceOf = 'Patient';
+      const myPackage = new Package();
+      myPackage.add(instance);
+      myPackage.add(referencedInstance);
+      optimizer.optimize(myPackage, fisher);
+
+      expect(instance.rules).toEqual([referenceRule]);
+    });
+
+    it('should not resolve a reference to an instance which is not in the package', () => {
+      const instance = new ExportableInstance('Foo');
+      instance.instanceOf = 'Observation';
+      const referenceRule = new ExportableAssignmentRule('subject');
+      referenceRule.value = new fshtypes.FshReference('Patient/Bar');
+      instance.rules = [referenceRule];
+
+      const myPackage = new Package();
+      myPackage.add(instance);
+      optimizer.optimize(myPackage, fisher);
+
+      expect(instance.rules).toEqual([referenceRule]);
+    });
+
+    it('should not resolve a reference to an instance for which the resourceType cannot be verified', () => {
+      const instance = new ExportableInstance('Foo');
+      instance.instanceOf = 'Observation';
+      const referenceRule = new ExportableAssignmentRule('subject');
+      referenceRule.value = new fshtypes.FshReference('Nonsense/Bar');
+      instance.rules = [referenceRule];
+
+      const referencedInstance = new ExportableInstance('Bar');
+      referencedInstance.instanceOf = 'Nonsense';
+      const myPackage = new Package();
+      myPackage.add(instance);
+      myPackage.add(referencedInstance);
+      optimizer.optimize(myPackage, fisher);
+
+      // Even though the resourceType matches the instanceOf, we cannot find the definition of the instanceOf
+      // so we don't replace the reference
+      expect(instance.rules).toEqual([referenceRule]);
+    });
+
+    it('should not resolve a reference to an instance which only matches on resourceType', () => {
+      const instance = new ExportableInstance('Foo');
+      instance.instanceOf = 'Observation';
+      const referenceRule = new ExportableAssignmentRule('subject');
+      referenceRule.value = new fshtypes.FshReference('Patient/Bar');
+      instance.rules = [referenceRule];
+
+      const referencedInstance = new ExportableInstance('Not-Bar');
+      referencedInstance.instanceOf = 'Patient';
+      const myPackage = new Package();
+      myPackage.add(instance);
+      myPackage.add(referencedInstance);
+      optimizer.optimize(myPackage, fisher);
+
+      expect(instance.rules).toEqual([referenceRule]);
+    });
+  });
+});


### PR DESCRIPTION
This adds a couple of optimizers which work together to support cleaner generation of FSH using the `Reference` keyword. Specifically these optimizers operate on Assignment Rules on Instances. The optimizers are:
* AddReferenceKeywordOptimizer - This optimizer replaces rules like this:
```
* <reference-type>.reference = "Foo"
* <reference-type>.display = "Some display"
```
with rules like:
```
* <reference-type> = Reference(Foo) "Some Display"
```
There are limits to when we can apply this rule. Resources in FHIR use the word `reference` on things that are not of type `reference` (I detected at least one example of this issue on [this resource](https://www.hl7.org/fhir/detectedissue.html)). So we only do this optimization if we can confirm that the parent of the `.reference` element is of type Reference, and we do this by looking up the InstanceOf SD for the Instance in question. 
* ResolveReferenceAssignmentsOptimizer - This optimizer has to run after the first (as it is defined to do) and it goes through rules that have a `FSHReference` value and replaces something like `Reference(Patient/Foo)` with `Reference(Foo)`. This optimization only happens if `Foo` is the name of another Instance and that Instance has an InstanceOf which resolves to an SD which has type Patient.

Click [here](https://gist.github.com/ngfreiter/8c174ac359ea2311c9158e2579172e78) for a link to a gist that contains some FSH you could use to test this if you want. If you test using that FSH, I would recommend first running SUSHI on that FSH (ensuring US Core is a dependency), then deleting the MyPatient StructureDefinition, and then running GoFSH on the `fsh-generated/resources` folder generated by SUSHI. The resulting round-trip FSH should conform to what you would expect in each case.