### PR TITLE
Optimize rule paths to use Soft Indexing

### DIFF
--- a/src/optimizer/OptimizerPlugin.ts
+++ b/src/optimizer/OptimizerPlugin.ts
@@ -21,13 +21,13 @@ export interface OptimizerPlugin {
    * A list of the optimizers (by name) that this optimizer should be run before (e.g., list of optimizers that depend on this one).
    * NOTE: Only one side of the relationship needs to be specified.  E.g., 'a' runBefore 'b' implies 'b' runAfter 'a'.
    */
-  runBefore?: string[];
+  runBefore?: (string | RegExp)[];
 
   /**
    * A list of the optimizers (by name) that this optimizer should be run after (e.g., list of optimizers that this optimizer depends on).
    * NOTE: Only one side of the relationship needs to be specified.  E.g., 'y' runAfter 'x' implies 'x' runBefore 'y'.
    */
-  runAfter?: string[];
+  runAfter?: (string | RegExp)[];
 
   /**
    * Optimizes definitions in the package by adding/modifying/removing definitions and/or rules.  Mutates the Package in place.

--- a/src/optimizer/loadOptimizers.ts
+++ b/src/optimizer/loadOptimizers.ts
@@ -39,8 +39,11 @@ export async function loadOptimizers(
   optimizers.forEach(opt => {
     nodes.push(opt.name);
     opt.runAfter?.forEach(dependsOn => {
-      if (optimizers.some(o => o.name === dependsOn)) {
-        edges.push([opt.name, dependsOn]);
+      const preceedingOptimizer = optimizers.find(o =>
+        dependsOn instanceof RegExp ? dependsOn.test(o.name) : dependsOn === o.name
+      );
+      if (preceedingOptimizer) {
+        edges.push([opt.name, preceedingOptimizer.name]);
       } else {
         logger.error(
           `The ${opt.name} optimizer specifies an unknown optimizer in runAfter: ${dependsOn}`
@@ -48,8 +51,11 @@ export async function loadOptimizers(
       }
     });
     opt.runBefore?.forEach(dependedOnBy => {
-      if (optimizers.some(o => o.name === dependedOnBy)) {
-        edges.push([dependedOnBy, opt.name]);
+      const succeedingOptimizer = optimizers.find(o =>
+        dependedOnBy instanceof RegExp ? dependedOnBy.test(o.name) : dependedOnBy === o.name
+      );
+      if (succeedingOptimizer) {
+        edges.push([succeedingOptimizer.name, opt.name]);
       } else {
         logger.error(
           `The ${opt.name} optimizer specifies an unknown optimizer in runBefore: ${dependedOnBy}`

--- a/src/optimizer/loadOptimizers.ts
+++ b/src/optimizer/loadOptimizers.ts
@@ -74,7 +74,6 @@ export async function loadOptimizers(
   let ordered: string[];
   try {
     ordered = toposort.array(nodes, edges).reverse();
-    console.log(JSON.stringify(ordered));
   } catch (e) {
     // This message should be reliably present and reliably in this format, but use '?' defensively just in case
     const nodeMatch = e.message?.match(/"([^"]+)"$/);

--- a/src/optimizer/plugins/SimplifyArrayIndexingOptimizer.ts
+++ b/src/optimizer/plugins/SimplifyArrayIndexingOptimizer.ts
@@ -1,0 +1,123 @@
+import { fshrules, fhirtypes, utils } from 'fsh-sushi';
+import { OptimizerPlugin } from '../OptimizerPlugin';
+import { Package } from '../../processor';
+import { ExportableCaretValueRule } from '../../exportable';
+
+const singletonArrayElements: Map<string, fhirtypes.PathPart[]> = new Map();
+
+export default {
+  name: 'simplify_array_indexing',
+  description: 'Replace numeric indices with soft indexing',
+  optimize(pkg: Package): void {
+    // If there is only a single element in an array, include no indices at all
+    // If there is more than one element in an array, reference the first element with
+    // a '0' and subsequent elements with soft indexing
+    [
+      ...pkg.profiles,
+      ...pkg.extensions,
+      ...pkg.valueSets,
+      ...pkg.codeSystems,
+      ...pkg.instances,
+      ...pkg.mappings
+    ].forEach(def => {
+      const pathMap: Map<string, number> = new Map();
+      const caretPathMap: Map<string, Map<string, number>> = new Map();
+      const ruleArr: fshrules.Rule[] = def.rules;
+      const parsedRules = ruleArr.map((rule: fshrules.Rule) => {
+        const parsedPath: { path: fhirtypes.PathPart[]; caretPath?: fhirtypes.PathPart[] } = {
+          path: utils.parseFSHPath(rule.path)
+        };
+        // If we have a CaretValueRule, we'll need a second round of parsing for the caret path
+        if (rule instanceof ExportableCaretValueRule) {
+          parsedPath.caretPath = utils.parseFSHPath(rule.caretPath);
+        }
+        return parsedPath;
+      });
+
+      parsedRules.forEach((parsedRule: any, ruleIndex: number) => {
+        const originalRule = def.rules[ruleIndex];
+        parsedRule.path.forEach((element: fhirtypes.PathPart, elementIndex: number) => {
+          // Add a prefix to the current element containing previously parsed rule elements
+          element.prefix = utils.assembleFSHPath(parsedRule.path.slice(0, elementIndex));
+          applySoftIndexing(element, pathMap);
+        });
+
+        parsedRule.caretPath?.forEach((element: fhirtypes.PathPart, elementIndex: number) => {
+          // Caret path indexes should only be resolved in the context of a specific path
+          // Each normal path has a separate map to keep track of the caret path indexes
+          if (!caretPathMap.has(originalRule.path)) {
+            caretPathMap.set(originalRule.path, new Map());
+          }
+
+          const elementCaretPathMap = caretPathMap.get(originalRule.path);
+          // Add a prefix to the current element containing previously parsed rule elements
+          element.prefix = utils.assembleFSHPath(parsedRule.caretPath.slice(0, elementIndex));
+          applySoftIndexing(element, elementCaretPathMap);
+        });
+      });
+
+      removeZeroIndices();
+
+      parsedRules.forEach((parsedRule: any, ruleIndex: number) => {
+        const originalRule = def.rules[ruleIndex];
+        originalRule.path = utils.assembleFSHPath(parsedRule.path);
+        if (originalRule instanceof ExportableCaretValueRule) {
+          originalRule.caretPath = utils.assembleFSHPath(parsedRule.caretPath);
+        }
+      });
+    });
+  }
+} as OptimizerPlugin;
+
+/**
+ *
+ * @param {PathPart} element - A single element in a rules path
+ * @param {Map<string, number} pathMap - A map containing an element's name as the key and that element's updated index as the value
+ */
+function applySoftIndexing(element: fhirtypes.PathPart, pathMap: Map<string, number>) {
+  // Must account for a pathPart's base name, prior portions of the path, as well as any slices it's contained in.
+  const mapName = `${element.prefix ?? ''}.${element.base}|${(element.slices ?? []).join('|')}`;
+  const indexRegex = /^[0-9]+$/;
+
+  const currentNumericBracket = element.brackets?.find(bracket => indexRegex.test(bracket));
+  if (!currentNumericBracket) return; // If the element is not an array, exit the function
+
+  const bracketIndex = element.brackets.indexOf(currentNumericBracket);
+
+  if (!pathMap.has(mapName)) {
+    pathMap.set(mapName, parseInt(currentNumericBracket));
+    // If the element contains a zero Index, we'll flag the rule to have the index removed
+    if (currentNumericBracket === '0') singletonArrayElements.set(mapName, [element]);
+  } else {
+    const previousNumericIndex = pathMap.get(mapName);
+    if (parseInt(currentNumericBracket) === previousNumericIndex + 1) {
+      if (previousNumericIndex === 0) singletonArrayElements.delete(mapName);
+      element.brackets[bracketIndex] = '+';
+      pathMap.set(mapName, previousNumericIndex + 1);
+    } else if (parseInt(currentNumericBracket) === previousNumericIndex) {
+      element.brackets[bracketIndex] = '=';
+      if (currentNumericBracket === '0') {
+        // If the element contains a zero Index, we'll flag the rule to have the index removed
+        singletonArrayElements.get(mapName).push(element);
+      }
+    } else {
+      singletonArrayElements.delete(mapName);
+    }
+  }
+}
+
+function removeZeroIndices() {
+  const redundantElementGroups = Array.from(singletonArrayElements.values());
+  redundantElementGroups.forEach(cluster => {
+    cluster.forEach(pathPart => {
+      if (pathPart.brackets.includes('0')) {
+        const zeroIndex = pathPart.brackets.indexOf('0');
+        delete pathPart.brackets[zeroIndex];
+      }
+      if (pathPart.brackets.includes('=')) {
+        const equalsIndex = pathPart.brackets.indexOf('=');
+        delete pathPart.brackets[equalsIndex];
+      }
+    });
+  });
+}

--- a/src/optimizer/plugins/SimplifyArrayIndexingOptimizer.ts
+++ b/src/optimizer/plugins/SimplifyArrayIndexingOptimizer.ts
@@ -2,6 +2,7 @@ import { fshrules, fhirtypes, utils } from 'fsh-sushi';
 import { OptimizerPlugin } from '../OptimizerPlugin';
 import { Package } from '../../processor';
 import { ExportableCaretValueRule } from '../../exportable';
+import _ from 'lodash';
 
 export default {
   name: 'simplify_array_indexing',
@@ -22,10 +23,10 @@ export default {
       const pathMap: Map<string, number> = new Map();
       const caretPathMap: Map<string, Map<string, number>> = new Map();
       const ruleArr: fshrules.Rule[] = def.rules;
-      const singletonArrayElements: Map<string, fhirtypes.PathPart[]> = new Map();
       const parsedPaths = ruleArr.map((rule: fshrules.Rule) => {
         const parsedPath: { path: fhirtypes.PathPart[]; caretPath?: fhirtypes.PathPart[] } = {
-          path: utils.parseFSHPath(rule.path)
+          path: utils.parseFSHPath(rule.path),
+          caretPath: []
         };
         // If we have a CaretValueRule, we'll need a second round of parsing for the caret path
         if (rule instanceof ExportableCaretValueRule) {
@@ -43,10 +44,10 @@ export default {
       parsedPaths.forEach((parsedRule: any, ruleIndex: number) => {
         const originalRule = def.rules[ruleIndex];
         parsedRule.path.forEach((element: fhirtypes.PathPart) => {
-          applySoftIndexing(element, pathMap, singletonArrayElements);
+          applySoftIndexing(element, pathMap);
         });
 
-        parsedRule.caretPath?.forEach((element: fhirtypes.PathPart) => {
+        parsedRule.caretPath.forEach((element: fhirtypes.PathPart) => {
           // Caret path indexes should only be resolved in the context of a specific path
           // Each normal path has a separate map to keep track of the caret path indexes
           if (!caretPathMap.has(originalRule.path)) {
@@ -54,11 +55,11 @@ export default {
           }
 
           const elementCaretPathMap = caretPathMap.get(originalRule.path);
-          applySoftIndexing(element, elementCaretPathMap, singletonArrayElements);
+          applySoftIndexing(element, elementCaretPathMap);
         });
       });
 
-      removeZeroIndices(singletonArrayElements);
+      removeZeroIndices(parsedPaths);
 
       parsedPaths.forEach((parsedRule: any, ruleIndex: number) => {
         const originalRule = def.rules[ruleIndex];
@@ -67,7 +68,6 @@ export default {
           originalRule.caretPath = utils.assembleFSHPath(parsedRule.caretPath);
         }
       });
-      singletonArrayElements.clear();
     });
   }
 } as OptimizerPlugin;
@@ -89,11 +89,7 @@ function addPrefixes(parsedPath: fhirtypes.PathPart[]) {
  * @param {Map<string, number} pathMap - A map containing an element's name as the key and that element's updated index as the value
  * @param {Map<string, PathPart[]} singletonArrayElements - A map containing a string unique to each element of type array as the key, and an array of PathParts as the value
  */
-function applySoftIndexing(
-  element: fhirtypes.PathPart,
-  pathMap: Map<string, number>,
-  singletonArrayElements: Map<string, fhirtypes.PathPart[]>
-) {
+function applySoftIndexing(element: fhirtypes.PathPart, pathMap: Map<string, number>) {
   // Must account for a pathPart's base name, prior portions of the path, as well as any slices it's contained in.
   const mapName = `${element.prefix ?? ''}.${element.base}|${(element.slices ?? []).join('|')}`;
   const indexRegex = /^[0-9]+$/;
@@ -105,46 +101,70 @@ function applySoftIndexing(
 
   if (!pathMap.has(mapName)) {
     pathMap.set(mapName, parseInt(currentNumericBracket));
-    // If the element contains a zero Index, we'll flag the rule to have the index removed
-    if (currentNumericBracket === '0') {
-      singletonArrayElements.set(mapName, [element]);
-    }
   } else {
     const previousNumericIndex = pathMap.get(mapName);
     if (parseInt(currentNumericBracket) === previousNumericIndex + 1) {
-      if (previousNumericIndex === 0) {
-        singletonArrayElements.delete(mapName);
-      }
       element.brackets[bracketIndex] = '+';
       pathMap.set(mapName, previousNumericIndex + 1);
     } else if (parseInt(currentNumericBracket) === previousNumericIndex) {
       element.brackets[bracketIndex] = '=';
-      if (currentNumericBracket === '0') {
-        // If the element contains a zero Index, we'll flag the rule to have the index removed
-        singletonArrayElements.get(mapName).push(element);
-      }
     } else {
-      singletonArrayElements.delete(mapName);
+      pathMap.set(mapName, parseInt(currentNumericBracket));
     }
   }
 }
 
-/**
- * Removes '[0]' and '[=]' indexing from elements with a single value in their array
- * @param {Map<string, PathPart[]} singletonArrayElements - A map containing a string unique to each element of type array as the key, and an array of PathParts as the value
- */
-function removeZeroIndices(singletonArrayElements: Map<string, fhirtypes.PathPart[]>) {
-  const redundantElementGroups = Array.from(singletonArrayElements.values());
-  redundantElementGroups.forEach(cluster => {
-    cluster.forEach(pathPart => {
-      if (pathPart.brackets.includes('0')) {
-        const zeroIndex = pathPart.brackets.indexOf('0');
-        delete pathPart.brackets[zeroIndex];
+// Removes '[0]' and '[=]' indexing from elements with a single value in their array
+function removeZeroIndices(parsedPaths: any[]) {
+  const regularPathElements = _.flatten(parsedPaths.map(rule => rule.path));
+  const caretPathElements = _.flatten(parsedPaths.map(rule => rule.caretPath));
+
+  const referencePathElements = _.cloneDeep(regularPathElements);
+  const referenceCaretPathElements = _.cloneDeep(caretPathElements);
+
+  regularPathElements.forEach((element: fhirtypes.PathPart) => {
+    if (!element.brackets) {
+      return;
+    }
+    const filteredElements = referencePathElements.filter(
+      e =>
+        e.base === element.base &&
+        e.prefix === element.prefix &&
+        e.brackets &&
+        !(e.brackets.includes('0') || e.brackets.includes('='))
+    );
+    if (filteredElements.length === 0) {
+      if (element.brackets.includes('0')) {
+        const zeroIndex = element.brackets.indexOf('0');
+        delete element.brackets[zeroIndex];
       }
-      if (pathPart.brackets.includes('=')) {
-        const equalsIndex = pathPart.brackets.indexOf('=');
-        delete pathPart.brackets[equalsIndex];
+      if (element.brackets.includes('=')) {
+        const equalsIndex = element.brackets.indexOf('=');
+        delete element.brackets[equalsIndex];
       }
-    });
+    }
+  });
+
+  caretPathElements.forEach((element: fhirtypes.PathPart) => {
+    if (!element.brackets) {
+      return;
+    }
+    const filteredElements = referenceCaretPathElements.filter(
+      e =>
+        e.base === element.base &&
+        e.prefix === element.prefix &&
+        e.brackets &&
+        !(e.brackets.includes('0') || e.brackets.includes('='))
+    );
+    if (filteredElements.length === 0) {
+      if (element.brackets.includes('0')) {
+        const zeroIndex = element.brackets.indexOf('0');
+        delete element.brackets[zeroIndex];
+      }
+      if (element.brackets.includes('=')) {
+        const equalsIndex = element.brackets.indexOf('=');
+        delete element.brackets[equalsIndex];
+      }
+    }
   });
 }

--- a/src/optimizer/plugins/SimplifyArrayIndexingOptimizer.ts
+++ b/src/optimizer/plugins/SimplifyArrayIndexingOptimizer.ts
@@ -114,10 +114,12 @@ function applySoftIndexing(element: fhirtypes.PathPart, pathMap: Map<string, num
   }
 }
 
+// TODO: remove once sushi has been released with fixes to the parseFSHPath function
 function splitOnPathPeriods(path: string): string[] {
   return path.split(/\.(?![^\[]*\])/g); // match a period that isn't within square brackets
 }
 
+// TODO: remove once sushi has been released with fixes to the parseFSHPath function
 export function parseFSHPath(fshPath: string): fhirtypes.PathPart[] {
   const pathParts: fhirtypes.PathPart[] = [];
   const seenSlices: string[] = [];

--- a/src/optimizer/plugins/SimplifyArrayIndexingOptimizer.ts
+++ b/src/optimizer/plugins/SimplifyArrayIndexingOptimizer.ts
@@ -147,7 +147,7 @@ export function parseFSHPath(fshPath: string): fhirtypes.PathPart[] {
         pathParts.push({
           base: fhirPathBase,
           brackets: brackets,
-          slices: seenSlices
+          slices: [...seenSlices]
         });
       } else {
         pathParts.push({ base: fhirPathBase, brackets: brackets });

--- a/src/optimizer/plugins/index.ts
+++ b/src/optimizer/plugins/index.ts
@@ -16,6 +16,7 @@ import ResolveOnlyRuleURLsOptimizer from './ResolveOnlyRuleURLsOptimizer';
 import ResolveParentURLsOptimizer from './ResolveParentURLsOptimizer';
 import ResolveValueRuleURLsOptimizer from './ResolveValueRuleURLsOptimizer';
 import ResolveValueSetComponentRuleURLsOptimizer from './ResolveValueSetComponentRuleURLsOptimizer';
+import SimplifyArrayIndexingOptimizer from './SimplifyArrayIndexingOptimizer';
 import SimplifyInstanceNameOptimizer from './SimplifyInstanceNameOptimizer';
 import SimplifyMappingNamesOptimizer from './SimplifyMappingNamesOptimizer';
 
@@ -38,6 +39,7 @@ export {
   ResolveParentURLsOptimizer,
   ResolveValueRuleURLsOptimizer,
   ResolveValueSetComponentRuleURLsOptimizer,
+  SimplifyArrayIndexingOptimizer,
   SimplifyInstanceNameOptimizer,
   SimplifyMappingNamesOptimizer
 };

--- a/test/optimizer/loadOptimizers.test.ts
+++ b/test/optimizer/loadOptimizers.test.ts
@@ -22,7 +22,11 @@ describe('optimizer', () => {
       it('should load the standard optimizers in the expected order', () => {
         optimizers.forEach((opt, i) => {
           opt.runAfter?.forEach(dependsOn => {
-            const dependsOnIdx = optimizers.findIndex(otherOpt => otherOpt.name === dependsOn);
+            const dependsOnIdx = optimizers.findIndex(otherOpt =>
+              dependsOn instanceof RegExp
+                ? dependsOn.test(otherOpt.name)
+                : dependsOn === otherOpt.name
+            );
             expect(dependsOnIdx).not.toBe(-1);
             try {
               expect(dependsOnIdx).toBeLessThan(i);
@@ -33,8 +37,10 @@ describe('optimizer', () => {
             }
           });
           opt.runBefore?.forEach(dependedOnBy => {
-            const dependedOnByIdx = optimizers.findIndex(
-              otherOpt => otherOpt.name === dependedOnBy
+            const dependedOnByIdx = optimizers.findIndex(otherOpt =>
+              dependedOnBy instanceof RegExp
+                ? dependedOnBy.test(otherOpt.name)
+                : dependedOnBy === otherOpt.name
             );
             expect(dependedOnByIdx).not.toBe(-1);
             try {

--- a/test/optimizer/loadOptimizers.test.ts
+++ b/test/optimizer/loadOptimizers.test.ts
@@ -22,34 +22,56 @@ describe('optimizer', () => {
       it('should load the standard optimizers in the expected order', () => {
         optimizers.forEach((opt, i) => {
           opt.runAfter?.forEach(dependsOn => {
-            const dependsOnIdx = optimizers.findIndex(otherOpt =>
-              dependsOn instanceof RegExp
-                ? dependsOn.test(otherOpt.name)
-                : dependsOn === otherOpt.name
-            );
-            expect(dependsOnIdx).not.toBe(-1);
-            try {
-              expect(dependsOnIdx).toBeLessThan(i);
-            } catch {
-              throw new Error(
-                `Expected ${opt.name} (i: ${i}) to come after ${dependsOn} (i: ${dependsOnIdx})`
-              );
-            }
+            const dependsOnIndices = optimizers
+              .map((otherOpt, index) => {
+                if (otherOpt.name === opt.name) {
+                  return '';
+                }
+                if (dependsOn instanceof RegExp && dependsOn.test(otherOpt.name)) {
+                  return index;
+                } else if (typeof dependsOn === 'string' && dependsOn === otherOpt.name) {
+                  return index;
+                } else {
+                  return '';
+                }
+              })
+              .filter(String);
+            expect(dependsOnIndices.length).not.toBe(0);
+            dependsOnIndices.forEach(dependencyIndex => {
+              try {
+                expect(dependencyIndex).toBeLessThan(i);
+              } catch {
+                throw new Error(
+                  `Expected ${opt.name} (i: ${i}) to come after ${dependsOn} (i: ${dependencyIndex})`
+                );
+              }
+            });
           });
           opt.runBefore?.forEach(dependedOnBy => {
-            const dependedOnByIdx = optimizers.findIndex(otherOpt =>
-              dependedOnBy instanceof RegExp
-                ? dependedOnBy.test(otherOpt.name)
-                : dependedOnBy === otherOpt.name
-            );
-            expect(dependedOnByIdx).not.toBe(-1);
-            try {
-              expect(dependedOnByIdx).toBeGreaterThan(i);
-            } catch {
-              throw new Error(
-                `Expected ${opt.name} (i: ${i}) to come before ${dependedOnBy} (i: ${dependedOnByIdx})`
-              );
-            }
+            const dependedOnByIndices = optimizers
+              .map((otherOpt, index) => {
+                if (otherOpt.name === opt.name) {
+                  return '';
+                }
+                if (dependedOnBy instanceof RegExp && dependedOnBy.test(otherOpt.name)) {
+                  return index;
+                } else if (typeof dependedOnBy === 'string' && dependedOnBy === otherOpt.name) {
+                  return index;
+                } else {
+                  return '';
+                }
+              })
+              .filter(String);
+            expect(dependedOnByIndices.length).not.toBe(0);
+            dependedOnByIndices.forEach(dependedOnByIdx => {
+              try {
+                expect(dependedOnByIdx).toBeGreaterThan(i);
+              } catch {
+                throw new Error(
+                  `Expected ${opt.name} (i: ${i}) to come before ${dependedOnBy} (i: ${dependedOnByIdx})`
+                );
+              }
+            });
           });
         });
       });

--- a/test/optimizer/plugins/SimplifyArrayIndexingOptimizer.test.ts
+++ b/test/optimizer/plugins/SimplifyArrayIndexingOptimizer.test.ts
@@ -14,7 +14,7 @@ describe('optimizer', () => {
       expect(optimizer.name).toBe('simplify_array_indexing');
       expect(optimizer.description).toBeDefined();
       expect(optimizer.runBefore).toBeUndefined();
-      expect(optimizer.runAfter).toBeUndefined();
+      expect(optimizer.runAfter).toStrictEqual([/.*/]);
     });
 
     it('should remove zero indices from elements referencing a singleton array', () => {

--- a/test/optimizer/plugins/SimplifyArrayIndexingOptimizer.test.ts
+++ b/test/optimizer/plugins/SimplifyArrayIndexingOptimizer.test.ts
@@ -1,0 +1,113 @@
+import '../../helpers/loggerSpy'; // side-effect: suppresses logs
+import { Package } from '../../../src/processor/Package';
+import {
+  ExportableAssignmentRule,
+  ExportableCaretValueRule,
+  ExportableInstance,
+  ExportableProfile
+} from '../../../src/exportable';
+import optimizer from '../../../src/optimizer/plugins/SimplifyArrayIndexingOptimizer';
+
+describe('optimizer', () => {
+  describe('#simplify_array_indexing', () => {
+    it('should have appropriate metadata', () => {
+      expect(optimizer.name).toBe('simplify_array_indexing');
+      expect(optimizer.description).toBeDefined();
+      expect(optimizer.runBefore).toBeUndefined();
+      expect(optimizer.runAfter).toBeUndefined();
+    });
+
+    it('should remove zero indices from elements referencing a singleton array', () => {
+      const instance = new ExportableInstance('testPatient');
+      instance.instanceOf = 'Patient';
+
+      const nameRule1 = new ExportableAssignmentRule('name[0].given[0]');
+      nameRule1.value = 'John';
+
+      const nameRule2 = new ExportableAssignmentRule('name[0].family');
+      nameRule2.value = 'Doe';
+
+      instance.rules.push(nameRule1, nameRule2);
+      const myPackage = new Package();
+      myPackage.add(instance);
+      optimizer.optimize(myPackage);
+
+      expect(myPackage.instances[0].rules[0].path).toBe('name.given');
+      expect(myPackage.instances[0].rules[1].path).toBe('name.family');
+    });
+
+    it('should convert non-zero numeric indices to soft indexing', () => {
+      const instance = new ExportableInstance('testPatient');
+      instance.instanceOf = 'Patient';
+
+      const nameRule1 = new ExportableAssignmentRule('name[0].given[0]');
+      nameRule1.value = 'John';
+
+      const nameRule2 = new ExportableAssignmentRule('name[0].family');
+      nameRule1.value = 'Doe';
+
+      const nameRule3 = new ExportableAssignmentRule('name[1].given[0]');
+      nameRule2.value = 'James';
+
+      instance.rules.push(nameRule1, nameRule2, nameRule3);
+      const myPackage = new Package();
+      myPackage.add(instance);
+      optimizer.optimize(myPackage);
+
+      expect(myPackage.instances[0].rules[0].path).toBe('name[0].given');
+      expect(myPackage.instances[0].rules[1].path).toBe('name[=].family');
+      expect(myPackage.instances[0].rules[2].path).toBe('name[+].given');
+    });
+
+    it('should avoid using soft indexing when gaps exist on an elements array', () => {
+      const instance = new ExportableInstance('testPatient');
+      instance.instanceOf = 'Patient';
+
+      const nameRule1 = new ExportableAssignmentRule('name[0].given[0]');
+      nameRule1.value = 'John';
+
+      const nameRule2 = new ExportableAssignmentRule('name[0].family');
+      nameRule1.value = 'Doe';
+
+      const nameRule3 = new ExportableAssignmentRule('name[5].given[0]');
+      nameRule2.value = 'James';
+
+      instance.rules.push(nameRule1, nameRule2, nameRule3);
+      const myPackage = new Package();
+      myPackage.add(instance);
+      optimizer.optimize(myPackage);
+
+      expect(myPackage.instances[0].rules[0].path).toBe('name[0].given');
+      expect(myPackage.instances[0].rules[1].path).toBe('name[=].family');
+      expect(myPackage.instances[0].rules[2].path).toBe('name[5].given');
+    });
+
+    it('should apply soft indexing on caret paths', () => {
+      const profile = new ExportableProfile('MyProfile');
+      const caretRule1 = new ExportableCaretValueRule('');
+      caretRule1.caretPath = 'contact[0].name';
+
+      const caretRule2 = new ExportableCaretValueRule('');
+      caretRule2.caretPath = 'contact[0].phone';
+
+      const caretRule3 = new ExportableCaretValueRule('');
+      caretRule3.caretPath = 'contact[0].email';
+
+      const caretRule4 = new ExportableCaretValueRule('');
+      caretRule4.caretPath = 'contact[1].phone';
+
+      profile.rules.push(caretRule1, caretRule2, caretRule3, caretRule4);
+
+      const myPackage = new Package();
+      myPackage.add(profile);
+      optimizer.optimize(myPackage);
+
+      const optimizedCaretRules = myPackage.profiles[0].rules as ExportableCaretValueRule[];
+
+      expect(optimizedCaretRules[0].caretPath).toBe('contact[0].name');
+      expect(optimizedCaretRules[1].caretPath).toBe('contact[=].phone');
+      expect(optimizedCaretRules[2].caretPath).toBe('contact[=].email');
+      expect(optimizedCaretRules[3].caretPath).toBe('contact[+].phone');
+    });
+  });
+});

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -303,7 +303,7 @@ describe('Processing', () => {
       const result = await getResources(processor, config);
       expect(result.instances).toHaveLength(2);
       const bundle = result.instances.find(i => i.id === 'foo');
-      const inlineInstanceRule = new ExportableAssignmentRule('entry[0].resource');
+      const inlineInstanceRule = new ExportableAssignmentRule('entry.resource');
       inlineInstanceRule.isInstance = true;
       inlineInstanceRule.value = 'bar';
       expect(bundle.rules).toContainEqual(inlineInstanceRule);


### PR DESCRIPTION
Completes [CIMPL-699](https://standardhealthrecord.atlassian.net/browse/CIMPL-699), creating the `SimplifyArrayIndexingOptimizer`. 

This optimizer removes `[0]` and `[=]` indices from elements referencing singleton arrays. This optimizer also converts numeric indices to soft indexing where appropriate, meaning only when an array's index remains the same as in the previous rule or is incremented by one. If an array includes gaps in its element references, then soft indexing is eschewed. I thought it would be most intuitive to new users to leave the _first_ index in a soft indexing sequence numeric and use soft indexing for all subsequent indexing, e.g: 

```
* name[0].given = Julian0
* name[0].family = Carter0
* name[1].given = Julian1
* name[1].family = Carter1
```

would convert to:
```
* name[0].given = Julian0
* name[=].family = Carter0
* name[+].given = Julian1
* name[=].family = Carter1
```

This way, if a user is new to FSH then it'll be a bit easier for them to figure out what's going on with the indices.