### PR TITLE
References to contained resources should refer by id (w/ no #)

### DIFF
--- a/src/optimizer/plugins/AddReferenceKeywordOptimizer.ts
+++ b/src/optimizer/plugins/AddReferenceKeywordOptimizer.ts
@@ -27,7 +27,9 @@ export default {
             const parentPath = splitOnPathPeriods(rule.path).slice(0, -1).join('.');
             const searchablePath = parentPath.replace(/\[\d+\]/g, '');
             if (sd?.findElementByPath(searchablePath, fisher)?.type?.[0]?.code === 'Reference') {
-              const reference = new fshtypes.FshReference(rule.value);
+              // Remove '#' prefix from references to contained resources (if applicable)
+              const referenceTarget = rule.value.replace(/^#/, '');
+              const reference = new fshtypes.FshReference(referenceTarget);
               // If we are converting the reference, look for a matching display rule, using the
               // original numerical parent path
               const matchingDisplayRuleIndex = instance.rules

--- a/test/optimizer/plugins/AddReferenceKeywordOptimizer.test.ts
+++ b/test/optimizer/plugins/AddReferenceKeywordOptimizer.test.ts
@@ -38,6 +38,22 @@ describe('optimizer', () => {
       expect(instance.rules).toEqual([expectedRule]);
     });
 
+    it('should add the Reference keyword on a reference rule with a contained reference', () => {
+      const instance = new ExportableInstance('Foo');
+      instance.instanceOf = 'Patient';
+      const referenceRule = new ExportableAssignmentRule('generalPractitioner.reference');
+      referenceRule.value = '#mypractitioner';
+      instance.rules = [referenceRule];
+      const myPackage = new Package();
+      myPackage.add(instance);
+      optimizer.optimize(myPackage, fisher);
+
+      const expectedRule = new ExportableAssignmentRule('generalPractitioner');
+      // In FSH, references to contained resources refer by id w/ no # (e.g., Reference(mypractitioner))
+      expectedRule.value = new fshtypes.FshReference('mypractitioner');
+      expect(instance.rules).toEqual([expectedRule]);
+    });
+
     it('should add the Reference keyword on a reference rule and find a corresponding display', () => {
       const instance = new ExportableInstance('Foo');
       instance.instanceOf = 'Patient';


### PR DESCRIPTION
Prior to this fix, when GoFSH created references to contained instances, it generated references like this:
```
* medicationReference = Reference(#mymed)
```
SUSHI did not like this because the parser tried to interpret `#mymed` as a code.  In FSH, you reference contained resources simply by their id (without the `#` prefix).  This PR fixes it so that the above reference is now rendered as:
```
* medicationReference = Reference(mymed)
```

The unit test shows the fix but you can also manually test w/ a simple JSON instance like:
```json
{
  "resourceType": "MedicationRequest",
  "id": "MyMedRequest",
  "status": "completed",
  "intent": "order",
  "contained": [
    {
      "resourceType": "Medication",
      "id": "mymed",
      "code": {
        "coding": [
          {
            "code": "bar",
            "system": "http://foo"
          }
        ]
      }
    }
  ],
  "subject": {
    "reference": "Patient/Bob"
  },
  "medicationReference": {
    "reference": "#mymed"
  }
}
```

If you want to test it on the package that exposed this bug, you can run GoFSH on the [US Core 3.2.0 package](http://hl7.org/fhir/us/core/2021Jan/package.tgz) to see it in action.  After running GoFSH, run SUSHI.  If you used the master version of GoFSH, _one of the errors_ SUSHI outputs will be:
> error Resolved value "Reference(" is not a valid URI.
>  File: /Users/cmoesel/dev/fhir/GoFSH/gofsh/input/fsh/instances.fsh
>  Line: 6838

If you use this branch's version of GoFSH and run SUSHI on the results, that error should go away.

Fixes #120