### PR TITLE
Optimize Quantity values based on new FSH STU2 syntax

### DIFF
--- a/src/extractor/AssignmentRuleExtractor.ts
+++ b/src/extractor/AssignmentRuleExtractor.ts
@@ -151,18 +151,8 @@ export class AssignmentRuleExtractor {
         matchingValue.system,
         matchingValue.unit
       );
-      // if system is http://unitsofmeasure.org, we can build a FshQuantity.
-      // otherwise, multiple assignments will be necessary.
-      if (matchingValue.system === 'http://unitsofmeasure.org') {
-        assignmentRule.value = new fshtypes.FshQuantity(matchingValue.value, unit);
-        return [assignmentRule];
-      } else {
-        assignmentRule.value = unit;
-        const valueRule = new ExportableAssignmentRule(`${assignmentRule.path}.value`);
-        valueRule.value = matchingValue.value;
-        valueRule.exactly = assignmentRule.exactly;
-        return [assignmentRule, valueRule];
-      }
+      assignmentRule.value = new fshtypes.FshQuantity(matchingValue.value, unit);
+      return [assignmentRule];
     } else {
       // we have something on patternQuantity that isn't expressible as a FshQuantity.
       // that's okay! we can still do good things here with whatever we have.

--- a/src/optimizer/plugins/CombineCodingAndQuantityValuesOptimizer.ts
+++ b/src/optimizer/plugins/CombineCodingAndQuantityValuesOptimizer.ts
@@ -41,6 +41,8 @@ export default {
   optimize(pkg: Package, fisher: MasterFisher): void {
     // Coding has: code, system, display
     // Quantity has: code, system, unit, value
+    // If "value" is present, the rule should use a FshQuantity.
+    // Otherwise, the rule should keep its FshCode.
     // Profiles and Extensions may have relevant caret rules
     // Instances may have relevant assignment rules
     // It is not necessary to check assignment rules on Profiles and Extensions. Codings and Quantities that
@@ -78,31 +80,30 @@ export default {
             const displaySibling = siblings.find(sibling => sibling.caretPath.endsWith('.display'));
             const unitSibling = siblings.find(sibling => sibling.caretPath.endsWith('.unit'));
             const valueSibling = siblings.find(sibling => sibling.caretPath.endsWith('.value'));
-            if (valueSibling && systemSibling?.value === 'http://unitsofmeasure.org') {
-              rule.caretPath = basePath;
+            rule.caretPath = basePath;
+            if (valueSibling) {
               rule.value = new FshQuantity(
                 valueSibling.value as number,
-                new FshCode(rule.value.code, 'http://unitsofmeasure.org')
+                new FshCode(rule.value.code)
               );
-              rulesToRemove.push(rules.indexOf(valueSibling), rules.indexOf(systemSibling));
-            } else if (unitSibling) {
-              rule.caretPath = basePath;
-              rule.value.display = unitSibling.value.toString();
-              rulesToRemove.push(rules.indexOf(unitSibling));
-              // system may also be present
+              rulesToRemove.push(rules.indexOf(valueSibling));
+              if (systemSibling) {
+                rule.value.unit.system = systemSibling.value.toString();
+                rulesToRemove.push(rules.indexOf(systemSibling));
+              }
+              if (unitSibling) {
+                rule.value.unit.display = unitSibling.value.toString();
+                rulesToRemove.push(rules.indexOf(unitSibling));
+              }
+            } else {
               if (systemSibling) {
                 rule.value.system = systemSibling.value.toString();
                 rulesToRemove.push(rules.indexOf(systemSibling));
               }
-            } else if (systemSibling || displaySibling) {
-              rule.caretPath = basePath;
-              if (systemSibling) {
-                rule.value.system = systemSibling.value.toString();
-                rulesToRemove.push(rules.indexOf(systemSibling));
-              }
-              if (displaySibling) {
-                rule.value.display = displaySibling.value.toString();
-                rulesToRemove.push(rules.indexOf(displaySibling));
+              if (displaySibling || unitSibling) {
+                const displaySource = displaySibling || unitSibling;
+                rule.value.display = displaySource.value.toString();
+                rulesToRemove.push(rules.indexOf(displaySource));
               }
               moveUpCaretValueRule(rule, def, siblings);
             }
@@ -145,34 +146,30 @@ export default {
             const displaySibling = siblings.find(sibling => sibling.path.endsWith('.display'));
             const unitSibling = siblings.find(sibling => sibling.path.endsWith('.unit'));
             const valueSibling = siblings.find(sibling => sibling.path.endsWith('.value'));
-            if (valueSibling && systemSibling?.value === 'http://unitsofmeasure.org') {
-              rule.path = basePath;
+            rule.path = basePath;
+            if (valueSibling) {
               rule.value = new FshQuantity(
                 valueSibling.value as number,
-                new FshCode(rule.value.code, 'http://unitsofmeasure.org')
+                new FshCode(rule.value.code)
               );
-              rulesToRemove.push(
-                instance.rules.indexOf(valueSibling),
-                instance.rules.indexOf(systemSibling)
-              );
-            } else if (unitSibling) {
-              rule.path = basePath;
-              rule.value.display = unitSibling.value.toString();
-              rulesToRemove.push(instance.rules.indexOf(unitSibling));
-              // system may also be present
+              rulesToRemove.push(instance.rules.indexOf(valueSibling));
+              if (systemSibling) {
+                rule.value.unit.system = systemSibling.value.toString();
+                rulesToRemove.push(instance.rules.indexOf(systemSibling));
+              }
+              if (unitSibling) {
+                rule.value.unit.display = unitSibling.value.toString();
+                rulesToRemove.push(instance.rules.indexOf(unitSibling));
+              }
+            } else {
               if (systemSibling) {
                 rule.value.system = systemSibling.value.toString();
                 rulesToRemove.push(instance.rules.indexOf(systemSibling));
               }
-            } else if (systemSibling || displaySibling) {
-              rule.path = basePath;
-              if (systemSibling) {
-                rule.value.system = systemSibling.value.toString();
-                rulesToRemove.push(instance.rules.indexOf(systemSibling));
-              }
-              if (displaySibling) {
-                rule.value.display = displaySibling.value.toString();
-                rulesToRemove.push(instance.rules.indexOf(displaySibling));
+              if (displaySibling || unitSibling) {
+                const displaySource = displaySibling || unitSibling;
+                rule.value.display = displaySource.value.toString();
+                rulesToRemove.push(instance.rules.indexOf(displaySource));
               }
               moveUpAssignmentRule(rule, instance, siblings);
             }

--- a/src/processor/InstanceProcessor.ts
+++ b/src/processor/InstanceProcessor.ts
@@ -86,7 +86,7 @@ export class InstanceProcessor {
       newRules.push(assignmentRule);
     });
     target.rules = compact(newRules);
-    switchQuantityRules(target.rules); // TODO: Once STU 2 features are enabled this can be removed
+    switchQuantityRules(target.rules);
   }
 
   static process(input: any, implementationGuide: any, fisher: utils.Fishable): ExportableInstance {

--- a/test/extractor/AssignmentRuleExtractor.test.ts
+++ b/test/extractor/AssignmentRuleExtractor.test.ts
@@ -179,17 +179,13 @@ describe('AssignmentRuleExtractor', () => {
       element.patternQuantity.system = 'http://other-units.org';
       element.patternQuantity.unit = 'Gigawatts';
       const assignmentRules = AssignmentRuleExtractor.process(element);
-      const expectedQuantityRule = new ExportableAssignmentRule('valueQuantity');
-      expectedQuantityRule.value = new fshtypes.FshCode(
-        'GW',
-        'http://other-units.org',
-        'Gigawatts'
+      const expectedRule = new ExportableAssignmentRule('valueQuantity');
+      expectedRule.value = new fshtypes.FshQuantity(
+        1.21,
+        new fshtypes.FshCode('GW', 'http://other-units.org', 'Gigawatts')
       );
-      const expectedValueRule = new ExportableAssignmentRule('valueQuantity.value');
-      expectedValueRule.value = 1.21;
-      expect(assignmentRules).toHaveLength(2);
-      expect(assignmentRules[0]).toEqual<ExportableAssignmentRule>(expectedQuantityRule);
-      expect(assignmentRules[1]).toEqual<ExportableAssignmentRule>(expectedValueRule);
+      expect(assignmentRules).toHaveLength(1);
+      expect(assignmentRules[0]).toEqual<ExportableAssignmentRule>(expectedRule);
       expect(element.processedPaths).toHaveLength(4);
       expect(element.processedPaths).toContain('patternQuantity.value');
       expect(element.processedPaths).toContain('patternQuantity.code');
@@ -223,23 +219,16 @@ describe('AssignmentRuleExtractor', () => {
       element.patternRatio.numerator.system = 'http://other-units.org';
       element.patternRatio.numerator.unit = 'centimeters';
       const assignmentRules = AssignmentRuleExtractor.process(element);
-      const expectedNumeratorQuantity = new ExportableAssignmentRule('valueRatio.numerator');
-      expectedNumeratorQuantity.value = new fshtypes.FshCode(
-        'cm',
-        'http://other-units.org',
-        'centimeters'
+      const expectedRule = new ExportableAssignmentRule('valueRatio');
+      expectedRule.value = new fshtypes.FshRatio(
+        new fshtypes.FshQuantity(
+          5,
+          new fshtypes.FshCode('cm', 'http://other-units.org', 'centimeters')
+        ),
+        new fshtypes.FshQuantity(1, new fshtypes.FshCode('s', 'http://unitsofmeasure.org'))
       );
-      const expectedNumeratorValue = new ExportableAssignmentRule('valueRatio.numerator.value');
-      expectedNumeratorValue.value = 5;
-      const expectedDenominatorRule = new ExportableAssignmentRule('valueRatio.denominator');
-      expectedDenominatorRule.value = new fshtypes.FshQuantity(
-        1,
-        new fshtypes.FshCode('s', 'http://unitsofmeasure.org')
-      );
-      expect(assignmentRules).toHaveLength(3);
-      expect(assignmentRules[0]).toEqual<ExportableAssignmentRule>(expectedNumeratorQuantity);
-      expect(assignmentRules[1]).toEqual<ExportableAssignmentRule>(expectedNumeratorValue);
-      expect(assignmentRules[2]).toEqual<ExportableAssignmentRule>(expectedDenominatorRule);
+      expect(assignmentRules).toHaveLength(1);
+      expect(assignmentRules[0]).toEqual<ExportableAssignmentRule>(expectedRule);
       expect(element.processedPaths).toHaveLength(8);
       expect(element.processedPaths).toContain('patternRatio.numerator.value');
       expect(element.processedPaths).toContain('patternRatio.numerator.code');
@@ -256,23 +245,13 @@ describe('AssignmentRuleExtractor', () => {
       element.patternRatio.denominator.system = 'http://other-units.org';
       element.patternRatio.denominator.unit = 'seconds';
       const assignmentRules = AssignmentRuleExtractor.process(element);
-      const expectedNumeratorRule = new ExportableAssignmentRule('valueRatio.numerator');
-      expectedNumeratorRule.value = new fshtypes.FshQuantity(
-        5,
-        new fshtypes.FshCode('cm', 'http://unitsofmeasure.org')
+      const expectedRule = new ExportableAssignmentRule('valueRatio');
+      expectedRule.value = new fshtypes.FshRatio(
+        new fshtypes.FshQuantity(5, new fshtypes.FshCode('cm', 'http://unitsofmeasure.org')),
+        new fshtypes.FshQuantity(1, new fshtypes.FshCode('s', 'http://other-units.org', 'seconds'))
       );
-      const expectedDenominatorQuantity = new ExportableAssignmentRule('valueRatio.denominator');
-      expectedDenominatorQuantity.value = new fshtypes.FshCode(
-        's',
-        'http://other-units.org',
-        'seconds'
-      );
-      const expectedDenominatorValue = new ExportableAssignmentRule('valueRatio.denominator.value');
-      expectedDenominatorValue.value = 1;
-      expect(assignmentRules).toHaveLength(3);
-      expect(assignmentRules[0]).toEqual<ExportableAssignmentRule>(expectedNumeratorRule);
-      expect(assignmentRules[1]).toEqual<ExportableAssignmentRule>(expectedDenominatorQuantity);
-      expect(assignmentRules[2]).toEqual<ExportableAssignmentRule>(expectedDenominatorValue);
+      expect(assignmentRules).toHaveLength(1);
+      expect(assignmentRules[0]).toEqual<ExportableAssignmentRule>(expectedRule);
       expect(element.processedPaths).toHaveLength(8);
       expect(element.processedPaths).toContain('patternRatio.numerator.value');
       expect(element.processedPaths).toContain('patternRatio.numerator.code');
@@ -291,27 +270,16 @@ describe('AssignmentRuleExtractor', () => {
       element.patternRatio.denominator.system = 'http://other-units.org';
       element.patternRatio.denominator.unit = 'seconds';
       const assignmentRules = AssignmentRuleExtractor.process(element);
-      const expectedNumeratorQuantity = new ExportableAssignmentRule('valueRatio.numerator');
-      expectedNumeratorQuantity.value = new fshtypes.FshCode(
-        'cm',
-        'http://other-units.org',
-        'centimeters'
+      const expectedRule = new ExportableAssignmentRule('valueRatio');
+      expectedRule.value = new fshtypes.FshRatio(
+        new fshtypes.FshQuantity(
+          5,
+          new fshtypes.FshCode('cm', 'http://other-units.org', 'centimeters')
+        ),
+        new fshtypes.FshQuantity(1, new fshtypes.FshCode('s', 'http://other-units.org', 'seconds'))
       );
-      const expectedNumeratorValue = new ExportableAssignmentRule('valueRatio.numerator.value');
-      expectedNumeratorValue.value = 5;
-      const expectedDenominatorQuantity = new ExportableAssignmentRule('valueRatio.denominator');
-      expectedDenominatorQuantity.value = new fshtypes.FshCode(
-        's',
-        'http://other-units.org',
-        'seconds'
-      );
-      const expectedDenominatorValue = new ExportableAssignmentRule('valueRatio.denominator.value');
-      expectedDenominatorValue.value = 1;
-      expect(assignmentRules).toHaveLength(4);
-      expect(assignmentRules[0]).toEqual<ExportableAssignmentRule>(expectedNumeratorQuantity);
-      expect(assignmentRules[1]).toEqual<ExportableAssignmentRule>(expectedNumeratorValue);
-      expect(assignmentRules[2]).toEqual<ExportableAssignmentRule>(expectedDenominatorQuantity);
-      expect(assignmentRules[3]).toEqual<ExportableAssignmentRule>(expectedDenominatorValue);
+      expect(assignmentRules).toHaveLength(1);
+      expect(assignmentRules[0]).toEqual<ExportableAssignmentRule>(expectedRule);
       expect(element.processedPaths).toContain('patternRatio.numerator.value');
       expect(element.processedPaths).toContain('patternRatio.numerator.code');
       expect(element.processedPaths).toContain('patternRatio.numerator.system');

--- a/test/extractor/AssignmentRuleExtractor.test.ts
+++ b/test/extractor/AssignmentRuleExtractor.test.ts
@@ -174,112 +174,17 @@ describe('AssignmentRuleExtractor', () => {
       expect(element.processedPaths).toContain('patternQuantity.unit');
     });
 
-    it('should extract assigned value rules with a fixed Quantity value that does not use UCUM units', () => {
-      const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[1]);
-      element.patternQuantity.system = 'http://other-units.org';
-      element.patternQuantity.unit = 'Gigawatts';
-      const assignmentRules = AssignmentRuleExtractor.process(element);
-      const expectedRule = new ExportableAssignmentRule('valueQuantity');
-      expectedRule.value = new fshtypes.FshQuantity(
-        1.21,
-        new fshtypes.FshCode('GW', 'http://other-units.org', 'Gigawatts')
-      );
-      expect(assignmentRules).toHaveLength(1);
-      expect(assignmentRules[0]).toEqual<ExportableAssignmentRule>(expectedRule);
-      expect(element.processedPaths).toHaveLength(4);
-      expect(element.processedPaths).toContain('patternQuantity.value');
-      expect(element.processedPaths).toContain('patternQuantity.code');
-      expect(element.processedPaths).toContain('patternQuantity.system');
-      expect(element.processedPaths).toContain('patternQuantity.unit');
-    });
-
     it('should extract an assigned value rule with a fixed Ratio value', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[2]);
       const assignmentRules = AssignmentRuleExtractor.process(element);
       const expectedRule = new ExportableAssignmentRule('valueRatio');
       expectedRule.value = new fshtypes.FshRatio(
-        new fshtypes.FshQuantity(5, new fshtypes.FshCode('cm', 'http://unitsofmeasure.org')),
-        new fshtypes.FshQuantity(1, new fshtypes.FshCode('s', 'http://unitsofmeasure.org'))
+        new fshtypes.FshQuantity(5, new fshtypes.FshCode('cm', 'http://other-units.org')),
+        new fshtypes.FshQuantity(1, new fshtypes.FshCode('s', 'http://different-units.org'))
       );
       expect(assignmentRules).toHaveLength(1);
       expect(assignmentRules[0]).toEqual<ExportableAssignmentRule>(expectedRule);
       expect(element.processedPaths).toHaveLength(8);
-      expect(element.processedPaths).toContain('patternRatio.numerator.value');
-      expect(element.processedPaths).toContain('patternRatio.numerator.code');
-      expect(element.processedPaths).toContain('patternRatio.numerator.system');
-      expect(element.processedPaths).toContain('patternRatio.numerator.unit');
-      expect(element.processedPaths).toContain('patternRatio.denominator.value');
-      expect(element.processedPaths).toContain('patternRatio.denominator.code');
-      expect(element.processedPaths).toContain('patternRatio.denominator.system');
-      expect(element.processedPaths).toContain('patternRatio.denominator.unit');
-    });
-
-    it('should extract assigned value rules with a fixed Ratio value when the numerator does not use UCUM units', () => {
-      const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[2]);
-      element.patternRatio.numerator.system = 'http://other-units.org';
-      element.patternRatio.numerator.unit = 'centimeters';
-      const assignmentRules = AssignmentRuleExtractor.process(element);
-      const expectedRule = new ExportableAssignmentRule('valueRatio');
-      expectedRule.value = new fshtypes.FshRatio(
-        new fshtypes.FshQuantity(
-          5,
-          new fshtypes.FshCode('cm', 'http://other-units.org', 'centimeters')
-        ),
-        new fshtypes.FshQuantity(1, new fshtypes.FshCode('s', 'http://unitsofmeasure.org'))
-      );
-      expect(assignmentRules).toHaveLength(1);
-      expect(assignmentRules[0]).toEqual<ExportableAssignmentRule>(expectedRule);
-      expect(element.processedPaths).toHaveLength(8);
-      expect(element.processedPaths).toContain('patternRatio.numerator.value');
-      expect(element.processedPaths).toContain('patternRatio.numerator.code');
-      expect(element.processedPaths).toContain('patternRatio.numerator.system');
-      expect(element.processedPaths).toContain('patternRatio.numerator.unit');
-      expect(element.processedPaths).toContain('patternRatio.denominator.value');
-      expect(element.processedPaths).toContain('patternRatio.denominator.code');
-      expect(element.processedPaths).toContain('patternRatio.denominator.system');
-      expect(element.processedPaths).toContain('patternRatio.denominator.unit');
-    });
-
-    it('should extract assigned value rules with a fixed Ratio value when the denominator does not use UCUM units', () => {
-      const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[2]);
-      element.patternRatio.denominator.system = 'http://other-units.org';
-      element.patternRatio.denominator.unit = 'seconds';
-      const assignmentRules = AssignmentRuleExtractor.process(element);
-      const expectedRule = new ExportableAssignmentRule('valueRatio');
-      expectedRule.value = new fshtypes.FshRatio(
-        new fshtypes.FshQuantity(5, new fshtypes.FshCode('cm', 'http://unitsofmeasure.org')),
-        new fshtypes.FshQuantity(1, new fshtypes.FshCode('s', 'http://other-units.org', 'seconds'))
-      );
-      expect(assignmentRules).toHaveLength(1);
-      expect(assignmentRules[0]).toEqual<ExportableAssignmentRule>(expectedRule);
-      expect(element.processedPaths).toHaveLength(8);
-      expect(element.processedPaths).toContain('patternRatio.numerator.value');
-      expect(element.processedPaths).toContain('patternRatio.numerator.code');
-      expect(element.processedPaths).toContain('patternRatio.numerator.system');
-      expect(element.processedPaths).toContain('patternRatio.numerator.unit');
-      expect(element.processedPaths).toContain('patternRatio.denominator.value');
-      expect(element.processedPaths).toContain('patternRatio.denominator.code');
-      expect(element.processedPaths).toContain('patternRatio.denominator.system');
-      expect(element.processedPaths).toContain('patternRatio.denominator.unit');
-    });
-
-    it('should extract assigned value rules with a fixed Ratio value when the numerator and denominator do not use UCUM units', () => {
-      const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[2]);
-      element.patternRatio.numerator.system = 'http://other-units.org';
-      element.patternRatio.numerator.unit = 'centimeters';
-      element.patternRatio.denominator.system = 'http://other-units.org';
-      element.patternRatio.denominator.unit = 'seconds';
-      const assignmentRules = AssignmentRuleExtractor.process(element);
-      const expectedRule = new ExportableAssignmentRule('valueRatio');
-      expectedRule.value = new fshtypes.FshRatio(
-        new fshtypes.FshQuantity(
-          5,
-          new fshtypes.FshCode('cm', 'http://other-units.org', 'centimeters')
-        ),
-        new fshtypes.FshQuantity(1, new fshtypes.FshCode('s', 'http://other-units.org', 'seconds'))
-      );
-      expect(assignmentRules).toHaveLength(1);
-      expect(assignmentRules[0]).toEqual<ExportableAssignmentRule>(expectedRule);
       expect(element.processedPaths).toContain('patternRatio.numerator.value');
       expect(element.processedPaths).toContain('patternRatio.numerator.code');
       expect(element.processedPaths).toContain('patternRatio.numerator.system');
@@ -295,11 +200,11 @@ describe('AssignmentRuleExtractor', () => {
       delete element.patternRatio.numerator.value;
       const assignmentRules = AssignmentRuleExtractor.process(element);
       const expectedNumeratorRule = new ExportableAssignmentRule('valueRatio.numerator');
-      expectedNumeratorRule.value = new fshtypes.FshCode('cm', 'http://unitsofmeasure.org');
+      expectedNumeratorRule.value = new fshtypes.FshCode('cm', 'http://other-units.org');
       const expectedDenominatorRule = new ExportableAssignmentRule('valueRatio.denominator');
       expectedDenominatorRule.value = new fshtypes.FshQuantity(
         1,
-        new fshtypes.FshCode('s', 'http://unitsofmeasure.org')
+        new fshtypes.FshCode('s', 'http://different-units.org')
       );
       expect(assignmentRules).toHaveLength(2);
       expect(assignmentRules[0]).toEqual<ExportableAssignmentRule>(expectedNumeratorRule);
@@ -321,10 +226,10 @@ describe('AssignmentRuleExtractor', () => {
       const expectedNumeratorRule = new ExportableAssignmentRule('valueRatio.numerator');
       expectedNumeratorRule.value = new fshtypes.FshQuantity(
         5,
-        new fshtypes.FshCode('cm', 'http://unitsofmeasure.org')
+        new fshtypes.FshCode('cm', 'http://other-units.org')
       );
       const expectedDenominatorRule = new ExportableAssignmentRule('valueRatio.denominator');
-      expectedDenominatorRule.value = new fshtypes.FshCode('s', 'http://unitsofmeasure.org');
+      expectedDenominatorRule.value = new fshtypes.FshCode('s', 'http://different-units.org');
       expect(assignmentRules).toHaveLength(2);
       expect(assignmentRules[0]).toEqual<ExportableAssignmentRule>(expectedNumeratorRule);
       expect(assignmentRules[1]).toEqual<ExportableAssignmentRule>(expectedDenominatorRule);

--- a/test/extractor/fixtures/complex-assigned-value-profile.json
+++ b/test/extractor/fixtures/complex-assigned-value-profile.json
@@ -41,12 +41,12 @@
           "numerator": {
             "value": 5,
             "code": "cm",
-            "system": "http://unitsofmeasure.org"
+            "system": "http://other-units.org"
           },
           "denominator": {
             "value": 1,
             "code": "s",
-            "system": "http://unitsofmeasure.org"
+            "system": "http://different-units.org"
           }
         }
       },

--- a/test/optimizer/plugins/CombineCodingAndQuantityValuesOptimizer.test.ts
+++ b/test/optimizer/plugins/CombineCodingAndQuantityValuesOptimizer.test.ts
@@ -299,7 +299,7 @@ describe('optimizer', () => {
         expect(extension.rules[0]).toEqual(expectedRule);
       });
 
-      it('should combine rules on code and system when value is available but the system is not http://unitsofmeasure.org', () => {
+      it('should combine rules on code, system, and value into a single rule even when the system is not http://unitsofmeasure.org', () => {
         const extension = new ExportableExtension('MyExtension');
         const codeRule = new ExportableCaretValueRule('');
         codeRule.caretPath = 'extension[0].valueQuantity.code';
@@ -316,14 +316,13 @@ describe('optimizer', () => {
 
         const expectedRule = new ExportableCaretValueRule('');
         expectedRule.caretPath = 'extension[0].valueQuantity';
-        expectedRule.value = new FshCode('GW', 'http://different-units.org');
+        expectedRule.value = new FshQuantity(1.21, new FshCode('GW', 'http://different-units.org'));
         optimizer.optimize(myPackage, fisher);
-        expect(extension.rules.length).toBe(2);
-        expect(extension.rules).toContainEqual(valueRule);
-        expect(extension.rules).toContainEqual(expectedRule);
+        expect(extension.rules.length).toBe(1);
+        expect(extension.rules[0]).toEqual(expectedRule);
       });
 
-      it('should not combine rules on code and value when system is not available', () => {
+      it('should combine rules on code and value', () => {
         const extension = new ExportableExtension('MyExtension');
         const codeRule = new ExportableCaretValueRule('');
         codeRule.caretPath = 'extension[0].valueQuantity.code';
@@ -335,13 +334,15 @@ describe('optimizer', () => {
         const myPackage = new Package();
         myPackage.add(extension);
 
+        const expectedRule = new ExportableCaretValueRule('');
+        expectedRule.caretPath = 'extension[0].valueQuantity';
+        expectedRule.value = new FshQuantity(1.21, new FshCode('GW'));
         optimizer.optimize(myPackage, fisher);
-        expect(extension.rules.length).toBe(2);
-        expect(extension.rules).toContainEqual(codeRule);
-        expect(extension.rules).toContainEqual(valueRule);
+        expect(extension.rules.length).toBe(1);
+        expect(extension.rules).toContainEqual(expectedRule);
       });
 
-      it('should prefer combining code, system, and value, even when unit is available, if system is http://unitsofmeasure.org', () => {
+      it('should combine rules on code, system, value, and unit when the system is http://unitsofmeasure.org', () => {
         const extension = new ExportableExtension('MyExtension');
         const codeRule = new ExportableCaretValueRule('');
         codeRule.caretPath = 'extension[0].valueQuantity.code';
@@ -361,14 +362,16 @@ describe('optimizer', () => {
 
         const expectedRule = new ExportableCaretValueRule('');
         expectedRule.caretPath = 'extension[0].valueQuantity';
-        expectedRule.value = new FshQuantity(1.21, new FshCode('GW', 'http://unitsofmeasure.org'));
+        expectedRule.value = new FshQuantity(
+          1.21,
+          new FshCode('GW', 'http://unitsofmeasure.org', 'Gigawatts')
+        );
         optimizer.optimize(myPackage, fisher);
-        expect(extension.rules.length).toBe(2);
+        expect(extension.rules.length).toBe(1);
         expect(extension.rules).toContainEqual(expectedRule);
-        expect(extension.rules).toContainEqual(unitRule);
       });
 
-      it('should combine rules on code, system, and unit when value is available, but system is not http://unitsofmeasure.org', () => {
+      it('should combine rules on code, system, value, and unit, even when system is not http://unitsofmeasure.org', () => {
         const extension = new ExportableExtension('MyExtension');
         const codeRule = new ExportableCaretValueRule('');
         codeRule.caretPath = 'extension[0].valueQuantity.code';
@@ -388,11 +391,13 @@ describe('optimizer', () => {
 
         const expectedRule = new ExportableCaretValueRule('');
         expectedRule.caretPath = 'extension[0].valueQuantity';
-        expectedRule.value = new FshCode('GW', 'http://other-units.org', 'Gigawatts');
+        expectedRule.value = new FshQuantity(
+          1.21,
+          new FshCode('GW', 'http://other-units.org', 'Gigawatts')
+        );
         optimizer.optimize(myPackage, fisher);
-        expect(extension.rules.length).toBe(2);
+        expect(extension.rules.length).toBe(1);
         expect(extension.rules).toContainEqual(expectedRule);
-        expect(extension.rules).toContainEqual(valueRule);
       });
 
       it('should not combine rules that have sibling caretPaths, but different paths', () => {
@@ -672,7 +677,7 @@ describe('optimizer', () => {
         expect(instance.rules[0]).toEqual(expectedRule);
       });
 
-      it('should combine rules on code and system when value is available but the system is not http://unitsofmeasure.org', () => {
+      it('should combine rules on code, system, value, and unit, even when system is not http://unitsofmeasure.org', () => {
         const instance = new ExportableInstance('MyProfile');
         instance.instanceOf = 'Observation';
         const codeRule = new ExportableAssignmentRule('referenceRange.low.code');
@@ -686,14 +691,13 @@ describe('optimizer', () => {
         myPackage.add(instance);
 
         const expectedRule = new ExportableAssignmentRule('referenceRange.low');
-        expectedRule.value = new FshCode('Cal', 'http://mystery-system.org');
+        expectedRule.value = new FshQuantity(6, new FshCode('Cal', 'http://mystery-system.org'));
         optimizer.optimize(myPackage, fisher);
-        expect(instance.rules.length).toBe(2);
-        expect(instance.rules).toContainEqual(valueRule);
-        expect(instance.rules).toContainEqual(expectedRule);
+        expect(instance.rules.length).toBe(1);
+        expect(instance.rules[0]).toEqual(expectedRule);
       });
 
-      it('should not combine rules on code and value when system is not available', () => {
+      it('should combine rules on code and value', () => {
         const instance = new ExportableInstance('MyProfile');
         instance.instanceOf = 'Observation';
         const codeRule = new ExportableAssignmentRule('referenceRange.low.code');
@@ -704,13 +708,14 @@ describe('optimizer', () => {
         const myPackage = new Package();
         myPackage.add(instance);
 
+        const expectedRule = new ExportableAssignmentRule('referenceRange.low');
+        expectedRule.value = new FshQuantity(6, new FshCode('Cal'));
         optimizer.optimize(myPackage, fisher);
-        expect(instance.rules.length).toBe(2);
-        expect(instance.rules).toContainEqual(codeRule);
-        expect(instance.rules).toContainEqual(valueRule);
+        expect(instance.rules.length).toBe(1);
+        expect(instance.rules).toContainEqual(expectedRule);
       });
 
-      it('should prefer combining code, system, and value, even when unit is available, if system is http://unitsofmeasure.org', () => {
+      it('should combine rules on code, system, value, and unit when the system is http://unitsofmeasure.org', () => {
         const instance = new ExportableInstance('MyProfile');
         instance.instanceOf = 'Observation';
         const codeRule = new ExportableAssignmentRule('referenceRange.low.code');
@@ -726,14 +731,16 @@ describe('optimizer', () => {
         myPackage.add(instance);
 
         const expectedRule = new ExportableAssignmentRule('referenceRange.low');
-        expectedRule.value = new FshQuantity(6, new FshCode('Cal', 'http://unitsofmeasure.org'));
+        expectedRule.value = new FshQuantity(
+          6,
+          new FshCode('Cal', 'http://unitsofmeasure.org', 'nutrition label Calories')
+        );
         optimizer.optimize(myPackage, fisher);
-        expect(instance.rules.length).toBe(2);
+        expect(instance.rules.length).toBe(1);
         expect(instance.rules).toContainEqual(expectedRule);
-        expect(instance.rules).toContainEqual(unitRule);
       });
 
-      it('should combine rules on code, system, and unit when value is available, but system is not http://unitsofmeasure.org', () => {
+      it('should combine rules on code, system, value, and unit, even when system is not http://unitsofmeasure.org', () => {
         const instance = new ExportableInstance('MyProfile');
         instance.instanceOf = 'Observation';
         const codeRule = new ExportableAssignmentRule('referenceRange.low.code');
@@ -749,15 +756,13 @@ describe('optimizer', () => {
         myPackage.add(instance);
 
         const expectedRule = new ExportableAssignmentRule('referenceRange.low');
-        expectedRule.value = new FshCode(
-          'Cal',
-          'http://other-units.org',
-          'nutrition label Calories'
+        expectedRule.value = new FshQuantity(
+          6,
+          new FshCode('Cal', 'http://other-units.org', 'nutrition label Calories')
         );
         optimizer.optimize(myPackage, fisher);
-        expect(instance.rules.length).toBe(2);
+        expect(instance.rules.length).toBe(1);
         expect(instance.rules).toContainEqual(expectedRule);
-        expect(instance.rules).toContainEqual(valueRule);
       });
 
       it('should not combine rules that have different base paths', () => {


### PR DESCRIPTION
Completes task [CIMPL-698](https://standardhealthrecord.atlassian.net/browse/CIMPL-698).

New FSH syntax for Quantity values in assignment and caret value rules allow for more elements to be combined into a single rule. The system on the Quantity is no longer required to be UCUM. The Quantity can now contain the display string in its unit element. These changes allow the ExportableAssignmentRule and ExportableCaretValueRule to take advantage of the new implementation of FshQuantity.toString without any further changes. As such, no tests are added for those two classes.

Overall, the removal of the requirement for UCUM makes this implementation a lot simpler. Hooray!