### PR TITLE
Export LogicalModels and Resources as Instances

### DIFF
--- a/src/processor/LakeOfFHIR.ts
+++ b/src/processor/LakeOfFHIR.ts
@@ -16,7 +16,9 @@ export class LakeOfFHIR implements utils.Fishable {
    * @returns {WildFHIR[]}
    */
   getAllStructureDefinitions(): WildFHIR[] {
-    return this.docs.filter(d => d.content.resourceType === 'StructureDefinition');
+    return this.docs
+      .filter(d => d.content.resourceType === 'StructureDefinition')
+      .filter(d => !this.isSpecialization(d)); // TODO: Remove this filter when full support for LogicalModels and Resources is implemented
   }
 
   /**
@@ -62,8 +64,11 @@ export class LakeOfFHIR implements utils.Fishable {
     return this.docs.filter(d => {
       switch (d.content.resourceType) {
         case 'ImplementationGuide':
-        case 'StructureDefinition':
           return false;
+        case 'StructureDefinition':
+          // TODO: This is a temporary fix to support exporting LogicalModels and Resources as Instances.
+          // This should return false when full support is implemented.
+          return this.isSpecialization(d);
         case 'CodeSystem':
           return (
             includeUnsupportedTerminologyResources &&
@@ -78,6 +83,12 @@ export class LakeOfFHIR implements utils.Fishable {
           return true;
       }
     });
+  }
+
+  isSpecialization(d: WildFHIR): boolean {
+    return (
+      d.content.resourceType === 'StructureDefinition' && d.content.derivation === 'specialization'
+    );
   }
 
   fishForFHIR(item: string, ...types: utils.Type[]) {

--- a/test/processor/LakeOfFHIR.test.ts
+++ b/test/processor/LakeOfFHIR.test.ts
@@ -12,6 +12,8 @@ describe('LakeOfHIR', () => {
       getWildFHIRs(
         'simple-profile.json',
         'simple-extension.json',
+        'simple-logical-model.json',
+        'simple-resource.json',
         'simple-codesystem.json',
         'simple-valueset.json',
         'simple-ig.json',
@@ -28,15 +30,17 @@ describe('LakeOfHIR', () => {
 
   describe('#constructor', () => {
     it('should store all the passed in values', () => {
-      expect(lake.docs).toHaveLength(8);
+      expect(lake.docs).toHaveLength(10);
       expect(lake.docs[0].content.id).toBe('simple.profile');
       expect(lake.docs[1].content.id).toBe('simple.extension');
-      expect(lake.docs[2].content.id).toBe('simple.codesystem');
-      expect(lake.docs[3].content.id).toBe('simple.valueset');
-      expect(lake.docs[4].content.id).toBe('simple.ig');
-      expect(lake.docs[5].content.id).toBe('rocky.balboa');
-      expect(lake.docs[6].content.id).toBe('unsupported.valueset');
-      expect(lake.docs[7].content.id).toBe('unsupported.codesystem');
+      expect(lake.docs[2].content.id).toBe('SimpleLogicalModel');
+      expect(lake.docs[3].content.id).toBe('SimpleResource');
+      expect(lake.docs[4].content.id).toBe('simple.codesystem');
+      expect(lake.docs[5].content.id).toBe('simple.valueset');
+      expect(lake.docs[6].content.id).toBe('simple.ig');
+      expect(lake.docs[7].content.id).toBe('rocky.balboa');
+      expect(lake.docs[8].content.id).toBe('unsupported.valueset');
+      expect(lake.docs[9].content.id).toBe('unsupported.codesystem');
     });
   });
 
@@ -46,6 +50,8 @@ describe('LakeOfHIR', () => {
       expect(results).toHaveLength(2);
       expect(results[0].content.id).toBe('simple.profile');
       expect(results[1].content.id).toBe('simple.extension');
+      // NOTE: This does not yet contain specializations (LogicalModels and Resources)
+      // When full support is implemented, LogicalModels and Resources should be included in this test.
     });
   });
 
@@ -104,22 +110,30 @@ describe('LakeOfHIR', () => {
   describe('#getAllInstances', () => {
     it('should get all non-IG/SD/VS/CS resources by default', () => {
       const results = lake.getAllInstances();
-      expect(results).toHaveLength(1);
-      expect(results[0].content.id).toBe('rocky.balboa');
+      expect(results).toHaveLength(3); // NOTE: Specializations are included temporarily until full support for LogicalModels and Resources is implemented
+      expect(results[2].content.id).toBe('rocky.balboa');
     });
 
     it('should get all non-IG/SD/VS/CS resources when includeUnsupportedValueSets is false', () => {
       const results = lake.getAllInstances(false);
-      expect(results).toHaveLength(1);
-      expect(results[0].content.id).toBe('rocky.balboa');
+      expect(results).toHaveLength(3);
+      expect(results[2].content.id).toBe('rocky.balboa');
     });
 
     it('should also get unsupported value sets and code systems when includeUnsupportedTerminologyResources is true', () => {
       const results = lake.getAllInstances(true);
+      expect(results).toHaveLength(5);
+      expect(results[2].content.id).toBe('rocky.balboa');
+      expect(results[3].content.id).toBe('unsupported.valueset');
+      expect(results[4].content.id).toBe('unsupported.codesystem');
+    });
+
+    // TODO: This test should be move to the getAllStructureDefinitions case when full support for LogicalModel and Resources is implemented.
+    it('should get specializations (temporarily)', () => {
+      const results = lake.getAllInstances();
       expect(results).toHaveLength(3);
-      expect(results[0].content.id).toBe('rocky.balboa');
-      expect(results[1].content.id).toBe('unsupported.valueset');
-      expect(results[2].content.id).toBe('unsupported.codesystem');
+      expect(results[0].content.id).toBe('SimpleLogicalModel');
+      expect(results[1].content.id).toBe('SimpleResource');
     });
   });
 

--- a/test/processor/fixtures/simple-logical-model.json
+++ b/test/processor/fixtures/simple-logical-model.json
@@ -1,0 +1,29 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "SimpleLogicalModel",
+  "url": "http://example.org/StructureDefinition/SimpleLogicalModel",
+  "version": "1.0.0",
+  "name": "SimpleLogicalModel",
+  "status": "active",
+  "fhirVersion": "4.0.1",
+  "mapping": [
+    {
+      "identity": "rim",
+      "name": "RIM Mapping",
+      "uri": "http://hl7.org/v3"
+    }
+  ],
+  "kind": "logical",
+  "abstract": false,
+  "type": "http://example.org/StructureDefinition/SimpleLogicalModel",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Base",
+  "derivation": "specialization",
+  "differential": {
+    "element": [
+      {
+        "id": "SimpleLogicalModel",
+        "path": "SimpleLogicalModel"
+      }
+    ]
+  }
+}

--- a/test/processor/fixtures/simple-resource.json
+++ b/test/processor/fixtures/simple-resource.json
@@ -1,0 +1,29 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "SimpleResource",
+  "url": "http://example.org/StructureDefinition/SimpleResource",
+  "version": "1.0.0",
+  "name": "SimpleResource",
+  "status": "active",
+  "fhirVersion": "4.0.1",
+  "mapping": [
+    {
+      "identity": "rim",
+      "uri": "http://hl7.org/v3",
+      "name": "RIM Mapping"
+    }
+  ],
+  "kind": "resource",
+  "abstract": false,
+  "type": "SimpleResource",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/DomainResource",
+  "derivation": "specialization",
+  "differential": {
+    "element": [
+      {
+        "id": "SimpleResource",
+        "path": "SimpleResource"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This PR supports exporting `LogicalModel`s and `Resource`s as `Instance`s. This is a temporary fix that should be removed when full support for `LogicalModel` and `Resource` is implemented in GoFSH. I tried to mark the places that will need to be updated again when that support is included.

Fixes #125 