### PR TITLE
Fix bug with choice slices

### DIFF
--- a/src/processor/StructureDefinitionProcessor.ts
+++ b/src/processor/StructureDefinitionProcessor.ts
@@ -90,8 +90,8 @@ export class StructureDefinitionProcessor {
     // Then extract rules based on the differential elements
     elements.forEach(element => {
       const ancestorSliceDefinition = getAncestorSliceDefinition(element, input, fisher);
-      // if there is a slice, but no ancestor definition, capture with a contains rule
-      if (element.sliceName && ancestorSliceDefinition == null) {
+      // if there is a slice, which is not a choice slice, but no ancestor definition, capture with a contains rule
+      if (element.sliceName && !element.id.includes('[x]:') && ancestorSliceDefinition == null) {
         newRules.push(
           ContainsRuleExtractor.process(element, input, fisher),
           OnlyRuleExtractor.process(element),

--- a/src/processor/StructureDefinitionProcessor.ts
+++ b/src/processor/StructureDefinitionProcessor.ts
@@ -91,7 +91,11 @@ export class StructureDefinitionProcessor {
     elements.forEach(element => {
       const ancestorSliceDefinition = getAncestorSliceDefinition(element, input, fisher);
       // if there is a slice, which is not a choice slice, but no ancestor definition, capture with a contains rule
-      if (element.sliceName && !element.id.includes('[x]:') && ancestorSliceDefinition == null) {
+      if (
+        element.sliceName &&
+        !/\[x]:[a-z][a-z0-9]*[A-Z][A-Za-z0-9]*$/.test(element.id) &&
+        ancestorSliceDefinition == null
+      ) {
         newRules.push(
           ContainsRuleExtractor.process(element, input, fisher),
           OnlyRuleExtractor.process(element),

--- a/test/processor/StructureDefinitionProcessor.test.ts
+++ b/test/processor/StructureDefinitionProcessor.test.ts
@@ -297,6 +297,51 @@ describe('StructureDefinitionProcessor', () => {
       expect(workingExtension.rules).toContainEqual<ExportableAssignmentRule>(assignmentRule);
     });
 
+    it('should not create contains rules when the extension SD puts the slicename in the choice (#122)', () => {
+      const input: ProcessableStructureDefinition = JSON.parse(
+        fs.readFileSync(path.join(__dirname, 'fixtures', 'slice-name-in-choice.json'), 'utf-8')
+      );
+      const elements =
+        input.differential?.element?.map(rawElement => {
+          return ProcessableElementDefinition.fromJSON(rawElement, false);
+        }) ?? [];
+      const workingExtension = new ExportableExtension('SliceNameInChoice');
+      StructureDefinitionProcessor.extractRules(input, elements, workingExtension, defs, config);
+      expect(workingExtension.rules.length).toBeGreaterThan(0);
+      const containsRules = workingExtension.rules.filter(r => r instanceof ExportableContainsRule);
+      expect(containsRules.length).toBe(0);
+    });
+
+    it('should still create contains rules when the extension SD puts the slicename child paths of the choice (#122)', () => {
+      const input: ProcessableStructureDefinition = JSON.parse(
+        fs.readFileSync(
+          path.join(__dirname, 'fixtures', 'slice-name-in-choice-child-paths.json'),
+          'utf-8'
+        )
+      );
+      const elements =
+        input.differential?.element?.map(rawElement => {
+          return ProcessableElementDefinition.fromJSON(rawElement, false);
+        }) ?? [];
+      const workingExtension = new ExportableExtension('SliceNameInChoiceChildPaths');
+      StructureDefinitionProcessor.extractRules(input, elements, workingExtension, defs, config);
+      expect(workingExtension.rules.length).toBeGreaterThan(0);
+      const containsRules = workingExtension.rules.filter(r => r instanceof ExportableContainsRule);
+      const containsRuleA = new ExportableContainsRule('valueCodeableConcept.coding');
+      containsRuleA.items = [{ name: 'codingA' }];
+      const cardRuleA = new ExportableCardRule('valueCodeableConcept.coding[codingA]');
+      cardRuleA.min = 0;
+      cardRuleA.max = '1';
+      containsRuleA.cardRules = [cardRuleA];
+      const containsRuleB = new ExportableContainsRule('valueCodeableConcept.coding');
+      containsRuleB.items = [{ name: 'codingB' }];
+      const cardRuleB = new ExportableCardRule('valueCodeableConcept.coding[codingB]');
+      cardRuleB.min = 0;
+      cardRuleB.max = '1';
+      containsRuleB.cardRules = [cardRuleB];
+      expect(containsRules).toEqual([containsRuleA, containsRuleB]);
+    });
+
     it('should add rules to a Profile with a new slice', () => {
       const input: ProcessableStructureDefinition = JSON.parse(
         fs.readFileSync(path.join(__dirname, 'fixtures', 'new-slice-profile.json'), 'utf-8')

--- a/test/processor/fixtures/slice-name-in-choice-child-paths.json
+++ b/test/processor/fixtures/slice-name-in-choice-child-paths.json
@@ -1,0 +1,91 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "slice-name-in-choice-child-path",
+  "url": "http://example.org/StructureDefinition/slice-name-in-choice-child-path",
+  "version": "1.0.0",
+  "name": "SliceNameInChoiceChildPath",
+  "title": "SliceName in Choice Child Path",
+  "status": "active",
+  "fhirVersion": "4.0.1",
+  "mapping": [
+    {
+      "identity": "rim",
+      "uri": "http://hl7.org/v3",
+      "name": "RIM Mapping"
+    }
+  ],
+  "kind": "complex-type",
+  "abstract": false,
+  "context": [
+    {
+      "type": "element",
+      "expression": "Element"
+    }
+  ],
+  "type": "Extension",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Extension",
+        "path": "Extension",
+        "short": "SliceName in Choice Child Path"
+      },
+      {
+        "id": "Extension.url",
+        "path": "Extension.url",
+        "fixedUri": "http://example.org/StructureDefinition/slice-name-in-choice-child-path"
+      },
+      {
+        "id": "Extension.value[x]:valueCodeableConcept",
+        "path": "Extension.valueCodeableConcept",
+        "min": 0,
+        "max": "1",
+        "type": [
+          {
+            "code": "CodeableConcept"
+          }
+        ]
+      },
+      {
+        "id": "Extension.value[x]:valueCodeableConcept.coding",
+        "path": "Extension.valueCodeableConcept.coding",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "code"
+            }
+          ]
+        }
+      },
+      {
+        "id": "Extension.value[x]:valueCodeableConcept.coding:codingA",
+        "path": "Extension.valueCodeableConcept.coding",
+        "sliceName": "codingA",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Extension.value[x]:valueCodeableConcept.coding:codingA.code",
+        "path": "Extension.valueCodeableConcept.coding.code",
+        "min": 1,
+        "fixedCode": "foo"
+      },
+      {
+        "id": "Extension.value[x]:valueCodeableConcept.coding:codingB",
+        "path": "Extension.valueCodeableConcept.coding",
+        "sliceName": "codingB",
+        "min": 0,
+        "max": "1"
+      },
+      {
+        "id": "Extension.value[x]:valueCodeableConcept.coding:codingB.code",
+        "path": "Extension.valueCodeableConcept.coding.code",
+        "min": 1,
+        "fixedCode": "bar"
+      }
+    ]
+  }
+}

--- a/test/processor/fixtures/slice-name-in-choice.json
+++ b/test/processor/fixtures/slice-name-in-choice.json
@@ -1,0 +1,51 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "slice-name-in-choice",
+  "url": "https://go.fsh/StructureDefinition/slice-name-in-choice",
+  "name": "SliceNameInChoice",
+  "title": "Slice Name in Choice",
+  "description": "Test of slicename in choice",
+  "fhirVersion": "4.0.1",
+  "kind": "complex-type",
+  "type": "Extension",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Extension.url",
+        "path": "Extension.url",
+        "fixedUri": "https://go.fsh/StructureDefinition/slice-name-in-choice"
+      },
+      {
+        "id": "Extension.value[x]",
+        "path": "Extension.value[x]",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "type",
+              "path": "$this"
+            }
+          ],
+          "ordered": false,
+          "rules": "open"
+        }
+      },
+      {
+        "id": "Extension.value[x]:valueReference",
+        "path": "Extension.valueReference",
+        "sliceName": "valueReference",
+        "min": 1,
+        "max": "1",
+        "type": [
+          {
+            "code": "Reference",
+            "targetProfile": [
+              "http://hl7.org/fhir/StructureDefinition/Organization"
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/FHIR/GoFSH/issues/122.

When someone has a `sliceName` specified in the differential on the choice slice, SUSHI doesn't really know how to handle that situation, see this example (pardon my xml):
```xml
<element id="Extension.value[x]:valueReference">
      <path value="Extension.valueReference"/>
      <sliceName value="valueReference"/>
      <min value="1"/>
      <type>
        <code value="Reference"/>
        <targetProfile value="http://hl7.org/fhir/StructureDefinition/HealthcareService"/>
      </type>
    </element>
```
I wasn't sure there was a good way to make this work in SUSHI using `contains` rules, so in this case I felt like it results in more clear FSH to just not process this as a `contains` rule. But I may be missing something about how this should be written as FSH, so let me know.