### PR TITLE
Organize FSH files per definition by type

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Options:
   -d, --dependency <dependency...> specify dependencies to be loaded using format dependencyId@version (FHIR R4 included by default)
   -v, --version                    print goFSH version
   -h, --help                       display help for command
-  -s, --style                      specify how the output is organized into files: group-by-fsh-type (default), group-by-profile, single-file, file-per-definition, files-organized-by-type
+  -s, --style                      specify how the output is organized into files: file-per-definition (default), group-by-fsh-type, group-by-profile, single-file
   -f, --fshing-trip                run SUSHI on the output of GoFSH and generate a comparison of the round trip results
   -t, --file-type                  specify which file types GoFSH should accept as input: json-only (default), xml-only, json-and-xml
   -i, --installed-sushi            use the locally installed version of SUSHI when generating comparisons with the "-f" option

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Options:
   -d, --dependency <dependency...> specify dependencies to be loaded using format dependencyId@version (FHIR R4 included by default)
   -v, --version                    print goFSH version
   -h, --help                       display help for command
-  -s, --style                      specify how the output is organized into files: group-by-fsh-type (default), group-by-profile, single-file, file-per-definition
+  -s, --style                      specify how the output is organized into files: group-by-fsh-type (default), group-by-profile, single-file, file-per-definition, files-organized-by-type
   -f, --fshing-trip                run SUSHI on the output of GoFSH and generate a comparison of the round trip results
   -t, --file-type                  specify which file types GoFSH should accept as input: json-only (default), xml-only, json-and-xml
   -i, --installed-sushi            use the locally installed version of SUSHI when generating comparisons with the "-f" option

--- a/src/app.ts
+++ b/src/app.ts
@@ -43,7 +43,7 @@ async function app() {
     )
     .option(
       '-s, --style <style>',
-      'specify how the output is organized into files: group-by-fsh-type (default), group-by-profile, single-file, file-per-definition'
+      'specify how the output is organized into files: group-by-fsh-type (default), group-by-profile, single-file, file-per-definition, files-organized-by-type'
     )
     .option(
       '-f, --fshing-trip',

--- a/src/app.ts
+++ b/src/app.ts
@@ -43,7 +43,7 @@ async function app() {
     )
     .option(
       '-s, --style <style>',
-      'specify how the output is organized into files: group-by-fsh-type (default), group-by-profile, single-file, file-per-definition, files-organized-by-type'
+      'specify how the output is organized into files: file-per-definition (default), group-by-fsh-type, group-by-profile, single-file'
     )
     .option(
       '-f, --fshing-trip',

--- a/src/export/FSHExporter.ts
+++ b/src/export/FSHExporter.ts
@@ -38,14 +38,11 @@ export class FSHExporter {
       case 'file-per-definition':
         files = this.groupAsFilePerDefinition();
         break;
-      case 'files-organized-by-type':
-        files = this.groupAsFilePerDefinition(true);
-        break;
       default:
         if (style != null) {
           logger.warn(`Unrecognized output style "${style}". Defaulting to "by-category" style.`);
         }
-        files = this.groupByFSHType();
+        files = this.groupAsFilePerDefinition();
     }
 
     const writtenFiles: Map<string, string> = new Map();
@@ -168,51 +165,46 @@ export class FSHExporter {
     return new Map().set('resources.fsh', results);
   }
 
-  private groupAsFilePerDefinition(byGroup = false): Map<string, Exportable[]> {
+  private groupAsFilePerDefinition(): Map<string, Exportable[]> {
     const files: Map<string, Exportable[]> = new Map();
     // Aliases, still get grouped into one file
     files.set('aliases.fsh', this.fshPackage.aliases);
 
     // Other definitions are each placed in an individual file
     for (const invariant of this.fshPackage.invariants) {
-      const fileDir = byGroup ? 'invariants' : '';
-      const filename = path.join(fileDir, `${invariant.name}-Invariant.fsh`);
+      const filename = path.join('invariants', `${invariant.name}.fsh`);
       files.set(filename, [invariant]);
     }
     for (const mapping of this.fshPackage.mappings) {
-      const fileDir = byGroup ? 'mappings' : '';
-      const filename = path.join(fileDir, `${mapping.name}-Mapping.fsh`);
+      const filename = path.join('mappings', `${mapping.name}.fsh`);
       files.set(filename, [mapping]);
     }
     for (const profile of this.fshPackage.profiles) {
-      const fileDir = byGroup ? 'profiles' : '';
-      const filename = path.join(fileDir, `${profile.name}-Profile.fsh`);
+      const filename = path.join('profiles', `${profile.name}.fsh`);
       files.set(filename, [profile]);
     }
     for (const extension of this.fshPackage.extensions) {
-      const fileDir = byGroup ? 'extensions' : '';
-      const filename = path.join(fileDir, `${extension.name}-Extension.fsh`);
+      const filename = path.join('extensions', `${extension.name}.fsh`);
       files.set(filename, [extension]);
     }
     for (const logical of this.fshPackage.logicals) {
-      files.set(`${logical.name}-Logical.fsh`, [logical]);
+      const filename = path.join('logicals', `${logical.name}.fsh`);
+      files.set(filename, [logical]);
     }
     for (const resource of this.fshPackage.resources) {
-      files.set(`${resource.name}-Resource.fsh`, [resource]);
+      const filename = path.join('resources', `${resource.name}.fsh`);
+      files.set(filename, [resource]);
     }
     for (const codeSystem of this.fshPackage.codeSystems) {
-      const fileDir = byGroup ? 'codesystems' : '';
-      const filename = path.join(fileDir, `${codeSystem.name}-CodeSystem.fsh`);
+      const filename = path.join('codesystems', `${codeSystem.name}.fsh`);
       files.set(filename, [codeSystem]);
     }
     for (const valueSet of this.fshPackage.valueSets) {
-      const fileDir = byGroup ? 'valuesets' : '';
-      const filename = path.join(fileDir, `${valueSet.name}-ValueSet.fsh`);
+      const filename = path.join('valuesets', `${valueSet.name}.fsh`);
       files.set(filename, [valueSet]);
     }
     for (const instance of this.fshPackage.instances) {
-      const fileDir = byGroup ? 'instances' : '';
-      const filename = path.join(fileDir, `${instance.name}-Instance.fsh`);
+      const filename = path.join('instances', `${instance.name}.fsh`);
       files.set(filename, [instance]);
     }
 

--- a/src/export/FSHExporter.ts
+++ b/src/export/FSHExporter.ts
@@ -1,6 +1,7 @@
 import table from 'text-table';
 import { partition } from 'lodash';
 import { EOL } from 'os';
+import path from 'path';
 import {
   Exportable,
   ExportableAlias,
@@ -36,6 +37,9 @@ export class FSHExporter {
         break;
       case 'file-per-definition':
         files = this.groupAsFilePerDefinition();
+        break;
+      case 'files-organized-by-type':
+        files = this.groupAsFilePerDefinition(true);
         break;
       default:
         if (style != null) {
@@ -164,23 +168,31 @@ export class FSHExporter {
     return new Map().set('resources.fsh', results);
   }
 
-  private groupAsFilePerDefinition(): Map<string, Exportable[]> {
+  private groupAsFilePerDefinition(byGroup = false): Map<string, Exportable[]> {
     const files: Map<string, Exportable[]> = new Map();
     // Aliases, still get grouped into one file
     files.set('aliases.fsh', this.fshPackage.aliases);
 
     // Other definitions are each placed in an individual file
     for (const invariant of this.fshPackage.invariants) {
-      files.set(`${invariant.name}-Invariant.fsh`, [invariant]);
+      const fileDir = byGroup ? 'invariants' : '';
+      const filename = path.join(fileDir, `${invariant.name}-Invariant.fsh`);
+      files.set(filename, [invariant]);
     }
     for (const mapping of this.fshPackage.mappings) {
-      files.set(`${mapping.name}-Mapping.fsh`, [mapping]);
+      const fileDir = byGroup ? 'mappings' : '';
+      const filename = path.join(fileDir, `${mapping.name}-Mapping.fsh`);
+      files.set(filename, [mapping]);
     }
     for (const profile of this.fshPackage.profiles) {
-      files.set(`${profile.name}-Profile.fsh`, [profile]);
+      const fileDir = byGroup ? 'profiles' : '';
+      const filename = path.join(fileDir, `${profile.name}-Profile.fsh`);
+      files.set(filename, [profile]);
     }
     for (const extension of this.fshPackage.extensions) {
-      files.set(`${extension.name}-Extension.fsh`, [extension]);
+      const fileDir = byGroup ? 'extensions' : '';
+      const filename = path.join(fileDir, `${extension.name}-Extension.fsh`);
+      files.set(filename, [extension]);
     }
     for (const logical of this.fshPackage.logicals) {
       files.set(`${logical.name}-Logical.fsh`, [logical]);
@@ -189,13 +201,19 @@ export class FSHExporter {
       files.set(`${resource.name}-Resource.fsh`, [resource]);
     }
     for (const codeSystem of this.fshPackage.codeSystems) {
-      files.set(`${codeSystem.name}-CodeSystem.fsh`, [codeSystem]);
+      const fileDir = byGroup ? 'codesystems' : '';
+      const filename = path.join(fileDir, `${codeSystem.name}-CodeSystem.fsh`);
+      files.set(filename, [codeSystem]);
     }
     for (const valueSet of this.fshPackage.valueSets) {
-      files.set(`${valueSet.name}-ValueSet.fsh`, [valueSet]);
+      const fileDir = byGroup ? 'valuesets' : '';
+      const filename = path.join(fileDir, `${valueSet.name}-ValueSet.fsh`);
+      files.set(filename, [valueSet]);
     }
     for (const instance of this.fshPackage.instances) {
-      files.set(`${instance.name}-Instance.fsh`, [instance]);
+      const fileDir = byGroup ? 'instances' : '';
+      const filename = path.join(fileDir, `${instance.name}-Instance.fsh`);
+      files.set(filename, [instance]);
     }
 
     return files;

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -77,8 +77,8 @@ export function writeFSH(resources: Package, outDir: string, style: string): voi
   const exporter = new FSHExporter(resources);
   try {
     const resourceDir = path.join(outDir, 'input', 'fsh');
-    fs.ensureDirSync(resourceDir);
     exporter.export(style).forEach((content, name) => {
+      fs.ensureFileSync(path.join(resourceDir, name));
       fs.writeFileSync(path.join(resourceDir, name), content);
     });
     logger.info(`Wrote fsh to ${resourceDir}.`);

--- a/test/export/FSHExporter.test.ts
+++ b/test/export/FSHExporter.test.ts
@@ -60,7 +60,7 @@ describe('FSHExporter', () => {
   it('should not export an empty file', () => {
     myPackage.add(new ExportableProfile('SomeProfile'));
 
-    const result = exporter.export('by-category');
+    const result = exporter.export('group-by-fsh-type');
     // Only the profiles.fsh file should be present in the map
     expect(result).toEqual(
       new Map().set('profiles.fsh', ['Profile: SomeProfile', EOL, 'Id: SomeProfile'].join('')).set(
@@ -242,59 +242,6 @@ describe('FSHExporter', () => {
       myPackage.aliases.push(new ExportableAlias('foo', 'http://example.com/foo'));
 
       const result = exporter.export('group-by-fsh-type');
-      expect(result).toEqual(
-        new Map()
-          .set('aliases.fsh', ['Alias: foo = http://example.com/foo'].join(''))
-          .set('profiles.fsh', ['Profile: SomeProfile', EOL, 'Id: SomeProfile'].join(''))
-          .set('extensions.fsh', ['Extension: SomeExtension', EOL, 'Id: SomeExtension'].join(''))
-          .set('logicals.fsh', ['Logical: SomeLogical', EOL, 'Id: SomeLogical'].join(''))
-          .set('resources.fsh', ['Resource: SomeResource', EOL, 'Id: SomeResource'].join(''))
-          .set('valueSets.fsh', ['ValueSet: SomeValueSet', EOL, 'Id: SomeValueSet'].join(''))
-          .set(
-            'codeSystems.fsh',
-            ['CodeSystem: SomeCodeSystem', EOL, 'Id: SomeCodeSystem'].join('')
-          )
-          .set(
-            'instances.fsh',
-            ['Instance: SomeInstance', EOL, 'InstanceOf: SomeProfile', EOL, 'Usage: #example'].join(
-              ''
-            )
-          )
-          .set('invariants.fsh', ['Invariant: SomeInvariant'].join(''))
-          .set('mappings.fsh', ['Mapping: SomeMapping', EOL, 'Id: SomeMapping'].join(''))
-          .set(
-            'index.txt',
-            table([
-              ['Name', 'Type', 'File'],
-              ['SomeCodeSystem', 'CodeSystem', 'codeSystems.fsh'],
-              ['SomeExtension', 'Extension', 'extensions.fsh'],
-              ['SomeInstance', 'Instance', 'instances.fsh'],
-              ['SomeInvariant', 'Invariant', 'invariants.fsh'],
-              ['SomeLogical', 'Logical', 'logicals.fsh'],
-              ['SomeMapping', 'Mapping', 'mappings.fsh'],
-              ['SomeProfile', 'Profile', 'profiles.fsh'],
-              ['SomeResource', 'Resource', 'resources.fsh'],
-              ['SomeValueSet', 'ValueSet', 'valueSets.fsh']
-            ])
-          )
-      );
-    });
-
-    it('should export to a multiple files grouped by category when style is undefined', () => {
-      myPackage.add(new ExportableProfile('SomeProfile'));
-      myPackage.add(new ExportableExtension('SomeExtension'));
-      myPackage.add(new ExportableLogical('SomeLogical'));
-      myPackage.add(new ExportableResource('SomeResource'));
-      myPackage.add(new ExportableValueSet('SomeValueSet'));
-      myPackage.add(new ExportableCodeSystem('SomeCodeSystem'));
-      const instance = new ExportableInstance('SomeInstance');
-      instance.instanceOf = 'SomeProfile';
-      myPackage.add(instance);
-      myPackage.add(new ExportableInvariant('SomeInvariant'));
-      myPackage.add(new ExportableMapping('SomeMapping'));
-      myPackage.aliases.push(new ExportableAlias('foo', 'http://example.com/foo'));
-
-      const result = exporter.export('by-category');
       expect(result).toEqual(
         new Map()
           .set('aliases.fsh', ['Alias: foo = http://example.com/foo'].join(''))
@@ -601,7 +548,98 @@ describe('FSHExporter', () => {
   });
 
   describe('#groupAsFilePerDefinition', () => {
-    it('should export each definition to its own file when style is "file-per-definition"', () => {
+    it('should export each definition to its own file nested within a folder of its fsh type when style is "file-per-definition"', () => {
+      myPackage.add(new ExportableProfile('SomeProfile'));
+      myPackage.add(new ExportableProfile('AnotherProfile'));
+      myPackage.add(new ExportableExtension('SomeExtension'));
+      myPackage.add(new ExportableLogical('SomeLogical'));
+      myPackage.add(new ExportableResource('SomeResource'));
+      myPackage.add(new ExportableValueSet('SomeValueSet'));
+      myPackage.add(new ExportableCodeSystem('SomeCodeSystem'));
+      const instance = new ExportableInstance('SomeInstance');
+      instance.instanceOf = 'SomeProfile';
+      myPackage.add(instance);
+      const anotherInstance = new ExportableInstance('AnotherInstance');
+      anotherInstance.instanceOf = 'AnotherProfile';
+      myPackage.add(anotherInstance);
+      myPackage.add(new ExportableInvariant('SomeInvariant'));
+      myPackage.add(new ExportableMapping('SomeMapping'));
+      myPackage.aliases.push(new ExportableAlias('foo', 'http://example.com/foo'));
+
+      const result = exporter.export('file-per-definition');
+      expect(result).toEqual(
+        new Map()
+          .set('aliases.fsh', ['Alias: foo = http://example.com/foo'].join(''))
+          .set(path.join('invariants', 'SomeInvariant.fsh'), ['Invariant: SomeInvariant'].join(''))
+          .set(
+            path.join('mappings', 'SomeMapping.fsh'),
+            ['Mapping: SomeMapping', EOL, 'Id: SomeMapping'].join('')
+          )
+          .set(
+            path.join('profiles', 'AnotherProfile.fsh'),
+            ['Profile: AnotherProfile', EOL, 'Id: AnotherProfile'].join('')
+          )
+          .set(
+            path.join('profiles', 'SomeProfile.fsh'),
+            ['Profile: SomeProfile', EOL, 'Id: SomeProfile'].join('')
+          )
+          .set(
+            path.join('extensions', 'SomeExtension.fsh'),
+            ['Extension: SomeExtension', EOL, 'Id: SomeExtension'].join('')
+          )
+          .set(
+            path.join('logicals', 'SomeLogical.fsh'),
+            ['Logical: SomeLogical', EOL, 'Id: SomeLogical'].join('')
+          )
+          .set(
+            path.join('resources', 'SomeResource.fsh'),
+            ['Resource: SomeResource', EOL, 'Id: SomeResource'].join('')
+          )
+          .set(
+            path.join('codesystems', 'SomeCodeSystem.fsh'),
+            ['CodeSystem: SomeCodeSystem', EOL, 'Id: SomeCodeSystem'].join('')
+          )
+          .set(
+            path.join('valuesets', 'SomeValueSet.fsh'),
+            ['ValueSet: SomeValueSet', EOL, 'Id: SomeValueSet'].join('')
+          )
+          .set(
+            path.join('instances', 'AnotherInstance.fsh'),
+            [
+              'Instance: AnotherInstance',
+              EOL,
+              'InstanceOf: AnotherProfile',
+              EOL,
+              'Usage: #example'
+            ].join('')
+          )
+          .set(
+            path.join('instances', 'SomeInstance.fsh'),
+            ['Instance: SomeInstance', EOL, 'InstanceOf: SomeProfile', EOL, 'Usage: #example'].join(
+              ''
+            )
+          )
+          .set(
+            'index.txt',
+            table([
+              ['Name', 'Type', 'File'],
+              ['AnotherInstance', 'Instance', path.join('instances', 'AnotherInstance.fsh')],
+              ['AnotherProfile', 'Profile', path.join('profiles', 'AnotherProfile.fsh')],
+              ['SomeCodeSystem', 'CodeSystem', path.join('codesystems', 'SomeCodeSystem.fsh')],
+              ['SomeExtension', 'Extension', path.join('extensions', 'SomeExtension.fsh')],
+              ['SomeInstance', 'Instance', path.join('instances', 'SomeInstance.fsh')],
+              ['SomeInvariant', 'Invariant', path.join('invariants', 'SomeInvariant.fsh')],
+              ['SomeLogical', 'Logical', path.join('logicals', 'SomeLogical.fsh')],
+              ['SomeMapping', 'Mapping', path.join('mappings', 'SomeMapping.fsh')],
+              ['SomeProfile', 'Profile', path.join('profiles', 'SomeProfile.fsh')],
+              ['SomeResource', 'Resource', path.join('resources', 'SomeResource.fsh')],
+              ['SomeValueSet', 'ValueSet', path.join('valuesets', 'SomeValueSet.fsh')]
+            ])
+          )
+      );
+    });
+
+    it('should export each definition to its own file nested within a folder of its fsh type when style is undefined', () => {
       myPackage.add(new ExportableProfile('SomeProfile'));
       myPackage.add(new ExportableExtension('SomeExtension'));
       myPackage.add(new ExportableLogical('SomeLogical'));
@@ -615,114 +653,41 @@ describe('FSHExporter', () => {
       myPackage.add(new ExportableMapping('SomeMapping'));
       myPackage.aliases.push(new ExportableAlias('foo', 'http://example.com/foo'));
 
-      const result = exporter.export('file-per-definition');
+      const result = exporter.export('unknown-style');
       expect(result).toEqual(
         new Map()
           .set('aliases.fsh', ['Alias: foo = http://example.com/foo'].join(''))
-          .set('SomeInvariant-Invariant.fsh', ['Invariant: SomeInvariant'].join(''))
-          .set('SomeMapping-Mapping.fsh', ['Mapping: SomeMapping', EOL, 'Id: SomeMapping'].join(''))
-          .set('SomeProfile-Profile.fsh', ['Profile: SomeProfile', EOL, 'Id: SomeProfile'].join(''))
+          .set(path.join('invariants', 'SomeInvariant.fsh'), ['Invariant: SomeInvariant'].join(''))
           .set(
-            'SomeExtension-Extension.fsh',
-            ['Extension: SomeExtension', EOL, 'Id: SomeExtension'].join('')
-          )
-          .set('SomeLogical-Logical.fsh', ['Logical: SomeLogical', EOL, 'Id: SomeLogical'].join(''))
-          .set(
-            'SomeResource-Resource.fsh',
-            ['Resource: SomeResource', EOL, 'Id: SomeResource'].join('')
-          )
-          .set(
-            'SomeCodeSystem-CodeSystem.fsh',
-            ['CodeSystem: SomeCodeSystem', EOL, 'Id: SomeCodeSystem'].join('')
-          )
-          .set(
-            'SomeValueSet-ValueSet.fsh',
-            ['ValueSet: SomeValueSet', EOL, 'Id: SomeValueSet'].join('')
-          )
-          .set(
-            'SomeInstance-Instance.fsh',
-            ['Instance: SomeInstance', EOL, 'InstanceOf: SomeProfile', EOL, 'Usage: #example'].join(
-              ''
-            )
-          )
-          .set(
-            'index.txt',
-            table([
-              ['Name', 'Type', 'File'],
-              ['SomeCodeSystem', 'CodeSystem', 'SomeCodeSystem-CodeSystem.fsh'],
-              ['SomeExtension', 'Extension', 'SomeExtension-Extension.fsh'],
-              ['SomeInstance', 'Instance', 'SomeInstance-Instance.fsh'],
-              ['SomeInvariant', 'Invariant', 'SomeInvariant-Invariant.fsh'],
-              ['SomeLogical', 'Logical', 'SomeLogical-Logical.fsh'],
-              ['SomeMapping', 'Mapping', 'SomeMapping-Mapping.fsh'],
-              ['SomeProfile', 'Profile', 'SomeProfile-Profile.fsh'],
-              ['SomeResource', 'Resource', 'SomeResource-Resource.fsh'],
-              ['SomeValueSet', 'ValueSet', 'SomeValueSet-ValueSet.fsh']
-            ])
-          )
-      );
-    });
-
-    it('should export each definition to its own file nested within a folder of its fsh type when style is "files-organized-by-type"', () => {
-      myPackage.add(new ExportableProfile('SomeProfile'));
-      myPackage.add(new ExportableProfile('AnotherProfile'));
-      myPackage.add(new ExportableExtension('SomeExtension'));
-      myPackage.add(new ExportableValueSet('SomeValueSet'));
-      myPackage.add(new ExportableCodeSystem('SomeCodeSystem'));
-      const instance = new ExportableInstance('SomeInstance');
-      instance.instanceOf = 'SomeProfile';
-      myPackage.add(instance);
-      const anotherInstance = new ExportableInstance('AnotherInstance');
-      anotherInstance.instanceOf = 'AnotherProfile';
-      myPackage.add(anotherInstance);
-      myPackage.add(new ExportableInvariant('SomeInvariant'));
-      myPackage.add(new ExportableMapping('SomeMapping'));
-      myPackage.aliases.push(new ExportableAlias('foo', 'http://example.com/foo'));
-
-      const result = exporter.export('files-organized-by-type');
-      expect(result).toEqual(
-        new Map()
-          .set('aliases.fsh', ['Alias: foo = http://example.com/foo'].join(''))
-          .set(
-            path.join('invariants', 'SomeInvariant-Invariant.fsh'),
-            ['Invariant: SomeInvariant'].join('')
-          )
-          .set(
-            path.join('mappings', 'SomeMapping-Mapping.fsh'),
+            path.join('mappings', 'SomeMapping.fsh'),
             ['Mapping: SomeMapping', EOL, 'Id: SomeMapping'].join('')
           )
           .set(
-            path.join('profiles', 'AnotherProfile-Profile.fsh'),
-            ['Profile: AnotherProfile', EOL, 'Id: AnotherProfile'].join('')
-          )
-          .set(
-            path.join('profiles', 'SomeProfile-Profile.fsh'),
+            path.join('profiles', 'SomeProfile.fsh'),
             ['Profile: SomeProfile', EOL, 'Id: SomeProfile'].join('')
           )
           .set(
-            path.join('extensions', 'SomeExtension-Extension.fsh'),
+            path.join('extensions', 'SomeExtension.fsh'),
             ['Extension: SomeExtension', EOL, 'Id: SomeExtension'].join('')
           )
           .set(
-            path.join('codesystems', 'SomeCodeSystem-CodeSystem.fsh'),
+            path.join('logicals', 'SomeLogical.fsh'),
+            ['Logical: SomeLogical', EOL, 'Id: SomeLogical'].join('')
+          )
+          .set(
+            path.join('resources', 'SomeResource.fsh'),
+            ['Resource: SomeResource', EOL, 'Id: SomeResource'].join('')
+          )
+          .set(
+            path.join('codesystems', 'SomeCodeSystem.fsh'),
             ['CodeSystem: SomeCodeSystem', EOL, 'Id: SomeCodeSystem'].join('')
           )
           .set(
-            path.join('valuesets', 'SomeValueSet-ValueSet.fsh'),
+            path.join('valuesets', 'SomeValueSet.fsh'),
             ['ValueSet: SomeValueSet', EOL, 'Id: SomeValueSet'].join('')
           )
           .set(
-            path.join('instances', 'AnotherInstance-Instance.fsh'),
-            [
-              'Instance: AnotherInstance',
-              EOL,
-              'InstanceOf: AnotherProfile',
-              EOL,
-              'Usage: #example'
-            ].join('')
-          )
-          .set(
-            path.join('instances', 'SomeInstance-Instance.fsh'),
+            path.join('instances', 'SomeInstance.fsh'),
             ['Instance: SomeInstance', EOL, 'InstanceOf: SomeProfile', EOL, 'Usage: #example'].join(
               ''
             )
@@ -731,31 +696,15 @@ describe('FSHExporter', () => {
             'index.txt',
             table([
               ['Name', 'Type', 'File'],
-              [
-                'AnotherInstance',
-                'Instance',
-                path.join('instances', 'AnotherInstance-Instance.fsh')
-              ],
-              ['AnotherProfile', 'Profile', path.join('profiles', 'AnotherProfile-Profile.fsh')],
-              [
-                'SomeCodeSystem',
-                'CodeSystem',
-                path.join('codesystems', 'SomeCodeSystem-CodeSystem.fsh')
-              ],
-              [
-                'SomeExtension',
-                'Extension',
-                path.join('extensions', 'SomeExtension-Extension.fsh')
-              ],
-              ['SomeInstance', 'Instance', path.join('instances', 'SomeInstance-Instance.fsh')],
-              [
-                'SomeInvariant',
-                'Invariant',
-                path.join('invariants', 'SomeInvariant-Invariant.fsh')
-              ],
-              ['SomeMapping', 'Mapping', path.join('mappings', 'SomeMapping-Mapping.fsh')],
-              ['SomeProfile', 'Profile', path.join('profiles', 'SomeProfile-Profile.fsh')],
-              ['SomeValueSet', 'ValueSet', path.join('valuesets', 'SomeValueSet-ValueSet.fsh')]
+              ['SomeCodeSystem', 'CodeSystem', path.join('codesystems', 'SomeCodeSystem.fsh')],
+              ['SomeExtension', 'Extension', path.join('extensions', 'SomeExtension.fsh')],
+              ['SomeInstance', 'Instance', path.join('instances', 'SomeInstance.fsh')],
+              ['SomeInvariant', 'Invariant', path.join('invariants', 'SomeInvariant.fsh')],
+              ['SomeLogical', 'Logical', path.join('logicals', 'SomeLogical.fsh')],
+              ['SomeMapping', 'Mapping', path.join('mappings', 'SomeMapping.fsh')],
+              ['SomeProfile', 'Profile', path.join('profiles', 'SomeProfile.fsh')],
+              ['SomeResource', 'Resource', path.join('resources', 'SomeResource.fsh')],
+              ['SomeValueSet', 'ValueSet', path.join('valuesets', 'SomeValueSet.fsh')]
             ])
           )
       );

--- a/test/export/FSHExporter.test.ts
+++ b/test/export/FSHExporter.test.ts
@@ -1,4 +1,5 @@
 import { EOL } from 'os';
+import path from 'path';
 import { FSHExporter } from '../../src/export';
 import { Package } from '../../src/processor';
 import {
@@ -657,6 +658,104 @@ describe('FSHExporter', () => {
               ['SomeProfile', 'Profile', 'SomeProfile-Profile.fsh'],
               ['SomeResource', 'Resource', 'SomeResource-Resource.fsh'],
               ['SomeValueSet', 'ValueSet', 'SomeValueSet-ValueSet.fsh']
+            ])
+          )
+      );
+    });
+
+    it('should export each definition to its own file nested within a folder of its fsh type when style is "files-organized-by-type"', () => {
+      myPackage.add(new ExportableProfile('SomeProfile'));
+      myPackage.add(new ExportableProfile('AnotherProfile'));
+      myPackage.add(new ExportableExtension('SomeExtension'));
+      myPackage.add(new ExportableValueSet('SomeValueSet'));
+      myPackage.add(new ExportableCodeSystem('SomeCodeSystem'));
+      const instance = new ExportableInstance('SomeInstance');
+      instance.instanceOf = 'SomeProfile';
+      myPackage.add(instance);
+      const anotherInstance = new ExportableInstance('AnotherInstance');
+      anotherInstance.instanceOf = 'AnotherProfile';
+      myPackage.add(anotherInstance);
+      myPackage.add(new ExportableInvariant('SomeInvariant'));
+      myPackage.add(new ExportableMapping('SomeMapping'));
+      myPackage.aliases.push(new ExportableAlias('foo', 'http://example.com/foo'));
+
+      const result = exporter.export('files-organized-by-type');
+      expect(result).toEqual(
+        new Map()
+          .set('aliases.fsh', ['Alias: foo = http://example.com/foo'].join(''))
+          .set(
+            path.join('invariants', 'SomeInvariant-Invariant.fsh'),
+            ['Invariant: SomeInvariant'].join('')
+          )
+          .set(
+            path.join('mappings', 'SomeMapping-Mapping.fsh'),
+            ['Mapping: SomeMapping', EOL, 'Id: SomeMapping'].join('')
+          )
+          .set(
+            path.join('profiles', 'AnotherProfile-Profile.fsh'),
+            ['Profile: AnotherProfile', EOL, 'Id: AnotherProfile'].join('')
+          )
+          .set(
+            path.join('profiles', 'SomeProfile-Profile.fsh'),
+            ['Profile: SomeProfile', EOL, 'Id: SomeProfile'].join('')
+          )
+          .set(
+            path.join('extensions', 'SomeExtension-Extension.fsh'),
+            ['Extension: SomeExtension', EOL, 'Id: SomeExtension'].join('')
+          )
+          .set(
+            path.join('codesystems', 'SomeCodeSystem-CodeSystem.fsh'),
+            ['CodeSystem: SomeCodeSystem', EOL, 'Id: SomeCodeSystem'].join('')
+          )
+          .set(
+            path.join('valuesets', 'SomeValueSet-ValueSet.fsh'),
+            ['ValueSet: SomeValueSet', EOL, 'Id: SomeValueSet'].join('')
+          )
+          .set(
+            path.join('instances', 'AnotherInstance-Instance.fsh'),
+            [
+              'Instance: AnotherInstance',
+              EOL,
+              'InstanceOf: AnotherProfile',
+              EOL,
+              'Usage: #example'
+            ].join('')
+          )
+          .set(
+            path.join('instances', 'SomeInstance-Instance.fsh'),
+            ['Instance: SomeInstance', EOL, 'InstanceOf: SomeProfile', EOL, 'Usage: #example'].join(
+              ''
+            )
+          )
+          .set(
+            'index.txt',
+            table([
+              ['Name', 'Type', 'File'],
+              [
+                'AnotherInstance',
+                'Instance',
+                path.join('instances', 'AnotherInstance-Instance.fsh')
+              ],
+              ['AnotherProfile', 'Profile', path.join('profiles', 'AnotherProfile-Profile.fsh')],
+              [
+                'SomeCodeSystem',
+                'CodeSystem',
+                path.join('codesystems', 'SomeCodeSystem-CodeSystem.fsh')
+              ],
+              [
+                'SomeExtension',
+                'Extension',
+                path.join('extensions', 'SomeExtension-Extension.fsh')
+              ],
+              ['SomeInstance', 'Instance', path.join('instances', 'SomeInstance-Instance.fsh')],
+              [
+                'SomeInvariant',
+                'Invariant',
+                path.join('invariants', 'SomeInvariant-Invariant.fsh')
+              ],
+              ['SomeMapping', 'Mapping', path.join('mappings', 'SomeMapping-Mapping.fsh')],
+              ['SomeProfile', 'Profile', path.join('profiles', 'SomeProfile-Profile.fsh')],
+              ['SomeValueSet', 'ValueSet', path.join('valuesets', 'SomeValueSet-ValueSet.fsh')]
             ])
           )
       );

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -354,11 +354,11 @@ describe('Processing', () => {
       expect(fs.existsSync(path.join(tempRoot, 'input', 'fsh', 'resources.fsh'))).toBeTruthy();
     });
 
-    it('should write output to files organized by category when style is by-category', () => {
+    it('should write output to files organized by category when style is group-by-fsh-type', () => {
       const resources = new Package();
       resources.add(new ExportableProfile('Foo'));
       resources.add(new ExportableInstance('Bar'));
-      writeFSH(resources, tempRoot, 'by-category');
+      writeFSH(resources, tempRoot, 'group-by-fsh-type');
       expect(fs.existsSync(path.join(tempRoot, 'input', 'fsh', 'profiles.fsh'))).toBeTruthy();
       expect(fs.existsSync(path.join(tempRoot, 'input', 'fsh', 'instances.fsh'))).toBeTruthy();
     });
@@ -368,8 +368,12 @@ describe('Processing', () => {
       resources.add(new ExportableProfile('Foo'));
       resources.add(new ExportableInstance('Bar'));
       writeFSH(resources, tempRoot, undefined);
-      expect(fs.existsSync(path.join(tempRoot, 'input', 'fsh', 'profiles.fsh'))).toBeTruthy();
-      expect(fs.existsSync(path.join(tempRoot, 'input', 'fsh', 'instances.fsh'))).toBeTruthy();
+      expect(
+        fs.existsSync(path.join(tempRoot, 'input', 'fsh', 'profiles', 'Foo.fsh'))
+      ).toBeTruthy();
+      expect(
+        fs.existsSync(path.join(tempRoot, 'input', 'fsh', 'instances', 'Bar.fsh'))
+      ).toBeTruthy();
     });
 
     it('should write configuration details to a file named sushi-config.yaml in the output directory', () => {


### PR DESCRIPTION
This PR fixes #126 by adding a new output style to GoFSH. The new output style is called `files-organized-by-type` and it outputs an individual file per FSH definition, and each file is organized into a folder based on its FSH entity type. For example, if there are two profiles created, they will be in separate files, both under the `profiles` directory.

There are two questions I'd like input on:
- Is there a clearer name than `files-organized-by-type`? I was trying to come up with a short, but clear, description for this style and that was the best I came up with.
- The issue mentions that this might be the best default option. Is there any reason we would want to avoid updating the default option? If not and if we like this style, I can update the default as part of this PR too.