### PR TITLE
Do not add caret or assignment rules with empty values

### DIFF
--- a/src/processor/InstanceProcessor.ts
+++ b/src/processor/InstanceProcessor.ts
@@ -2,7 +2,7 @@ import { cloneDeep, compact, isEmpty } from 'lodash';
 import { fhirtypes, utils } from 'fsh-sushi';
 import { ExportableAssignmentRule, ExportableInstance } from '../exportable';
 import { removeUnderscoreForPrimitiveChildPath } from '../exportable/common';
-import { getFSHValue, getPathValuePairs, logger } from '../utils';
+import { getFSHValue, isFSHValueEmpty, getPathValuePairs, logger } from '../utils';
 import { switchQuantityRules } from '.';
 
 export class InstanceProcessor {
@@ -83,7 +83,14 @@ export class InstanceProcessor {
       const path = removeUnderscoreForPrimitiveChildPath(key);
       const assignmentRule = new ExportableAssignmentRule(path);
       assignmentRule.value = getFSHValue(key, flatInstance, instanceOfJSON.type, fisher);
-      newRules.push(assignmentRule);
+      // if the value is empty, we can't use that
+      if (isFSHValueEmpty(assignmentRule.value)) {
+        logger.error(
+          `Value in Instance ${target.name} at path ${key} is empty. No assignment rule will be created.`
+        );
+      } else {
+        newRules.push(assignmentRule);
+      }
     });
     target.rules = compact(newRules);
     switchQuantityRules(target.rules);

--- a/src/utils/element.ts
+++ b/src/utils/element.ts
@@ -1,5 +1,5 @@
 import { flatten } from 'flat';
-import { pickBy, mapKeys, flatMap, flatten as flat } from 'lodash';
+import { pickBy, mapKeys, flatMap, flatten as flat, isObject, isEmpty, isNil } from 'lodash';
 import { fhirtypes, fshtypes, utils } from 'fsh-sushi';
 import { removeUnderscoreForPrimitiveChildPath } from '../exportable/common';
 import { ProcessableStructureDefinition, ProcessableElementDefinition } from '../processor';
@@ -93,6 +93,11 @@ export function getFSHValue(
     return BigInt(value);
   }
   return value;
+}
+
+// Typical empty FSH values are: [], {}, null, undefined
+export function isFSHValueEmpty(fshValue: any): boolean {
+  return (isObject(fshValue) && isEmpty(fshValue)) || isNil(fshValue);
 }
 
 export function getAncestorElement(

--- a/test/extractor/CaretValueRuleExtractor.test.ts
+++ b/test/extractor/CaretValueRuleExtractor.test.ts
@@ -142,6 +142,21 @@ describe('CaretValueRuleExtractor', () => {
       ]);
     });
 
+    it('should not extract array caret value rules when the array is empty', () => {
+      const sd = cloneDeep(looseSD);
+      sd.contextInvariant = [];
+      const caretRules = CaretValueRuleExtractor.processStructureDefinition(sd, defs, config);
+      expect(caretRules).not.toContainEqual(
+        expect.objectContaining({
+          path: '',
+          caretPath: 'contextInvariant'
+        })
+      );
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        'Value in StructureDefinition ObservationWithCaret for element contextInvariant is empty.'
+      );
+    });
+
     it('should convert a FHIR code string to a FSH code when extracting', () => {
       const sd = cloneDeep(looseSD);
       sd.status = 'draft';
@@ -495,6 +510,23 @@ describe('CaretValueRuleExtractor', () => {
       expect(caretRules).toContainEqual<ExportableCaretValueRule>(expectedRule3);
       expect(caretRules).toHaveLength(3);
     });
+
+    it('should not extract ValueSet caret rules when the value of the rule is empty', () => {
+      const vs = cloneDeep(looseVS);
+      vs.status = 'active';
+      vs.compose.inactive = true;
+      vs.identifier = {};
+      const caretRules = CaretValueRuleExtractor.processResource(vs, defs, vs.resourceType, config);
+      expect(caretRules).not.toContainEqual(
+        expect.objectContaining({
+          path: '',
+          caretPath: 'identifier'
+        })
+      );
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        'Value in ValueSet ValueSetWithCaret for element identifier is empty.'
+      );
+    });
   });
 
   describe('CodeSystem', () => {
@@ -541,6 +573,23 @@ describe('CaretValueRuleExtractor', () => {
       expect(caretRules).toContainEqual<ExportableCaretValueRule>(expectedRule2);
       expect(caretRules).toContainEqual<ExportableCaretValueRule>(expectedRule3);
       expect(caretRules).toHaveLength(3);
+    });
+
+    it('should not extract CodeSystem caret rules when the value of the rule is empty', () => {
+      const cs = cloneDeep(looseCS);
+      cs.status = 'active';
+      cs.experimental = true;
+      cs.identifier = {};
+      const caretRules = CaretValueRuleExtractor.processResource(cs, defs, cs.resourceType, config);
+      expect(caretRules).not.toContainEqual(
+        expect.objectContaining({
+          path: '',
+          caretPath: 'identifier'
+        })
+      );
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        'Value in CodeSystem CodeSystemWithCaret for element identifier is empty.'
+      );
     });
   });
 
@@ -810,6 +859,24 @@ describe('CaretValueRuleExtractor', () => {
       expect(caretRules).toHaveLength(2);
       expect(caretRules).toContainEqual<ExportableCaretValueRule>(expectedRule1);
       expect(caretRules).toContainEqual<ExportableCaretValueRule>(expectedRule2);
+    });
+
+    it('should not create rules when the value of the rule is empty', () => {
+      const modifiedInput = cloneDeep(looseSD.differential.element[2]);
+      // turn base into an empty object
+      modifiedInput.base = {};
+      const element = ProcessableElementDefinition.fromJSON(modifiedInput);
+      // There should be no rule created with path partOf and caret path base
+      const caretRules = CaretValueRuleExtractor.process(element, looseSD, defs);
+      expect(caretRules).not.toContainEqual(
+        expect.objectContaining({
+          path: 'partOf',
+          caretPath: 'base'
+        })
+      );
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        'Value in StructureDefinition ObservationWithCaret for element partOf.base is empty.'
+      );
     });
   });
 });

--- a/test/processor/InstanceProcessor.test.ts
+++ b/test/processor/InstanceProcessor.test.ts
@@ -289,5 +289,24 @@ describe('InstanceProcessor', () => {
       expect(loggerSpy.getLastMessage('error')).toMatch(/Definition of ResourceType not found/s);
       expect(result.rules).toHaveLength(0); // Do not add rules
     });
+
+    it('should not add assignment rules when the value of the rule is empty', () => {
+      const input = JSON.parse(
+        fs.readFileSync(path.join(__dirname, 'fixtures', 'complex-patient.json'), 'utf-8')
+      );
+      // turn name[0].given into an empty list
+      input.name[0].given = [];
+      const result = InstanceProcessor.process(input, simpleIg, defs);
+      expect(result).toBeInstanceOf(ExportableInstance);
+      // There should be no rule created with path name[0].given
+      expect(result.rules).not.toContainEqual(
+        expect.objectContaining({
+          path: 'name[0].given'
+        })
+      );
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        'Value in Instance complex-patient-of-http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient at path name[0].given is empty.'
+      );
+    });
   });
 });


### PR DESCRIPTION
Fixes #118 and completes task [CIMPL-760](https://standardhealthrecord.atlassian.net/browse/CIMPL-760).

When input JSON contains an empty list, an empty object, or an explicit null or undefined, do not create a rule that uses that empty value. These values are not valid FHIR, and would result in invalid FSH. Display an error message to the user so they know the value is being ignored.

The original issue only mentioned empty lists, but I check for other empty values that should also be avoided.