### PR TITLE
Support fhirVersions > 4.0.1

### DIFF
--- a/src/api/FhirToFsh.ts
+++ b/src/api/FhirToFsh.ts
@@ -77,10 +77,12 @@ export async function fhirToFsh(
   const dependencies = configuration.config.dependencies?.map(
     (dep: fhirtypes.ImplementationGuideDependsOn) => `${dep.packageId}@${dep.version}`
   );
-  const fhirPackageId = configuration.config.fhirVersion[0].startsWith('4.0')
-    ? 'hl7.fhir.r4.core'
-    : 'hl7.fhir.r5.core';
-  dependencies.push(`${fhirPackageId}@${configuration.config.fhirVersion[0]}`);
+  if (dependencies) {
+    const fhirPackageId = configuration.config.fhirVersion[0].startsWith('4.0')
+      ? 'hl7.fhir.r4.core'
+      : 'hl7.fhir.r5.core';
+    dependencies.push(`${fhirPackageId}@${configuration.config.fhirVersion[0]}`);
+  }
   await Promise.all(loadExternalDependencies(defs, dependencies));
 
   // Process the FHIR to rules, and then export to FSH

--- a/src/api/FhirToFsh.ts
+++ b/src/api/FhirToFsh.ts
@@ -77,6 +77,10 @@ export async function fhirToFsh(
   const dependencies = configuration.config.dependencies?.map(
     (dep: fhirtypes.ImplementationGuideDependsOn) => `${dep.packageId}@${dep.version}`
   );
+  const fhirPackageId = configuration.config.fhirVersion[0].startsWith('4.0')
+    ? 'hl7.fhir.r4.core'
+    : 'hl7.fhir.r5.core';
+  dependencies.push(`${fhirPackageId}@${configuration.config.fhirVersion[0]}`);
   await Promise.all(loadExternalDependencies(defs, dependencies));
 
   // Process the FHIR to rules, and then export to FSH

--- a/src/app.ts
+++ b/src/app.ts
@@ -115,9 +115,10 @@ async function app() {
   const config = processor.processConfig(dependencies);
 
   // Load dependencies from config for GoFSH processing
-  const allDependencies = config.config.dependencies?.map(
-    (dep: fhirtypes.ImplementationGuideDependsOn) => `${dep.packageId}@${dep.version}`
-  );
+  const allDependencies =
+    config.config.dependencies?.map(
+      (dep: fhirtypes.ImplementationGuideDependsOn) => `${dep.packageId}@${dep.version}`
+    ) ?? [];
   const fhirPackageId = config.config.fhirVersion[0].startsWith('4.0')
     ? 'hl7.fhir.r4.core'
     : 'hl7.fhir.r5.core';

--- a/src/app.ts
+++ b/src/app.ts
@@ -118,6 +118,10 @@ async function app() {
   const allDependencies = config.config.dependencies?.map(
     (dep: fhirtypes.ImplementationGuideDependsOn) => `${dep.packageId}@${dep.version}`
   );
+  const fhirPackageId = config.config.fhirVersion[0].startsWith('4.0')
+    ? 'hl7.fhir.r4.core'
+    : 'hl7.fhir.r5.core';
+  allDependencies.push(`${fhirPackageId}@${config.config.fhirVersion[0]}`);
   const dependencyDefs = loadExternalDependencies(defs, allDependencies);
 
   await Promise.all(dependencyDefs);

--- a/src/exportable/ExportableAssignmentRule.ts
+++ b/src/exportable/ExportableAssignmentRule.ts
@@ -8,7 +8,11 @@ export class ExportableAssignmentRule extends fshrules.AssignmentRule implements
 
   toFSH(): string {
     let printableValue = '';
-    if (typeof this.value === 'boolean' || typeof this.value === 'number') {
+    if (
+      typeof this.value === 'boolean' ||
+      typeof this.value === 'number' ||
+      typeof this.value === 'bigint'
+    ) {
       printableValue = String(this.value);
     } else if (typeof this.value === 'string') {
       printableValue = this.isInstance ? this.value : `"${this.value}"`;

--- a/src/extractor/AssignmentRuleExtractor.ts
+++ b/src/extractor/AssignmentRuleExtractor.ts
@@ -20,10 +20,12 @@ export class AssignmentRuleExtractor {
         assignmentRule.exactly = true;
       }
       if (isPrimitiveValue(matchingValue)) {
-        // a primitive string could represent a string value or a code value
+        // a primitive string could represent a string value, code value, or integer64 value
         if (typeof matchingValue === 'string') {
           if (matchingKey.endsWith('Code')) {
             assignmentRule.value = new fshtypes.FshCode(matchingValue);
+          } else if (matchingKey.endsWith('Integer64')) {
+            assignmentRule.value = BigInt(matchingValue);
           } else {
             assignmentRule.value = fshifyString(matchingValue);
           }

--- a/src/extractor/ConfigurationExtractor.ts
+++ b/src/extractor/ConfigurationExtractor.ts
@@ -12,9 +12,13 @@ export class ConfigurationExtractor {
     if (igResource && !igResource.url) {
       missingIGProperties.push('url');
     }
-    let fhirVersion: string[] = igResource?.fhirVersion?.filter((v: string) =>
-      utils.isSupportedFHIRVersion(v)
-    );
+    let fhirVersion: string[] = igResource?.fhirVersion?.filter((v: string) => {
+      if (!utils.isSupportedFHIRVersion(v)) {
+        logger.warn(`Unsupported fhirVersion ${v} in ImplementationGuide will be ignored.`);
+        return false;
+      }
+      return true;
+    });
     if (igResource && !fhirVersion?.length) {
       missingIGProperties.push('fhirVersion');
     }

--- a/src/extractor/OnlyRuleExtractor.ts
+++ b/src/extractor/OnlyRuleExtractor.ts
@@ -9,7 +9,7 @@ export class OnlyRuleExtractor {
     }
     const onlyRule = new ExportableOnlyRule(getPath(input));
     input.type.forEach((t, i) => {
-      if (t.code === 'Reference' && t.targetProfile) {
+      if (['Reference', 'CodeableReference'].includes(t.code) && t.targetProfile) {
         t.targetProfile.forEach((tp, tpi) => {
           onlyRule.types.push({ type: tp, isReference: true });
           input.processedPaths.push(`type[${i}].targetProfile[${tpi}]`);

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -97,8 +97,8 @@ export function loadExternalDependencies(
   defs: fhirdefs.FHIRDefinitions,
   dependencies: string[] = []
 ): Promise<fhirdefs.FHIRDefinitions | void>[] {
-  // Automatically include FHIR R4
-  if (!dependencies.includes('hl7.fhir.r4.core@4.0.1')) {
+  // Automatically include FHIR R4 if no other versions of FHIR are already included
+  if (!dependencies.some(dep => /hl7\.fhir\.r[45]\.core/.test(dep))) {
     dependencies.push('hl7.fhir.r4.core@4.0.1');
   }
 

--- a/src/utils/element.ts
+++ b/src/utils/element.ts
@@ -52,7 +52,7 @@ export function getFSHValue(
   flatObject: FlatObject,
   resourceType: string,
   fisher: utils.Fishable
-): number | boolean | string | fshtypes.FshCode {
+): number | boolean | string | fshtypes.FshCode | bigint {
   const value = flatObject[key];
   const definition = fhirtypes.StructureDefinition.fromJSON(
     fisher.fishForFHIR(resourceType, utils.Type.Resource, utils.Type.Type)
@@ -89,6 +89,8 @@ export function getFSHValue(
   }
   if (element?.type?.[0]?.code === 'code') {
     return new fshtypes.FshCode(value.toString());
+  } else if (element?.type?.[0]?.code === 'integer64') {
+    return BigInt(value);
   }
   return typeof value === 'string' ? fshifyString(value) : value;
 }

--- a/test/api/FhirToFsh.test.ts
+++ b/test/api/FhirToFsh.test.ts
@@ -117,7 +117,11 @@ describe('fhirToFsh', () => {
     });
 
     expect(loadSpy.mock.calls).toHaveLength(1);
-    expect(loadSpy.mock.calls[0][1]).toEqual(['hl7.fhir.us.core@3.1.0', 'hl7.fhir.us.mcode@1.0.0']);
+    expect(loadSpy.mock.calls[0][1]).toEqual([
+      'hl7.fhir.us.core@3.1.0',
+      'hl7.fhir.us.mcode@1.0.0',
+      'hl7.fhir.r4.core@4.0.1'
+    ]);
   });
 
   it('should parse a string input into JSON', async () => {

--- a/test/exportable/ExportableAssignmentRule.test.ts
+++ b/test/exportable/ExportableAssignmentRule.test.ts
@@ -22,6 +22,12 @@ describe('ExportableAssignmentRule', () => {
     expect(rule.toFSH()).toEqual('* valueDecimal = 1.21');
   });
 
+  it('should export a AssignmentRule with a bigint value', () => {
+    const rule = new ExportableAssignmentRule('valueInteger64');
+    rule.value = BigInt('9223372036854775807');
+    expect(rule.toFSH()).toEqual('* valueInteger64 = 9223372036854775807');
+  });
+
   it('should export a AssignmentRule with a string value', () => {
     const rule = new ExportableAssignmentRule('note.text');
     rule.value = 'This is the \\"note text\\".\\nThis is the second line.';

--- a/test/extractor/AssignmentRuleExtractor.test.ts
+++ b/test/extractor/AssignmentRuleExtractor.test.ts
@@ -80,6 +80,27 @@ describe('AssignmentRuleExtractor', () => {
       expect(element.processedPaths).toContain('patternBoolean');
     });
 
+    it('should extract an assigned value rule with a fixed integer64 value', () => {
+      const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[8]);
+      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const expectedRule = new ExportableAssignmentRule('valueInteger64');
+      expectedRule.value = BigInt('9223372036854775807');
+      expectedRule.exactly = true;
+      expect(assignmentRules).toHaveLength(1);
+      expect(assignmentRules[0]).toEqual<ExportableAssignmentRule>(expectedRule);
+      expect(element.processedPaths).toContain('fixedInteger64');
+    });
+
+    it('should extract an assigned value rule with a pattern integer64 value', () => {
+      const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[9]);
+      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const expectedRule = new ExportableAssignmentRule('valueInteger64');
+      expectedRule.value = BigInt('9223372036854775807');
+      expect(assignmentRules).toHaveLength(1);
+      expect(assignmentRules[0]).toEqual<ExportableAssignmentRule>(expectedRule);
+      expect(element.processedPaths).toContain('patternInteger64');
+    });
+
     it('should extract an assigned value rule with a pattern code', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[6]);
       const assignmentRules = AssignmentRuleExtractor.process(element);

--- a/test/extractor/ConfigurationExtractor.test.ts
+++ b/test/extractor/ConfigurationExtractor.test.ts
@@ -137,6 +137,7 @@ describe('ConfigurationExtractor', () => {
         expect(loggerSpy.getLastMessage('warn')).toMatch(
           /ImplementationGuide missing properties.*fhirVersion/s
         );
+        expect(loggerSpy.getMessageAtIndex(-2, 'warn')).toMatch(/Unsupported fhirVersion 99\.0\.0/);
       });
 
       it('should create a Configuration with additional properties', () => {

--- a/test/extractor/ConfigurationExtractor.test.ts
+++ b/test/extractor/ConfigurationExtractor.test.ts
@@ -121,6 +121,24 @@ describe('ConfigurationExtractor', () => {
         );
       });
 
+      it('should default to 4.0.1 when no supported fhirVersion is given', () => {
+        const ig = JSON.parse(
+          fs.readFileSync(
+            path.join(__dirname, 'fixtures', 'unsupported-fhir-version-ig.json'),
+            'utf-8'
+          )
+        );
+        const result = ConfigurationExtractor.process([ig]);
+        expect(result).toBeInstanceOf(ExportableConfiguration);
+        expect(result.config.canonical).toBe('http://example.org/tests'); // From IG
+        expect(result.config.fhirVersion).toEqual(['4.0.1']); // Default
+        expect(result.config.FSHOnly).toBe(true);
+        expect(result.config.applyExtensionMetadataToRoot).toBe(false);
+        expect(loggerSpy.getLastMessage('warn')).toMatch(
+          /ImplementationGuide missing properties.*fhirVersion/s
+        );
+      });
+
       it('should create a Configuration with additional properties', () => {
         const ig = JSON.parse(
           fs.readFileSync(path.join(__dirname, 'fixtures', 'bigger-ig.json'), 'utf-8')

--- a/test/extractor/OnlyRuleExtractor.test.ts
+++ b/test/extractor/OnlyRuleExtractor.test.ts
@@ -6,10 +6,19 @@ import { ProcessableElementDefinition } from '../../src/processor';
 
 describe('OnlyRuleExtractor', () => {
   let looseSD: any;
+  let sdWithCodeableReference: any;
 
   beforeAll(() => {
     looseSD = JSON.parse(
       fs.readFileSync(path.join(__dirname, 'fixtures', 'only-profile.json'), 'utf-8').trim()
+    );
+    sdWithCodeableReference = JSON.parse(
+      fs
+        .readFileSync(
+          path.join(__dirname, 'fixtures', 'only-profile-with-codeablereference.json'),
+          'utf-8'
+        )
+        .trim()
     );
   });
 
@@ -61,6 +70,38 @@ describe('OnlyRuleExtractor', () => {
     expectedRule.types = [
       { type: 'string' },
       { type: 'http://hl7.org/fhir/StructureDefinition/ProfileOfReference' }
+    ];
+    expect(onlyRule).toEqual<ExportableOnlyRule>(expectedRule);
+    expect(element.processedPaths).toEqual(['type[0].code', 'type[1].profile[0]', 'type[1].code']);
+  });
+
+  it('should extract an only rule with a subset of a CodeableReference type', () => {
+    const element = ProcessableElementDefinition.fromJSON(
+      sdWithCodeableReference.differential.element[0]
+    );
+    const onlyRule = OnlyRuleExtractor.process(element);
+    const expectedRule = new ExportableOnlyRule('activity.performedActivity');
+    expectedRule.types = [
+      { type: 'http://hl7.org/fhir/StructureDefinition/Observation', isReference: true },
+      { type: 'http://hl7.org/fhir/StructureDefinition/MolecularSequence', isReference: true }
+    ];
+    expect(onlyRule).toEqual<ExportableOnlyRule>(expectedRule);
+    expect(element.processedPaths).toEqual([
+      'type[0].targetProfile[0]',
+      'type[0].targetProfile[1]',
+      'type[0].code'
+    ]);
+  });
+
+  it('should extract an only rule with a profile on a CodeableReference', () => {
+    const element = ProcessableElementDefinition.fromJSON(
+      sdWithCodeableReference.differential.element[1]
+    );
+    const onlyRule = OnlyRuleExtractor.process(element);
+    const expectedRule = new ExportableOnlyRule('extension[foo].value[x]');
+    expectedRule.types = [
+      { type: 'string' },
+      { type: 'http://hl7.org/fhir/StructureDefinition/ProfileOfCodeableReference' }
     ];
     expect(onlyRule).toEqual<ExportableOnlyRule>(expectedRule);
     expect(element.processedPaths).toEqual(['type[0].code', 'type[1].profile[0]', 'type[1].code']);

--- a/test/extractor/fixtures/assigned-value-profile.json
+++ b/test/extractor/fixtures/assigned-value-profile.json
@@ -37,6 +37,14 @@
       {
         "id": "Observation.valueString",
         "isSummary": true
+      },
+      {
+        "id": "Observation.valueInteger64",
+        "fixedInteger64": "9223372036854775807"
+      },
+      {
+        "id": "Observation.valueInteger64",
+        "patternInteger64": "9223372036854775807"
       }
     ]
   }

--- a/test/extractor/fixtures/only-profile-with-codeablereference.json
+++ b/test/extractor/fixtures/only-profile-with-codeablereference.json
@@ -1,0 +1,40 @@
+{
+  "resourceType": "StructureDefinition",
+  "kind": "resource",
+  "type": "CarePlan",
+  "name": "CarePlanWithOnly",
+  "snapshot": {
+    "element": []
+  },
+  "differential": {
+    "element": [
+      {
+        "id": "CarePlan.activity.performedActivity",
+        "path": "CarePlan.activity.performedActivity",
+        "type": [
+          {
+            "code": "CodeableReference",
+            "targetProfile": [
+              "http://hl7.org/fhir/StructureDefinition/Observation",
+              "http://hl7.org/fhir/StructureDefinition/MolecularSequence"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "CarePlan.extension:foo.value[x]",
+        "path": "CarePlan.extension:foo.value[x]",
+        "type": [
+          {
+            "code": "string"
+          },
+          {
+            "code": "CodeableReference",
+            "profile": ["http://hl7.org/fhir/StructureDefinition/ProfileOfCodeableReference"],
+            "versioning": "either"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/extractor/fixtures/unsupported-fhir-version-ig.json
+++ b/test/extractor/fixtures/unsupported-fhir-version-ig.json
@@ -1,0 +1,7 @@
+{
+  "resourceType": "ImplementationGuide",
+  "id": "simple.ig",
+  "url": "http://example.org/tests/ImplementationGuide/simple.ig",
+  "name": "UnsupportedImplementationGuide",
+  "fhirVersion": ["99.0.0"]
+}


### PR DESCRIPTION
This fixes #107 by adding support for versions of FHIR > 4.0.1. 

# Changes
There are a few things that had to change to do this. First there were changes related to allowing loading versions of FHIR > 4.0.1:
* `ConfigurationExtractor.ts`was updated so that only supported versions of FHIR will be used as the `fhirVersion` in the configuration.
* `app.ts` was updated so that the package corresponding to the given `fhirVersion` is included in the set of dependencies that is loaded.
* `Processing.ts` was updated so that the `loadExternalDependencies` function now only defaults to FHIR 4.0.1 if no other version of FHIR is already specified in the dependencies. I don't think this check should be necessary in any situation anymore, but I think it doesn't hurt to keep it.

Then there were some changes to make `CodeableReference` work:
* `OnlyRuleExtractor.ts` was updated to check if the type of an element is `Reference` or `CodeableReference`.

Then changes to make `integer64` work:
* `element.ts` was updated so that `getFSHValue` will convert an `integer64` string value to a `bigint`
* `ExportableAssignmentRule.ts` was updated so that its `toFSH` method will print a `bigint` without `""` around it
* `AssignmentRuleExtractor.ts` was updated so that a string value representing an `integer64` will be extracted to a `bigint`, so that when it is printed with `toFSH`, it will not have `""` around it.

We actually could leave out the `integer64` stuff if we are fine with writing an `integer64` in FSH as a string, which SUSHI does support. I'm not really sure what the "preferred" style is in this case. An `integer64` is serialized in JSON as a string, so maybe that is preferred, but all other numbers are written as numbers, so maybe that is preferred.

# Testing
Here is a FSH Online [link](https://fshschool.org/FSHOnline/#/share/3egoUc0) to the FSH I used to test this, by running through SUSHI and then GoFSH and comparing with the original. The things to test are:
* If `fhirVersion` is something other than 4.0.1, we load that version of FHIR
* If `fhirVersion` is not present and cannot be inferred, we still default to 4.0.1
* When a `fhirVersion` other than 4.0.1 is given, you can run GoFSH on SDs that inherit from Resources only in that version of FHIR
* When a VS binding or a Reference type constraint is placed on a `CodeableReference`, GoFSH processes that without resorting to `^` rules
* When an `integer64` is assigned on an `Instance` or a `Profile/Extension`, GoFSH writes it as a number, not a string (but the number loses no precision)

This feels a little too easy, but I cannot find evidence of anything else we've done to SUSHI relating to FHIR R5, so I'm not sure what else there would be to do here. But please as part of the review make sure to also consider anything that may be missing from this PR.