### PR TITLE
Fix errors in slice cardinality when extracting a contains rule

### DIFF
--- a/src/extractor/ContainsRuleExtractor.ts
+++ b/src/extractor/ContainsRuleExtractor.ts
@@ -32,31 +32,37 @@ export class ContainsRuleExtractor {
     // 1. Check the element differential
     // 2. Check the element snapshot
     // 3. Use defaults: min = 0, max = sliced element's max
-    const cardRule = CardRuleExtractor.process(input, structDef, fisher, false);
-    if (cardRule) {
-      containsRule.cardRules.push(cardRule);
-    } else {
-      // can we get information from the snapshot?
+    // Once both min and max are defined, the CardRule is ready to use.
+    let cardRule = CardRuleExtractor.process(input, structDef, fisher, false);
+    // if no information was available, the extractor will return null. but we need a rule!
+    if (cardRule == null) {
+      cardRule = new ExportableCardRule(elementPath);
+    }
+    // fill in missing information from snapshot
+    if (cardRule.min == null || cardRule.max == null) {
       const snapshotElement = structDef.snapshot?.element.find(el => el.id === input.id);
-      if (snapshotElement?.min != null || snapshotElement?.max != null) {
-        const cardRule = new ExportableCardRule(elementPath);
+      if (cardRule.min == null && snapshotElement?.min != null) {
         cardRule.min = snapshotElement.min;
+      }
+      if (cardRule.max == null && snapshotElement?.max != null) {
         cardRule.max = snapshotElement.max;
-        containsRule.cardRules.push(cardRule);
-      } else {
-        // use defaults, which means check the sliced element's max
-        const slicedElementId = input.id.slice(0, input.id.lastIndexOf(':'));
-        const card = getCardinality(slicedElementId, structDef, fisher);
-        if (card) {
-          const cardRule = new ExportableCardRule(elementPath);
-          cardRule.min = 0;
-          cardRule.max = card.max;
-          containsRule.cardRules.push(cardRule);
-        } else {
-          return null;
-        }
       }
     }
+    // fill in missing information using defaults
+    if (cardRule.min == null) {
+      cardRule.min = 0;
+    }
+    if (cardRule.max == null) {
+      const slicedElementId = input.id.slice(0, input.id.lastIndexOf(':'));
+      const card = getCardinality(slicedElementId, structDef, fisher);
+      if (card) {
+        cardRule.max = card?.max ?? '*';
+      } else {
+        // we couldn't find the cardinality of the sliced element, which means this slice is probably not valid
+        return null;
+      }
+    }
+    containsRule.cardRules.push(cardRule);
     // FlagRule is optional
     const flagRule = FlagRuleExtractor.process(input);
     if (flagRule) {

--- a/test/extractor/ContainsRuleExtractor.test.ts
+++ b/test/extractor/ContainsRuleExtractor.test.ts
@@ -55,14 +55,14 @@ describe('ContainsRuleExtractor', () => {
     expect(element.processedPaths).toEqual(['min', 'max', 'mustSupport', 'sliceName']);
   });
 
-  it('should inherit cardinality on a ContainsRule from the element being sliced', () => {
+  it('should use default cardinality on a ContainsRule when cardinality information is not available', () => {
     const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[7]);
     const containsRule = ContainsRuleExtractor.process(element, looseSD, defs);
     const expectedRule = new ExportableContainsRule('extension');
     expectedRule.items.push({ name: 'Rutabega' });
     const cardRule = new ExportableCardRule('extension[Rutabega]');
-    cardRule.min = 3;
-    cardRule.max = '*';
+    cardRule.min = 0;
+    cardRule.max = '100';
     expectedRule.cardRules.push(cardRule);
     expect(containsRule).toEqual<ExportableContainsRule>(expectedRule);
   });
@@ -88,6 +88,18 @@ describe('ContainsRuleExtractor', () => {
   it('should return null when no cardinality information can be found', () => {
     const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[8]);
     expect(ContainsRuleExtractor.process(element, looseSD, defs)).toBeNull();
+  });
+
+  it('should use cardinality information on the snapshot when the information is not present on the differential', () => {
+    const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[10]);
+    const containsRule = ContainsRuleExtractor.process(element, looseSD, defs);
+    const expectedRule = new ExportableContainsRule('extension');
+    expectedRule.items.push({ name: 'Pomelo' });
+    const cardRule = new ExportableCardRule('extension[Pomelo]');
+    cardRule.max = '3'; // max available on snapshot
+    // there is no min on the differential or snapshot, so the rule only has a max.
+    expectedRule.cardRules.push(cardRule);
+    expect(containsRule).toEqual<ExportableContainsRule>(expectedRule);
   });
 
   it.todo('should extract a ContainsRule with cardinality and a name');

--- a/test/extractor/ContainsRuleExtractor.test.ts
+++ b/test/extractor/ContainsRuleExtractor.test.ts
@@ -85,7 +85,7 @@ describe('ContainsRuleExtractor', () => {
     );
   });
 
-  it('should return null when no cardinality information can be found', () => {
+  it('should return null when no cardinality information can be found for the sliced element', () => {
     const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[8]);
     expect(ContainsRuleExtractor.process(element, looseSD, defs)).toBeNull();
   });
@@ -96,8 +96,8 @@ describe('ContainsRuleExtractor', () => {
     const expectedRule = new ExportableContainsRule('extension');
     expectedRule.items.push({ name: 'Pomelo' });
     const cardRule = new ExportableCardRule('extension[Pomelo]');
+    cardRule.min = 0; // no min on differential or snapshot, so use default slice min
     cardRule.max = '3'; // max available on snapshot
-    // there is no min on the differential or snapshot, so the rule only has a max.
     expectedRule.cardRules.push(cardRule);
     expect(containsRule).toEqual<ExportableContainsRule>(expectedRule);
   });

--- a/test/extractor/fixtures/contains-profile.json
+++ b/test/extractor/fixtures/contains-profile.json
@@ -8,8 +8,12 @@
   "status": "active",
   "url": "http://hl7.org/fhir/us/mcode/StructureDefinition/EggObservation",
   "derivation": "constraint",
-  "differential": {
+  "snapshot": {
     "element": [
+      {
+        "id": "Observation",
+        "path": "Observation"
+      },
       {
         "id": "Observation.extension",
         "path": "Observation.extension",
@@ -23,7 +27,8 @@
           "ordered": false,
           "rules": "open"
         },
-        "min": 3
+        "min": 3,
+        "max": "100"
       },
       {
         "id": "Observation.extension:Oranges",
@@ -75,7 +80,9 @@
         "type": [
           {
             "code": "Extension",
-            "profile": ["http://example.org/StructureDefinition/Pears"]
+            "profile": [
+              "http://example.org/StructureDefinition/Pears"
+            ]
           }
         ],
         "extension": [
@@ -101,6 +108,116 @@
         "sliceName": "Plums",
         "min": 1,
         "max": "4"
+      },
+      {
+        "id": "Observation.extension:Pomelo",
+        "path": "Observation.extension",
+        "sliceName": "Pomelo",
+        "max": "3"
+      }
+    ]
+  },
+  "differential": {
+    "element": [
+      {
+        "id": "Observation.extension",
+        "path": "Observation.extension",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "url"
+            }
+          ],
+          "ordered": false,
+          "rules": "open"
+        },
+        "min": 3,
+        "max": "100"
+      },
+      {
+        "id": "Observation.extension:Oranges",
+        "path": "Observation.extension",
+        "sliceName": "Oranges",
+        "min": 1,
+        "max": "4"
+      },
+      {
+        "id": "Observation.extension:Oranges.url",
+        "path": "Observation.extension.url",
+        "fixedUri": "Oranges"
+      },
+      {
+        "id": "Observation.extension:Apples",
+        "path": "Observation.extension",
+        "sliceName": "Apples",
+        "min": 0,
+        "max": "1",
+        "mustSupport": true
+      },
+      {
+        "id": "Observation.extension:Apples.url",
+        "path": "Observation.extension.url",
+        "fixedUri": "Apples"
+      },
+      {
+        "id": "Observation.extension:Bananas",
+        "path": "Observation.extension",
+        "sliceName": "Bananas",
+        "min": 0,
+        "max": "*",
+        "type": [
+          {
+            "code": "Extension",
+            "profile": [
+              "http://example.org/StructureDefinition/Bananas",
+              "http://example.org/StructureDefinition/NoBananas"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "Observation.extension:Pears",
+        "path": "Observation.extension",
+        "sliceName": "Pears",
+        "min": 2,
+        "max": "2",
+        "type": [
+          {
+            "code": "Extension",
+            "profile": [
+              "http://example.org/StructureDefinition/Pears"
+            ]
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/structuredefinition-standards-status",
+            "valueCode": "normative"
+          }
+        ]
+      },
+      {
+        "id": "Observation.extension:Rutabega",
+        "path": "Observation.extension",
+        "sliceName": "Rutabega"
+      },
+      {
+        "id": "Observation.error:Grapes",
+        "path": "Observation.error:Grapes",
+        "sliceName": "Grapes"
+      },
+      {
+        "id": "Observation.extension:Nectarines",
+        "path": "Observation.extension",
+        "sliceName": "Plums",
+        "min": 1,
+        "max": "4"
+      },
+      {
+        "id": "Observation.extension:Pomelo",
+        "path": "Observation.extension",
+        "sliceName": "Pomelo"
       }
     ]
   }

--- a/test/processor/StructureDefinitionProcessor.test.ts
+++ b/test/processor/StructureDefinitionProcessor.test.ts
@@ -626,7 +626,7 @@ describe('StructureDefinitionProcessor', () => {
       const containsRule = new ExportableContainsRule('category');
       containsRule.items = [{ name: 'Foo' }];
       const cardRule = new ExportableCardRule('category[Foo]');
-      cardRule.min = 1;
+      cardRule.min = 0;
       cardRule.max = '*';
       containsRule.cardRules.push(cardRule);
 


### PR DESCRIPTION
Fixes #135 and completes task [CIMPL-781](https://standardhealthrecord.atlassian.net/browse/CIMPL-781).

When trying to determine the cardinality of a slice, check for min and max in these places:
1. differential
2. snapshot
3. the sliced element's cardinality (only for the max) or a default 0 (only for the min)

Keep looking for a min and a max until both of them are defined. This means that the min and max may come from different sources. If we end up with an undefined max after checking all three places, we give up. This should only happen when the sliced element is not actually defined.