### PR TITLE
Debug message added for large instances

### DIFF
--- a/src/api/FhirToFsh.ts
+++ b/src/api/FhirToFsh.ts
@@ -58,7 +58,7 @@ export async function fhirToFsh(
       }
     }
     if (isProcessableContent(resource, location)) {
-      docs.push(new WildFHIR(resource, location));
+      docs.push(new WildFHIR({ content: resource }, location));
     }
   });
 

--- a/src/processor/FHIRProcessor.ts
+++ b/src/processor/FHIRProcessor.ts
@@ -135,7 +135,7 @@ export class FHIRProcessor {
     instances.forEach((wild, index) => {
       try {
         if (wild.large) {
-          logger.debug(
+          logger.info(
             `Instance ${wild.content.id} is especially large. Processing may take a while.`
           );
         }

--- a/src/processor/FHIRProcessor.ts
+++ b/src/processor/FHIRProcessor.ts
@@ -134,6 +134,11 @@ export class FHIRProcessor {
     if (instances.length > 0) logger.info('Processing Instances...');
     instances.forEach((wild, index) => {
       try {
+        if (wild.large) {
+          logger.debug(
+            `Instance ${wild.content.id} is especially large. Processing may take a while.`
+          );
+        }
         resources.add(InstanceProcessor.process(wild.content, igForConfig?.content, this.fisher));
         this.outputCount(instances, index, 'Instance');
       } catch (ex) {

--- a/src/processor/WildFHIR.ts
+++ b/src/processor/WildFHIR.ts
@@ -4,7 +4,7 @@ export class WildFHIR {
   public readonly large: boolean;
   public readonly content: FHIRResource;
 
-  constructor(file: any, path?: string) {
+  constructor(file: FileImport, path?: string) {
     this.content = file.content;
     this.path = path ?? '';
     this.large = file.large ?? false;

--- a/src/processor/WildFHIR.ts
+++ b/src/processor/WildFHIR.ts
@@ -1,9 +1,15 @@
 // Represents FHIR we find out in the wild.  Usually collected in the LakeOfFHIR.  Similar to RawFSH in SUSHI.
 export class WildFHIR {
   public readonly path: string;
-  constructor(public readonly content: FHIRResource, path?: string) {
+  public readonly large: boolean;
+  public readonly content: FHIRResource;
+
+  constructor(file: any, path?: string) {
+    this.content = file.content;
     this.path = path ?? '';
+    this.large = file.large ?? false;
   }
 }
 
+export type FileImport = { content: FHIRResource; large?: boolean };
 export type FHIRResource = { resourceType?: string; [key: string]: any };

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -206,7 +206,7 @@ function findNonDuplicateSecondaryFiles(files: string[], docs: WildFHIR[]): stri
   });
 }
 
-function readJSONorXML(file: string): any {
+export function readJSONorXML(file: string): FileImport {
   if (file.endsWith('.json')) {
     const buffer = fs.readFileSync(file);
     const importedFile: FileImport = { content: JSON.parse(buffer.toString()) };

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -210,14 +210,14 @@ export function readJSONorXML(file: string): FileImport {
   if (file.endsWith('.json')) {
     const buffer = fs.readFileSync(file);
     const importedFile: FileImport = { content: JSON.parse(buffer.toString()) };
-    if (buffer.length > 200000) {
+    if (buffer.length > LARGE_FILE_BUFFER_LENGTH) {
       importedFile.large = true;
     }
     return importedFile;
   } else if (file.endsWith('.xml')) {
     const buffer = fs.readFileSync(file);
     const importedFile: FileImport = { content: FHIRConverter.xmlToObj(buffer.toString()) };
-    if (buffer.length > 200000) {
+    if (buffer.length > LARGE_FILE_BUFFER_LENGTH) {
       importedFile.large = true;
     }
     return importedFile;
@@ -301,3 +301,5 @@ const IGNORED_NON_RESOURCE_DIRECTORIES = [
   `input${path.sep}images`,
   `input${path.sep}images-source`
 ];
+
+const LARGE_FILE_BUFFER_LENGTH = 200000;

--- a/test/helpers/stockLake.ts
+++ b/test/helpers/stockLake.ts
@@ -9,6 +9,6 @@ export function stockLake(...paths: string[]): LakeOfFHIR {
 
 export function restockLake(lake: LakeOfFHIR, ...paths: string[]): void {
   paths.forEach(p => {
-    lake.docs.push(new WildFHIR(fs.readJSONSync(p), p));
+    lake.docs.push(new WildFHIR({ content: fs.readJSONSync(p) }, p));
   });
 }

--- a/test/helpers/stockLake.ts
+++ b/test/helpers/stockLake.ts
@@ -1,5 +1,5 @@
-import fs from 'fs-extra';
 import { LakeOfFHIR, WildFHIR } from '../../src/processor';
+import { readJSONorXML } from '../../src/utils';
 
 export function stockLake(...paths: string[]): LakeOfFHIR {
   const lake = new LakeOfFHIR([]);
@@ -9,6 +9,7 @@ export function stockLake(...paths: string[]): LakeOfFHIR {
 
 export function restockLake(lake: LakeOfFHIR, ...paths: string[]): void {
   paths.forEach(p => {
-    lake.docs.push(new WildFHIR({ content: fs.readJSONSync(p) }, p));
+    const importedFile = readJSONorXML(p);
+    lake.docs.push(new WildFHIR(importedFile, p));
   });
 }

--- a/test/processor/LakeOfFHIR.test.ts
+++ b/test/processor/LakeOfFHIR.test.ts
@@ -672,6 +672,6 @@ describe('LakeOfHIR', () => {
 function getWildFHIRs(...files: string[]): WildFHIR[] {
   return files.map(f => {
     const fPath = path.join(__dirname, 'fixtures', f);
-    return new WildFHIR(fs.readJSONSync(fPath), fPath);
+    return new WildFHIR({ content: fs.readJSONSync(fPath) }, fPath);
   });
 }

--- a/test/processor/WildFHIR.test.ts
+++ b/test/processor/WildFHIR.test.ts
@@ -3,13 +3,16 @@ import { WildFHIR } from '../../src/processor';
 describe('WildFHIR', () => {
   describe('#constructor', () => {
     it('should set properties correctly when both are provided', () => {
-      const myRawFHIR = new WildFHIR({ resourceType: 'Patient' }, '/path/to/patient.json');
+      const myRawFHIR = new WildFHIR(
+        { content: { resourceType: 'Patient' } },
+        '/path/to/patient.json'
+      );
       expect(myRawFHIR.content).toEqual({ resourceType: 'Patient' });
       expect(myRawFHIR.path).toBe('/path/to/patient.json');
     });
 
     it('should set empty path when no path is provided', () => {
-      const myRawFHIR = new WildFHIR({ resourceType: 'Patient' });
+      const myRawFHIR = new WildFHIR({ content: { resourceType: 'Patient' } });
       expect(myRawFHIR.content).toEqual({ resourceType: 'Patient' });
       expect(myRawFHIR.path).toBe('');
     });

--- a/test/processor/fixtures/large-instance.json
+++ b/test/processor/fixtures/large-instance.json
@@ -1,0 +1,4370 @@
+{
+  "resourceType": "CapabilityStatement",
+  "id": "large-instance",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"> <h2 id=\"title\">US Core Client CapabilityStatement</h2> <ul> <li>Official URL: <code>http://hl7.org/fhir/us/core/CapabilityStatement/us-core-client</code></li> <li>Implementation Guide Version: 3.1.1</li> <li>FHIR Version: 4.0.1</li> <li>Supported formats: <strong>SHALL</strong> support JSON, <strong>SHOULD</strong> support XML </li> <li>Published: 2021-06-17 14:23:50.993763-08:00</li> <li>Published by: HL7 International - US Realm Steering Committee</li> </ul> <p>This Section describes the expected capabilities of the US Core Client which is responsible for creating and initiating the queries for information about an individual patient. The complete list of FHIR profiles, RESTful operations, and search parameters supported by US Core Servers are defined in the <a href=\"CapabilityStatement-us-core-server.html\">Conformance Requirements for Server</a>. US Core Clients have the option of choosing from this list to access necessary data based on their local use cases and other contextual requirements.</p> <h3 class=\"no_toc\" id=\"should_igs\">SHOULD Support the Following Implementation Guides:</h3> <ul> <li><a href=\"http://hl7.org/fhir/smart-app-launch/index.html\">SMART Application Launch Framework Implementation Guide</a></li> </ul> <ul> <li><a href=\"http://hl7.org/fhir/uv/bulkdata/index.html\">Bulk Data Access IG</a></li> </ul> <h3 class=\"no_toc\" id=\"shall_css\">SHALL Implement All Or Parts Of The Following Capability Statements:</h3> <ul> <li><a href=\"CapabilityStatement-us-core-client.html\">US Core Client CapabilityStatement</a></li> </ul> <h3 id=\"behavior\">FHIR RESTful Capabilities</h3> <p>The US Core Client <strong>SHALL</strong>:</p> <ol> <li>Support fetching and querying of one or more US Core profile(s), using the supported RESTful interactions and search parameters declared in the US Core Server CapabilityStatement.</li> </ol> <p id=\"security\"><strong>Security:</strong></p> <ol> <li>See the [General Security Considerations] section for requirements and recommendations.</li> </ol> <p><strong>Summary of System Wide Interactions</strong></p> <ul> <li><strong>MAY</strong> support the <code>transaction</code> interaction.</li> <li><strong>MAY</strong> support the <code>batch</code> interaction.</li> <li><strong>MAY</strong> support the <code>search-system</code> interaction.</li> <li><strong>MAY</strong> support the <code>history-system</code> interaction.</li> </ul> <h3 class=\"no_toc\" id=\"resource-details\">RESTful Capabilities by Resource/Profile:</h3> <h4>Summary</h4> <table class=\"grid\"> <thead> <tr> <th>Resource Type</th> <th>Supported Profiles</th> <th>Supported Searches</th> <th>Supported <code>_includes</code></th> <th>Supported <code>_revincludes</code></th> <th>Supported Operations</th> </tr> </thead> <tbody> <tr> <td> <a href=\"#allergyintolerance\">AllergyIntolerance</a> </td> <td> <a href=\"StructureDefinition-us-core-allergyintolerance.html\">US Core AllergyIntolerance Profile</a> </td> <td> clinical-status, patient patient+clinical-status </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#careplan\">CarePlan</a> </td> <td> <a href=\"StructureDefinition-us-core-careplan.html\">US Core CarePlan Profile</a> </td> <td> category, date, patient, status patient+category+date, patient+category+status+date, patient+category+status, patient+category </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#careteam\">CareTeam</a> </td> <td> <a href=\"StructureDefinition-us-core-careteam.html\">US Core CareTeam Profile</a> </td> <td> patient, status patient+status </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#condition\">Condition</a> </td> <td> <a href=\"StructureDefinition-us-core-condition.html\">US Core Condition Profile</a> </td> <td> category, clinical-status, patient, onset-date, code patient+code, patient+onset-date, patient+clinical-status, patient+category </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#device\">Device</a> </td> <td> <a href=\"StructureDefinition-us-core-implantable-device.html\">US Core Implantable Device Profile</a> </td> <td> patient, type patient+type </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#diagnosticreport\">DiagnosticReport</a> </td> <td> <a href=\"StructureDefinition-us-core-diagnosticreport-lab.html\">US Core DiagnosticReport Profile for Laboratory Results Reporting</a>, <a href=\"StructureDefinition-us-core-diagnosticreport-note.html\">US Core DiagnosticReport Profile for Report and Note exchange</a> </td> <td> status, patient, category, code, date patient+code, patient+code+date, patient+category+date, patient+status, patient+category </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#documentreference\">DocumentReference</a> </td> <td> <a href=\"StructureDefinition-us-core-documentreference.html\">US Core DocumentReference Profile</a> </td> <td> _id, status, patient, category, type, date, period patient+category+date, patient+status, patient+type, patient+type+period, patient+category </td> <td> - </td> <td> Provenance:target </td> <td> docref </td> </tr> <tr> <td> <a href=\"#encounter\">Encounter</a> </td> <td> <a href=\"StructureDefinition-us-core-encounter.html\">US Core Encounter Profile</a> </td> <td> _id, class, date, identifier, patient, status, type patient+type, patient+status, class+patient, date+patient </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#goal\">Goal</a> </td> <td> <a href=\"StructureDefinition-us-core-goal.html\">US Core Goal Profile</a> </td> <td> lifecycle-status, patient, target-date patient+lifecycle-status, patient+target-date </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#immunization\">Immunization</a> </td> <td> <a href=\"StructureDefinition-us-core-immunization.html\">US Core Immunization Profile</a> </td> <td> patient, status, date patient+status, patient+date </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#location\">Location</a> </td> <td> <a href=\"StructureDefinition-us-core-location.html\">US Core Location Profile</a> </td> <td> name, address, address-city, address-state, address-postalcode </td> <td> - </td> <td> - </td> <td> - </td> </tr> <tr> <td> <a href=\"#medication\">Medication</a> </td> <td> <a href=\"StructureDefinition-us-core-medication.html\">US Core Medication Profile</a> </td> <td> - </td> <td> - </td> <td> - </td> <td> - </td> </tr> <tr> <td> <a href=\"#medicationrequest\">MedicationRequest</a> </td> <td> <a href=\"StructureDefinition-us-core-medicationrequest.html\">US Core MedicationRequest Profile</a> </td> <td> status, intent, patient, encounter, authoredon patient+intent+status, patient+intent+authoredon, patient+intent+encounter, patient+intent </td> <td> MedicationRequest:medication </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#observation\">Observation</a> </td> <td> <a href=\"StructureDefinition-us-core-observation-lab.html\">US Core Laboratory Result Observation Profile</a>, <a href=\"StructureDefinition-us-core-vital-signs.html\">US Core Vital Signs Profile</a>, <a href=\"StructureDefinition-us-core-blood-pressure.html\">US Core Blood Pressure Profile</a>, <a href=\"StructureDefinition-us-core-bmi.html\">US Core BMI Profile</a>, <a href=\"StructureDefinition-us-core-head-circumference.html\">US Core Head Circumference Profile</a>, <a href=\"StructureDefinition-us-core-body-height.html\">US Core Body Height Profile</a>, <a href=\"StructureDefinition-us-core-body-weight.html\">US Core Body Weight Profile</a>, <a href=\"StructureDefinition-us-core-body-temperature.html\">US Core Body Temperature Profile</a>, <a href=\"StructureDefinition-us-core-heart-rate.html\">US Core Heart Rate Profile</a>, <a href=\"StructureDefinition-pediatric-bmi-for-age.html\">US Core Pediatric BMI for Age Observation Profile</a>, <a href=\"StructureDefinition-head-occipital-frontal-circumference-percentile.html\">US Core Pediatric Head Occipital-frontal Circumference Percentile Profile</a>, <a href=\"StructureDefinition-pediatric-weight-for-height.html\">US Core Pediatric Weight for Height Observation Profile</a>, <a href=\"StructureDefinition-us-core-pulse-oximetry.html\">US Core Pulse Oximetry Profile</a>, <a href=\"StructureDefinition-us-core-respiratory-rate.html\">US Core Respiratory Rate Profile</a>, <a href=\"StructureDefinition-us-core-smokingstatus.html\">US Core Smoking Status Observation Profile</a> </td> <td> status, category, code, date, patient patient+category+status, patient+code, patient+code+date, patient+category+date, patient+category </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#organization\">Organization</a> </td> <td> <a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a> </td> <td> name, address </td> <td> - </td> <td> - </td> <td> - </td> </tr> <tr> <td> <a href=\"#patient\">Patient</a> </td> <td> <a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a> </td> <td> _id, birthdate, family, gender, given, identifier, name gender+name, family+gender, birthdate+family, birthdate+name </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#practitioner\">Practitioner</a> </td> <td> <a href=\"StructureDefinition-us-core-practitioner.html\">US Core Practitioner Profile</a> </td> <td> name, identifier </td> <td> - </td> <td> - </td> <td> - </td> </tr> <tr> <td> <a href=\"#practitionerrole\">PractitionerRole</a> </td> <td> <a href=\"StructureDefinition-us-core-practitionerrole.html\">US Core PractitionerRole Profile</a> </td> <td> specialty, practitioner </td> <td> PractitionerRole:endpoint, PractitionerRole:practitioner </td> <td> - </td> <td> - </td> </tr> <tr> <td> <a href=\"#procedure\">Procedure</a> </td> <td> <a href=\"StructureDefinition-us-core-procedure.html\">US Core Procedure Profile</a> </td> <td> status, patient, date, code patient+code+date, patient+status, patient+date </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#provenance\">Provenance</a> </td> <td> <a href=\"StructureDefinition-us-core-provenance.html\">US Core Provenance Profile</a> </td> <td> - </td> <td> - </td> <td> - </td> <td> - </td> </tr> <tr> <td> <a href=\"#valueset\">ValueSet</a> </td> <td> - </td> <td> - </td> <td> - </td> <td> - </td> <td> expand </td> </tr> </tbody> </table> <h4 class=\"no_toc\" id=\"allergyintolerance\">AllergyIntolerance</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-allergyintolerance.html\">US Core AllergyIntolerance Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a AllergyIntolerance resource using: <code class=\"highlighter-rouge\">GET [base]/AllergyIntolerance/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/AllergyIntolerance?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-allergyintolerance-clinical-status.html\"> clinical-status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-allergyintolerance-patient.html\"> patient</a> </td> <td> reference </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-clinical-status\"> clinical-status</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-allergyintolerance-clinical-status.html\"> clinical-status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-allergyintolerance-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"careplan\">CarePlan</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>Additional considerations for systems aligning with <a href=\"http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492\">HL7 Consolidated (C-CDA)</a> Care Plan requirements: <ul> <li>US Core Goal <strong>SHOULD</strong> be present in CarePlan.goal</li> <li>US Core Condition <strong>SHOULD</strong> be present in CarePlan.addresses</li> <li>Assement and Plan <strong>MAY</strong> be included as narrative text</li> </ul> </li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-careplan.html\">US Core CarePlan Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a CarePlan resource using: <code class=\"highlighter-rouge\">GET [base]/CarePlan/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/CarePlan?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-careplan-category.html\"> category</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-careplan-date.html\"> date</a> </td> <td> date </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-careplan-patient.html\"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-careplan-status.html\"> status</a> </td> <td> token </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category\"> category</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-date\"> date</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category\"> category</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-status\"> status</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-date\"> date</a> </td> <td>reference+token+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category\"> category</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-status\"> status</a> </td> <td>reference+token+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category\"> category</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-careplan-category.html\"> category</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-careplan-date.html\"> date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li><li><a href=\"SearchParameter-us-core-careplan-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-careplan-status.html\"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"careteam\">CareTeam</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-careteam.html\">US Core CareTeam Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a CareTeam resource using: <code class=\"highlighter-rouge\">GET [base]/CareTeam/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/CareTeam?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-careteam-patient.html\"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-careteam-status.html\"> status</a> </td> <td> token </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-status\"> status</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-careteam-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-careteam-status.html\"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"condition\">Condition</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-condition.html\">US Core Condition Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Condition resource using: <code class=\"highlighter-rouge\">GET [base]/Condition/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/Condition?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-condition-category.html\"> category</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-condition-clinical-status.html\"> clinical-status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-condition-patient.html\"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-condition-onset-date.html\"> onset-date</a> </td> <td> date </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-condition-code.html\"> code</a> </td> <td> token </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-code\"> code</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-onset-date\"> onset-date</a> </td> <td>reference+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-clinical-status\"> clinical-status</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-category\"> category</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-condition-category.html\"> category</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-condition-clinical-status.html\"> clinical-status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-condition-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-condition-onset-date.html\"> onset-date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li><li><a href=\"SearchParameter-us-core-condition-code.html\"> code</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"device\">Device</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li> <p>Implantable medical devices that have UDI information <strong>SHALL</strong> represent the UDI code in <code>Device.udiCarrier.carrierHRF</code>.</p> <ul> <li>All of the five UDI-PI elements that are present in the UDI code <strong>SHALL</strong> be represented in the corresponding US Core Implantable Device Profile element.</li> </ul> <p>UDI may not be present in all scenarios such as historical implantable devices, patient reported implant information, payer reported devices, or improperly documented implants. If UDI is not present and the manufacturer and/or model number information is available, they <strong>SHOULD</strong> be included to support historical reports of implantable medical devices as follows:</p> <table> <thead> <tr class=\"header\"> <th>data element</th> <th>US Core Implantable Device Profile element</th> </tr> </thead> <tbody> <tr class=\"odd\"> <td>manufacturer</td> <td>Device.manufacturer</td> </tr> <tr class=\"even\"> <td>model</td> <td>Device.model</td> </tr> </tbody> </table> </li> <li> <p>Servers <strong>SHOULD</strong> support query by Device.type to allow clients to request the patient's devices by a specific type. Note: The Device.type is too granular to differentiate implantable vs. non-implantable devices.</p> </li> <li> <p>In the Quick Start section below, searching for all devices is described. Records of implanted devices <strong>MAY</strong> be queried against UDI data including:</p> <ul> <li>UDI HRF string (<code>udi-carrier</code>)</li> <li>UDI Device Identifier (<code>udi-di</code>)</li> <li>Manufacturer (<code>manufacturer</code>)</li> <li>Model number (<code>model</code>)</li> </ul> <p>Implementers <strong>MAY</strong> also adopt custom SearchParameters for searching by:</p> <ul> <li>lot numbers</li> <li>serial number</li> <li>expiration date</li> <li>manufacture date</li> <li>distinct identifier</li> </ul> </li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-implantable-device.html\">US Core Implantable Device Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Device resource using: <code class=\"highlighter-rouge\">GET [base]/Device/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/Device?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-device-patient.html\"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-device-type.html\"> type</a> </td> <td> token </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-device-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type\"> type</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-device-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-device-type.html\"> type</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"diagnosticreport\">DiagnosticReport</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-diagnosticreport-lab.html\">US Core DiagnosticReport Profile for Laboratory Results Reporting</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-diagnosticreport-note.html\">US Core DiagnosticReport Profile for Report and Note exchange</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>create</code><sup>&#8224;</sup>, <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <blockquote>create<sup>&#8224;</sup><p>This conformance expectation applies <strong>only</strong> to the <em>US Core DiagnosticReport Profile for Report and Note exchange</em> profile. The conformance expectation for the <em>US Core DiagnosticReport Profile for Laboratory Results Reporting</em> is <strong>MAY</strong>.</p> </blockquote> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a DiagnosticReport resource using: <code class=\"highlighter-rouge\">GET [base]/DiagnosticReport/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/DiagnosticReport?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-diagnosticreport-status.html\"> status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-diagnosticreport-patient.html\"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-diagnosticreport-category.html\"> category</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-diagnosticreport-code.html\"> code</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-diagnosticreport-date.html\"> date</a> </td> <td> date </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-code\"> code</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-code\"> code</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-date\"> date</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-category\"> category</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-date\"> date</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-status\"> status</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-category\"> category</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-diagnosticreport-status.html\"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-diagnosticreport-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-diagnosticreport-category.html\"> category</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-diagnosticreport-code.html\"> code</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-diagnosticreport-date.html\"> date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"documentreference\">DocumentReference</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><p>The DocumentReference.type binding SHALL support at a minimum the <a href=\"ValueSet-us-core-clinical-note-type.html\">5 Common Clinical Notes</a> and may extend to the full US Core DocumentReference Type Value Set</p> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-documentreference.html\">US Core DocumentReference Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>create</code>, <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Operation Summary:</p> <ul> <li><strong>SHOULD</strong> support the <a href=\"OperationDefinition-docref.html\">$docref</a> operation <p>A client <strong>SHOULD</strong> be capable of transacting a $docref operation and capable of receiving at least a reference to a generated CCD document, and <strong>MAY</strong> be able to receive other document types, if available. <strong>SHOULD</strong> be capable of receiving documents as included resources in response to the operation.</p> <p><code>GET [base]/DocumentReference/$docref?patient=[id]</code></p> </li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a DocumentReference resource using: <code class=\"highlighter-rouge\">GET [base]/DocumentReference/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/DocumentReference?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-documentreference-id.html\"> _id</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-documentreference-status.html\"> status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-documentreference-patient.html\"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-documentreference-category.html\"> category</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-documentreference-type.html\"> type</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-documentreference-date.html\"> date</a> </td> <td> date </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-documentreference-period.html\"> period</a> </td> <td> date </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-category\"> category</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-date\"> date</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-status\"> status</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-type\"> type</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-type\"> type</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-period\"> period</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-category\"> category</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-documentreference-status.html\"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-documentreference-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-documentreference-category.html\"> category</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-documentreference-type.html\"> type</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-documentreference-date.html\"> date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li><li><a href=\"SearchParameter-us-core-documentreference-period.html\"> period</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"encounter\">Encounter</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>The Encounter resource can represent a reason using either a code with <code>Encounter.reasonCode</code>, or a reference with <code>Encounter.reasonReference</code> to Condition or other resource. <ul> <li>Although both are marked as must support, the server systems are not required to support both a code and a reference, but they <strong>SHALL</strong> support <em>at least one</em> of these elements.</li> <li>The client application <strong>SHALL</strong> support both elements.</li> <li>if <code>Encounter.reasonReference</code> references an Observation, it <strong>SHOULD</strong> conform to a US Core Observation if applicable. (for example, a laboratory result should conform to the US Core Laboratory Result Observation Profile)</li> </ul> </li> <li>The intent of this profile is to support <em>where the encounter occurred</em>. The location address can be represented by either by the Location referenced by <code>Encounter.location.location</code> or indirectly through the Organization referenced by <code>Encounter.serviceProvider</code>. <ul> <li>Although both are marked as must support, the server systems are not required to support both <code>Encounter.location.location</code> and <code>Encounter.serviceProvider</code>, but they <strong>SHALL</strong> support <em>at least one</em> of these elements.</li> <li>The client application <strong>SHALL</strong> support both elements.</li> <li>if using <code>Encounter.locatison.location</code> it <strong>SHOULD</strong> conform to US Core Location. However, as a result of implementation feedback, it <strong>MAY</strong> reference the base FHIR Location resource. See this guidance on [Referencing US Core Profiles]</li> </ul> </li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-encounter.html\">US Core Encounter Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Encounter resource using: <code class=\"highlighter-rouge\">GET [base]/Encounter/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/Encounter?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-encounter-id.html\"> _id</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-encounter-class.html\"> class</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-encounter-date.html\"> date</a> </td> <td> date </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-encounter-identifier.html\"> identifier</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-encounter-patient.html\"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-encounter-status.html\"> status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-encounter-type.html\"> type</a> </td> <td> token </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-type\"> type</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-status\"> status</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-class\"> class</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient\"> patient</a> </td> <td>token+reference </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-date\"> date</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient\"> patient</a> </td> <td>date+reference </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-encounter-class.html\"> class</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-encounter-date.html\"> date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li><li><a href=\"SearchParameter-us-core-encounter-identifier.html\"> identifier</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-encounter-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-encounter-status.html\"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-encounter-type.html\"> type</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"goal\">Goal</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-goal.html\">US Core Goal Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Goal resource using: <code class=\"highlighter-rouge\">GET [base]/Goal/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/Goal?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-goal-lifecycle-status.html\"> lifecycle-status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-goal-patient.html\"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-goal-target-date.html\"> target-date</a> </td> <td> date </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-lifecycle-status\"> lifecycle-status</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-target-date\"> target-date</a> </td> <td>reference+date </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-goal-lifecycle-status.html\"> lifecycle-status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-goal-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-goal-target-date.html\"> target-date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>day</em>.</p> <p>A server <strong>SHALL</strong> support a value a value precise to the <em>day</em>.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"immunization\">Immunization</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>Based upon the ONC U.S. Core Data for Interoperability (USCDI) v1 requirements, CVX vaccine codes are required and the NDC vaccine codes <strong>SHOULD</strong> be supported as translations to them.</li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-immunization.html\">US Core Immunization Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Immunization resource using: <code class=\"highlighter-rouge\">GET [base]/Immunization/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/Immunization?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-immunization-patient.html\"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-immunization-status.html\"> status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-immunization-date.html\"> date</a> </td> <td> date </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-status\"> status</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-date\"> date</a> </td> <td>reference+date </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-immunization-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-immunization-status.html\"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-immunization-date.html\"> date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"location\">Location</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>The US Core Location and PractitionerRole Profiles are not explicitly referenced in any US Core Profile. However they <strong>SHOULD</strong> be used as the default profile if referenced by another US Core profile.</li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-location.html\">US Core Location Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Location resource using: <code class=\"highlighter-rouge\">GET [base]/Location/[id]</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-location-name.html\"> name</a> </td> <td> string </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-location-address.html\"> address</a> </td> <td> string </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-location-address-city.html\"> address-city</a> </td> <td> string </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-location-address-state.html\"> address-state</a> </td> <td> string </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-location-address-postalcode.html\"> address-postalcode</a> </td> <td> string </td> </tr> </tbody> </table> <hr /> <h4 class=\"no_toc\" id=\"medication\">Medication</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>The MedicationRequest resource can represent a medication, using an external reference to a Medication resource. If an external Medication Resource is used in a MedicationRequest, then the READ <strong>SHALL</strong> be supported.</li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-medication.html\">US Core Medication Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>search-type</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Medication resource using: <code class=\"highlighter-rouge\">GET [base]/Medication/[id]</code> </li> </ul> <hr /> <h4 class=\"no_toc\" id=\"medicationrequest\">MedicationRequest</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>The MedicationRequest resources can represent a medication using either a code or refer to the Medication resource. When referencing Medication, the resource may be <a href=\"http://hl7.org/fhir/R4/references.html#contained\">contained</a> or an external resource. The server application <strong>MAY</strong> choose any one way or more than one method, but if an external reference to Medication is used, the server <strong>SHALL</strong> support the _include` parameter for searching this element. The client application must support all methods.</li> </ul> <p>For example, A server <strong>SHALL</strong> be capable of returning all medications for a patient using one of or both:</p> <p><code>GET /MedicationRequest?patient=[id]</code></p> <p><code>GET /MedicationRequest?patient=[id]&amp;_include=MedicationRequest:medication</code></p> <ul> <li>The MedicationRequest resource can represent that information is from a secondary source using either a boolean flag or reference in <code>MedicationRequest.reportedBoolean</code>, or a reference using <code>MedicationRequest.reportedReference</code> to Practitioner or other resource. <ul> <li>Although both are marked as must support, the server systems are not required to support both a boolean and a reference, but <strong>SHALL</strong> choose to support at least one of these elements.</li> <li>The client application <strong>SHALL</strong> support both elements.</li> </ul> </li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-medicationrequest.html\">US Core MedicationRequest Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a MedicationRequest resource using: <code class=\"highlighter-rouge\">GET [base]/MedicationRequest/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _includes: MedicationRequest:medication - <code class=\"highlighter-rouge\">GET [base]/MedicationRequest?[parameter=value]&amp;_include=MedicationRequest:medication</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/MedicationRequest?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-medicationrequest-status.html\"> status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-medicationrequest-intent.html\"> intent</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-medicationrequest-patient.html\"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-medicationrequest-encounter.html\"> encounter</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-medicationrequest-authoredon.html\"> authoredon</a> </td> <td> date </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent\"> intent</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-status\"> status</a> </td> <td>reference+token+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent\"> intent</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-authoredon\"> authoredon</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent\"> intent</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-encounter\"> encounter</a> </td> <td>reference+token+reference </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent\"> intent</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-medicationrequest-status.html\"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-medicationrequest-intent.html\"> intent</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-medicationrequest-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-medicationrequest-encounter.html\"> encounter</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-medicationrequest-authoredon.html\"> authoredon</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"observation\">Observation</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>Systems <strong>SHOULD</strong> support <code>Observation.effectivePeriod</code> to accurately represent laboratory tests that are collected over a period of time (for example, a 24-Hour Urine Collection test).</li> <li>An Observation without a value, <strong>SHALL</strong> include a reason why the data is absent unless there are component observations, or references to other Observations that are grouped within it.</li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-observation-lab.html\">US Core Laboratory Result Observation Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-vital-signs.html\">US Core Vital Signs Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-blood-pressure.html\">US Core Blood Pressure Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-bmi.html\">US Core BMI Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-head-circumference.html\">US Core Head Circumference Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-body-height.html\">US Core Body Height Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-body-weight.html\">US Core Body Weight Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-body-temperature.html\">US Core Body Temperature Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-heart-rate.html\">US Core Heart Rate Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-pediatric-bmi-for-age.html\">US Core Pediatric BMI for Age Observation Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-head-occipital-frontal-circumference-percentile.html\">US Core Pediatric Head Occipital-frontal Circumference Percentile Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-pediatric-weight-for-height.html\">US Core Pediatric Weight for Height Observation Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-pulse-oximetry.html\">US Core Pulse Oximetry Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-respiratory-rate.html\">US Core Respiratory Rate Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-smokingstatus.html\">US Core Smoking Status Observation Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Observation resource using: <code class=\"highlighter-rouge\">GET [base]/Observation/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/Observation?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-observation-status.html\"> status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-observation-category.html\"> category</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-observation-code.html\"> code</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-observation-date.html\"> date</a> </td> <td> date </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-observation-patient.html\"> patient</a> </td> <td> reference </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category\"> category</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-status\"> status</a> </td> <td>reference+token+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-code\"> code</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-code\"> code</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-date\"> date</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category\"> category</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-date\"> date</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category\"> category</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-observation-status.html\"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-observation-category.html\"> category</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-observation-code.html\"> code</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-observation-date.html\"> date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li><li><a href=\"SearchParameter-us-core-observation-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"organization\">Organization</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Organization resource using: <code class=\"highlighter-rouge\">GET [base]/Organization/[id]</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-organization-name.html\"> name</a> </td> <td> string </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-organization-address.html\"> address</a> </td> <td> string </td> </tr> </tbody> </table> <hr /> <h4 class=\"no_toc\" id=\"patient\">Patient</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>For ONC's USCDI requirements, each Patient must support the following additional elements. These elements are included in the formal definition of the profile. The patient examples include all of these elements.</li> </ul> <ol> <li>contact detail (e.g. a telephone number or an email address)</li> <li>a communication language</li> <li>a race</li> <li>an ethnicity</li> <li>a birth sex*</li> <li>previous name <ul> <li>Previous name is represented by providing an end date in the <code>Patient.name.period</code> element for a previous name.</li> </ul> </li> <li>suffix <ul> <li>Suffix is represented using the <code>Patient.name.suffix</code> element.</li> </ul> </li> </ol> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Patient resource using: <code class=\"highlighter-rouge\">GET [base]/Patient/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/Patient?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-patient-id.html\"> _id</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-patient-birthdate.html\"> birthdate</a> </td> <td> date </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-patient-family.html\"> family</a> </td> <td> string </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-patient-gender.html\"> gender</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-patient-given.html\"> given</a> </td> <td> string </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-patient-identifier.html\"> identifier</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-patient-name.html\"> name</a> </td> <td> string </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender\"> gender</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-name\"> name</a> </td> <td>token+string </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-family\"> family</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender\"> gender</a> </td> <td>string+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-birthdate\"> birthdate</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-family\"> family</a> </td> <td>date+string </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-birthdate\"> birthdate</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-name\"> name</a> </td> <td>date+string </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-patient-birthdate.html\"> birthdate</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>day</em>.</p> <p>A server <strong>SHALL</strong> support a value a value precise to the <em>day</em>.</p> </li><li><a href=\"SearchParameter-us-core-patient-gender.html\"> gender</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-patient-identifier.html\"> identifier</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"practitioner\">Practitioner</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-practitioner.html\">US Core Practitioner Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Practitioner resource using: <code class=\"highlighter-rouge\">GET [base]/Practitioner/[id]</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-practitioner-name.html\"> name</a> </td> <td> string </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-practitioner-identifier.html\"> identifier</a> </td> <td> token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-practitioner-identifier.html\"> identifier</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"practitionerrole\">PractitionerRole</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>The US Core Location and PractitionerRole Profiles are not explicitly referenced in any US Core Profile. However they <strong>SHOULD</strong> be used as the default profile if referenced by another US Core profile.</li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-practitionerrole.html\">US Core PractitionerRole Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a PractitionerRole resource using: <code class=\"highlighter-rouge\">GET [base]/PractitionerRole/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _includes: PractitionerRole:endpoint - <code class=\"highlighter-rouge\">GET [base]/PractitionerRole?[parameter=value]&amp;_include=PractitionerRole:endpoint</code> PractitionerRole:practitioner - <code class=\"highlighter-rouge\">GET [base]/PractitionerRole?[parameter=value]&amp;_include=PractitionerRole:practitioner</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-practitionerrole-specialty.html\"> specialty</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-practitionerrole-practitioner.html\"> practitioner</a> </td> <td> reference </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-practitionerrole-specialty.html\"> specialty</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-practitionerrole-practitioner.html\"> practitioner</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"procedure\">Procedure</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>A procedure including an implantable device <strong>SHOULD</strong> use <code>Procedure.focalDevice</code> with a reference to the [US Core Implantable Device Profile].</li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-procedure.html\">US Core Procedure Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Procedure resource using: <code class=\"highlighter-rouge\">GET [base]/Procedure/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/Procedure?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-procedure-status.html\"> status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-procedure-patient.html\"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-procedure-date.html\"> date</a> </td> <td> date </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-procedure-code.html\"> code</a> </td> <td> token </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-code\"> code</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-date\"> date</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-status\"> status</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-date\"> date</a> </td> <td>reference+date </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-procedure-status.html\"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-procedure-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-procedure-date.html\"> date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li><li><a href=\"SearchParameter-us-core-procedure-code.html\"> code</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"provenance\">Provenance</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>If a system receives a provider in <code>Provenance.agent.who</code> as free text they must capture who sent them the information as the organization. On request they <strong>SHALL</strong> provide this organization as the source and <strong>MAY</strong> include the free text provider.</li> <li>Systems that need to know the activity has occurred <strong>SHOULD</strong> populate the activity.</li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-provenance.html\">US Core Provenance Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>search-type</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Provenance resource using: <code class=\"highlighter-rouge\">GET [base]/Provenance/[id]</code> </li> </ul> <hr /> <h4 class=\"no_toc\" id=\"valueset\">ValueSet</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Operation Summary:</p> <ul> <li><strong>SHOULD</strong> support the <a href=\"http://hl7.org/fhir/OperationDefinition/ValueSet-expand\">$expand</a> operation <p>A client can determine the note and report types support by a server by invoking the standard FHIR Value Set Expansion ($expand) operation defined in the FHIR R4 specification. Because servers may support different read and write formats, it also is used to determine the formats (for example, text, pdf) the server supports read and write transactions.</p> </li> </ul> <hr /> </div>"
+  },
+  "url": "http://example.org/CapabilityStatement/us-core-client",
+  "version": "3.1.1",
+  "name": "UsCoreClientCapabilityStatement",
+  "title": "US Core Client CapabilityStatement",
+  "status": "active",
+  "experimental": false,
+  "date": "2021-06-17T14:23:50.993763-08:00",
+  "publisher": "HL7 International - US Realm Steering Committee",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+        }
+      ]
+    }
+  ],
+  "description": "This Section describes the expected capabilities of the US Core Client which is responsible for creating and initiating the queries for information about an individual patient. The complete list of FHIR profiles, RESTful operations, and search parameters supported by US Core Servers are defined in the [Conformance Requirements for Server](CapabilityStatement-us-core-server.html). US Core Clients have the option of choosing from this list to access necessary data based on their local use cases and other contextual requirements.",
+  "jurisdiction": [
+    {
+      "coding": [
+        {
+          "system": "urn:iso:std:iso:3166",
+          "code": "US"
+        }
+      ]
+    }
+  ],
+  "kind": "requirements",
+  "instantiates": [
+    "http://hl7.org/fhir/us/core/CapabilityStatement/us-core-client"
+  ],
+  "_instantiates": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+          "valueCode": "SHALL"
+        }
+      ]
+    }
+  ],
+  "fhirVersion": "4.0.1",
+  "format": [
+    "json",
+    "xml"
+  ],
+  "_format": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+          "valueCode": "SHALL"
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+          "valueCode": "SHOULD"
+        }
+      ]
+    }
+  ],
+  "patchFormat": [
+    "application/json-patch+json"
+  ],
+  "_patchFormat": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+          "valueCode": "SHOULD"
+        }
+      ]
+    }
+  ],
+  "implementationGuide": [
+    "http://fhir-registry.smarthealthit.org",
+    "http://hl7.org/fhir/uv/bulkdata/ImplementationGuide/hl7.fhir.uv.bulkdata"
+  ],
+  "_implementationGuide": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+          "valueCode": "SHOULD"
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+          "valueCode": "SHOULD"
+        }
+      ]
+    }
+  ],
+  "rest": [
+    {
+      "mode": "client",
+      "documentation": "The US Core Client **SHALL**:\n\n1. Support fetching and querying of one or more US Core profile(s), using the supported RESTful interactions and search parameters declared in the US Core Server CapabilityStatement.\n",
+      "security": {
+        "description": "1. See the [General Security Considerations] section for requirements and recommendations."
+      },
+      "resource": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "clinical-status"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "AllergyIntolerance",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "clinical-status",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-clinical-status",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "category"
+                },
+                {
+                  "url": "required",
+                  "valueString": "date"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "category"
+                },
+                {
+                  "url": "required",
+                  "valueString": "status"
+                },
+                {
+                  "url": "required",
+                  "valueString": "date"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "category"
+                },
+                {
+                  "url": "required",
+                  "valueString": "status"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "category"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "CarePlan",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "* Additional considerations for systems aligning with [HL7 Consolidated (C-CDA)](http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492) Care Plan requirements:\n    - US Core Goal **SHOULD** be present in CarePlan.goal\n    - US Core Condition **SHOULD** be present in CarePlan.addresses\n    - Assement and Plan **MAY** be included as narrative text",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "category",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "date",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-date",
+              "type": "date",
+              "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "status",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-status",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "status"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "CareTeam",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "status",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-status",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "code"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "onset-date"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "clinical-status"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "category"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "Condition",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "category",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-category",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "clinical-status",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-clinical-status",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "onset-date",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-onset-date",
+              "type": "date",
+              "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "code",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-code",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "type"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "Device",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "* Implantable medical devices that have UDI information **SHALL** represent the UDI code in `Device.udiCarrier.carrierHRF`.\n   - All of the five UDI-PI elements that are present in the UDI code **SHALL** be represented in the corresponding US Core Implantable Device Profile element.\n   \n   UDI may not be present in all scenarios such as historical implantable devices, patient reported implant information, payer reported devices, or improperly documented implants. If UDI is not present and the manufacturer and/or model number information is available, they **SHOULD** be included to support historical reports of implantable medical devices as follows:\n\n    <table>\n    <thead>\n    <tr class=\"header\">\n    <th>data element</th>\n    <th>US Core Implantable Device Profile element</th>\n    </tr>\n    </thead>\n    <tbody>\n    <tr class=\"odd\">\n    <td>manufacturer</td>\n    <td>Device.manufacturer</td>\n    </tr>\n    <tr class=\"even\">\n    <td>model</td>\n    <td>Device.model</td>\n    </tr>\n    </tbody>\n    </table>\n\n* Servers **SHOULD** support query by Device.type to allow clients to request the patient's devices by a specific type. Note: The Device.type is too granular to differentiate implantable vs. non-implantable devices.  \n* In the Quick Start section below, searching for all devices is described. Records of implanted devices **MAY** be queried against UDI data including:\n\n    - UDI HRF string (`udi-carrier`)\n    - UDI Device Identifier (`udi-di`)\n    - Manufacturer (`manufacturer`)\n    - Model number (`model`)\n\n  Implementers **MAY** also adopt custom SearchParameters for searching by:\n\n    - lot numbers\n    - serial number\n    - expiration date\n    - manufacture date\n    - distinct identifier",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "type",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "code"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "code"
+                },
+                {
+                  "url": "required",
+                  "valueString": "date"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "category"
+                },
+                {
+                  "url": "required",
+                  "valueString": "date"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "status"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "category"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "DiagnosticReport",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "create",
+              "documentation": "This conformance expectation applies **only**  to the *US Core DiagnosticReport Profile for Report and Note exchange* profile.  The conformance expectation for the *US Core DiagnosticReport Profile for Laboratory Results Reporting* is  **MAY**."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "status",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-status",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "category",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-category",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "code",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-code",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "date",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-date",
+              "type": "date",
+              "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "category"
+                },
+                {
+                  "url": "required",
+                  "valueString": "date"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "status"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "type"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "type"
+                },
+                {
+                  "url": "required",
+                  "valueString": "period"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "category"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "DocumentReference",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "The DocumentReference.type binding SHALL support at a minimum the [5 Common Clinical Notes](ValueSet-us-core-clinical-note-type.html) and may extend to the full US Core DocumentReference Type Value Set",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "_id",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-id",
+              "type": "token"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "status",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-status",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "category",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-category",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "type",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-type",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "date",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-date",
+              "type": "date",
+              "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "period",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-period",
+              "type": "date",
+              "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+            }
+          ],
+          "operation": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "docref",
+              "definition": "http://hl7.org/fhir/us/core/OperationDefinition/docref",
+              "documentation": "A client **SHOULD** be capable of transacting a $docref operation and capable of receiving at least a reference to a generated CCD document, and  **MAY** be able to receive other document types, if available.   **SHOULD**  be capable of receiving documents as included resources in response to the operation.\n\n`GET [base]/DocumentReference/$docref?patient=[id]`"
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "type"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "status"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "class"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "date"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "Encounter",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "* The Encounter resource can represent a reason using either a code with `Encounter.reasonCode`, or a reference with `Encounter.reasonReference` to  Condition or other resource.\n   * Although both are marked as must support, the server systems are not required to support both a code and a reference, but they **SHALL** support *at least one* of these elements.\n   * The client application **SHALL** support both elements.\n   * if `Encounter.reasonReference` references an Observation, it **SHOULD** conform to a US Core Observation if applicable. (for example, a laboratory result should conform to the US Core Laboratory Result Observation Profile)\n* The intent of this profile is to support *where the encounter occurred*.  The location address can be represented by either by the Location referenced by `Encounter.location.location` or indirectly through the Organization referenced by `Encounter.serviceProvider`.\n  * Although both are marked as must support, the server systems are not required to support both `Encounter.location.location` and `Encounter.serviceProvider`, but they **SHALL** support *at least one* of these elements.\n  * The client application **SHALL** support both elements.\n  * if using `Encounter.locatison.location` it **SHOULD** conform to US Core Location.  However, as a result of implementation feedback, it **MAY**  reference the base FHIR Location resource.  See this guidance on [Referencing US Core Profiles]",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "_id",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-id",
+              "type": "token"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "class",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-class",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "date",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-date",
+              "type": "date",
+              "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "identifier",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-identifier",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "status",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-status",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "type",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-type",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "lifecycle-status"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "target-date"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "Goal",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "lifecycle-status",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-lifecycle-status",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "target-date",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-target-date",
+              "type": "date",
+              "documentation": "A client **SHALL** provide a value precise to the *day*.\n\nA server **SHALL** support a value a value precise to the *day*."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "status"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "date"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "Immunization",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "* Based upon the ONC U.S. Core Data for Interoperability (USCDI) v1 requirements, CVX vaccine codes are required and the NDC vaccine codes **SHOULD** be supported as translations to them.",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "status",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-status",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "date",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-date",
+              "type": "date",
+              "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            }
+          ],
+          "type": "Location",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-location"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "* The US Core Location  and PractitionerRole Profiles are not explicitly referenced in any US Core Profile. However they **SHOULD** be used as the default profile if referenced by another US Core profile.",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "name",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-name",
+              "type": "string"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "address",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address",
+              "type": "string"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "address-city",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-city",
+              "type": "string"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "address-state",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-state",
+              "type": "string"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "address-postalcode",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-postalcode",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            }
+          ],
+          "type": "Medication",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "* The  MedicationRequest resource can represent a medication, using an external reference to a Medication resource. If an external Medication Resource is used in a MedicationRequest, then the READ  **SHALL**  be supported.",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "intent"
+                },
+                {
+                  "url": "required",
+                  "valueString": "status"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "intent"
+                },
+                {
+                  "url": "required",
+                  "valueString": "authoredon"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "intent"
+                },
+                {
+                  "url": "required",
+                  "valueString": "encounter"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "intent"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "MedicationRequest",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "* The MedicationRequest resources can represent a medication using either a code or refer to the Medication resource. When referencing Medication, the resource may be [contained](http://hl7.org/fhir/R4/references.html#contained) or an external resource. The server application **MAY** choose any one way or more than one method, but if an external reference to Medication is used, the server **SHALL** support the _include` parameter for searching this element. The client application must support all methods.\n\n For example, A server **SHALL** be capable of returning all medications for a patient using one of or both:\n\n `GET /MedicationRequest?patient=[id]`\n\n `GET /MedicationRequest?patient=[id]&_include=MedicationRequest:medication`\n\n* The MedicationRequest resource can represent that information is from a secondary source using either a boolean flag or reference in `MedicationRequest.reportedBoolean`, or a reference using `MedicationRequest.reportedReference` to Practitioner or other resource.\n   *   Although both are marked as must support, the server systems are not required to support both a boolean and a reference, but **SHALL** choose to support at least one of these elements.\n   *  The client application **SHALL** support both elements.",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchInclude": [
+            "MedicationRequest:medication"
+          ],
+          "_searchInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "status",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-status",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "intent",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "encounter",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-encounter",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "authoredon",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-authoredon",
+              "type": "date",
+              "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "category"
+                },
+                {
+                  "url": "required",
+                  "valueString": "status"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "code"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "code"
+                },
+                {
+                  "url": "required",
+                  "valueString": "date"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "category"
+                },
+                {
+                  "url": "required",
+                  "valueString": "date"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "category"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "Observation",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-head-circumference",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-temperature",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate",
+            "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age",
+            "http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile",
+            "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-respiratory-rate",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "* Systems **SHOULD** support `Observation.effectivePeriod` to accurately represent laboratory tests that are collected over a period of time (for example, a 24-Hour Urine Collection test).\n* An Observation without a value, **SHALL** include a reason why the data is absent unless there are component observations, or references to other Observations that are grouped within it.",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "status",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-status",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "category",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "code",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-code",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "date",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-date",
+              "type": "date",
+              "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            }
+          ],
+          "type": "Organization",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "name",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-name",
+              "type": "string"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "address",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-address",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "gender"
+                },
+                {
+                  "url": "required",
+                  "valueString": "name"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "family"
+                },
+                {
+                  "url": "required",
+                  "valueString": "gender"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "birthdate"
+                },
+                {
+                  "url": "required",
+                  "valueString": "family"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "birthdate"
+                },
+                {
+                  "url": "required",
+                  "valueString": "name"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "Patient",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "* For ONC's USCDI requirements, each Patient must support the following additional elements. These elements are included in the formal definition of the profile. The patient examples include all of these elements.\n\n1. contact detail (e.g. a telephone number or an email address)\n1. a communication language\n1. a race\n1. an ethnicity\n1. a birth sex*\n1. previous name\n   - Previous name is represented by providing an end date in the `Patient.name.period` element for a previous name.\n1. suffix\n   - Suffix is represented using the `Patient.name.suffix` element.\n\n",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "_id",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-id",
+              "type": "token"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "birthdate",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-birthdate",
+              "type": "date",
+              "documentation": "A client **SHALL** provide a value precise to the *day*.\n\nA server **SHALL** support a value a value precise to the *day*."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "family",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-family",
+              "type": "string"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "gender",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "given",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-given",
+              "type": "string"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "identifier",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-identifier",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "name",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-name",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            }
+          ],
+          "type": "Practitioner",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "name",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-name",
+              "type": "string"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "identifier",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-identifier",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            }
+          ],
+          "type": "PractitionerRole",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "* The US Core Location  and PractitionerRole Profiles are not explicitly referenced in any US Core Profile. However they **SHOULD** be used as the default profile if referenced by another US Core profile.",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchInclude": [
+            "PractitionerRole:endpoint",
+            "PractitionerRole:practitioner"
+          ],
+          "_searchInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "specialty",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-specialty",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "practitioner",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-practitioner",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "code"
+                },
+                {
+                  "url": "required",
+                  "valueString": "date"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "status"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "date"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "Procedure",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "*  A procedure including an implantable device **SHOULD** use `Procedure.focalDevice` with a reference to the [US Core Implantable Device Profile].",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "status",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-status",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "date",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-date",
+              "type": "date",
+              "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "code",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-code",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            }
+          ],
+          "type": "Provenance",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "* If a system receives a provider in `Provenance.agent.who` as free text they must capture who sent them the information as the organization. On request they **SHALL** provide this organization as the source and **MAY** include the free text provider.\n* Systems that need to know the activity has occurred **SHOULD** populate the activity.",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            }
+          ],
+          "type": "ValueSet",
+          "operation": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "expand",
+              "definition": "http://hl7.org/fhir/OperationDefinition/ValueSet-expand",
+              "documentation": "A  client can determine the note and report types support by a server by invoking the standard FHIR Value Set Expansion ($expand) operation defined in the FHIR R4 specification. Because servers may support different read and write formats, it also is used to determine the formats (for example, text, pdf) the server supports read and write transactions."
+            }
+          ]
+        }
+      ],
+      "interaction": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "MAY"
+            }
+          ],
+          "code": "transaction"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "MAY"
+            }
+          ],
+          "code": "batch"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "MAY"
+            }
+          ],
+          "code": "search-system"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "MAY"
+            }
+          ],
+          "code": "history-system"
+        }
+      ]
+    }
+  ]
+}

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -418,12 +418,7 @@ describe('Processing', () => {
     it('should properly read json and xml files', () => {
       const FHIRProcessor = new Fhir();
 
-      const JSONFilePath = path.join(
-        __dirname,
-        'fixtures',
-        'instance-files',
-        'small-instance.json'
-      );
+      const JSONFilePath = path.join(__dirname, 'fixtures', 'only-json', 'patient.json');
       const XMLFilePath = path.join(__dirname, 'fixtures', 'only-xml', 'patient.xml');
 
       const jsonFileImport = readJSONorXML(JSONFilePath);

--- a/test/utils/fixtures/instance-files/large-instance.json
+++ b/test/utils/fixtures/instance-files/large-instance.json
@@ -1,0 +1,4370 @@
+{
+  "resourceType": "CapabilityStatement",
+  "id": "us-core-client",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"> <h2 id=\"title\">US Core Client CapabilityStatement</h2> <ul> <li>Official URL: <code>http://hl7.org/fhir/us/core/CapabilityStatement/us-core-client</code></li> <li>Implementation Guide Version: 3.1.1</li> <li>FHIR Version: 4.0.1</li> <li>Supported formats: <strong>SHALL</strong> support JSON, <strong>SHOULD</strong> support XML </li> <li>Published: 2021-06-17 14:23:50.993763-08:00</li> <li>Published by: HL7 International - US Realm Steering Committee</li> </ul> <p>This Section describes the expected capabilities of the US Core Client which is responsible for creating and initiating the queries for information about an individual patient. The complete list of FHIR profiles, RESTful operations, and search parameters supported by US Core Servers are defined in the <a href=\"CapabilityStatement-us-core-server.html\">Conformance Requirements for Server</a>. US Core Clients have the option of choosing from this list to access necessary data based on their local use cases and other contextual requirements.</p> <h3 class=\"no_toc\" id=\"should_igs\">SHOULD Support the Following Implementation Guides:</h3> <ul> <li><a href=\"http://hl7.org/fhir/smart-app-launch/index.html\">SMART Application Launch Framework Implementation Guide</a></li> </ul> <ul> <li><a href=\"http://hl7.org/fhir/uv/bulkdata/index.html\">Bulk Data Access IG</a></li> </ul> <h3 class=\"no_toc\" id=\"shall_css\">SHALL Implement All Or Parts Of The Following Capability Statements:</h3> <ul> <li><a href=\"CapabilityStatement-us-core-client.html\">US Core Client CapabilityStatement</a></li> </ul> <h3 id=\"behavior\">FHIR RESTful Capabilities</h3> <p>The US Core Client <strong>SHALL</strong>:</p> <ol> <li>Support fetching and querying of one or more US Core profile(s), using the supported RESTful interactions and search parameters declared in the US Core Server CapabilityStatement.</li> </ol> <p id=\"security\"><strong>Security:</strong></p> <ol> <li>See the [General Security Considerations] section for requirements and recommendations.</li> </ol> <p><strong>Summary of System Wide Interactions</strong></p> <ul> <li><strong>MAY</strong> support the <code>transaction</code> interaction.</li> <li><strong>MAY</strong> support the <code>batch</code> interaction.</li> <li><strong>MAY</strong> support the <code>search-system</code> interaction.</li> <li><strong>MAY</strong> support the <code>history-system</code> interaction.</li> </ul> <h3 class=\"no_toc\" id=\"resource-details\">RESTful Capabilities by Resource/Profile:</h3> <h4>Summary</h4> <table class=\"grid\"> <thead> <tr> <th>Resource Type</th> <th>Supported Profiles</th> <th>Supported Searches</th> <th>Supported <code>_includes</code></th> <th>Supported <code>_revincludes</code></th> <th>Supported Operations</th> </tr> </thead> <tbody> <tr> <td> <a href=\"#allergyintolerance\">AllergyIntolerance</a> </td> <td> <a href=\"StructureDefinition-us-core-allergyintolerance.html\">US Core AllergyIntolerance Profile</a> </td> <td> clinical-status, patient patient+clinical-status </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#careplan\">CarePlan</a> </td> <td> <a href=\"StructureDefinition-us-core-careplan.html\">US Core CarePlan Profile</a> </td> <td> category, date, patient, status patient+category+date, patient+category+status+date, patient+category+status, patient+category </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#careteam\">CareTeam</a> </td> <td> <a href=\"StructureDefinition-us-core-careteam.html\">US Core CareTeam Profile</a> </td> <td> patient, status patient+status </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#condition\">Condition</a> </td> <td> <a href=\"StructureDefinition-us-core-condition.html\">US Core Condition Profile</a> </td> <td> category, clinical-status, patient, onset-date, code patient+code, patient+onset-date, patient+clinical-status, patient+category </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#device\">Device</a> </td> <td> <a href=\"StructureDefinition-us-core-implantable-device.html\">US Core Implantable Device Profile</a> </td> <td> patient, type patient+type </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#diagnosticreport\">DiagnosticReport</a> </td> <td> <a href=\"StructureDefinition-us-core-diagnosticreport-lab.html\">US Core DiagnosticReport Profile for Laboratory Results Reporting</a>, <a href=\"StructureDefinition-us-core-diagnosticreport-note.html\">US Core DiagnosticReport Profile for Report and Note exchange</a> </td> <td> status, patient, category, code, date patient+code, patient+code+date, patient+category+date, patient+status, patient+category </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#documentreference\">DocumentReference</a> </td> <td> <a href=\"StructureDefinition-us-core-documentreference.html\">US Core DocumentReference Profile</a> </td> <td> _id, status, patient, category, type, date, period patient+category+date, patient+status, patient+type, patient+type+period, patient+category </td> <td> - </td> <td> Provenance:target </td> <td> docref </td> </tr> <tr> <td> <a href=\"#encounter\">Encounter</a> </td> <td> <a href=\"StructureDefinition-us-core-encounter.html\">US Core Encounter Profile</a> </td> <td> _id, class, date, identifier, patient, status, type patient+type, patient+status, class+patient, date+patient </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#goal\">Goal</a> </td> <td> <a href=\"StructureDefinition-us-core-goal.html\">US Core Goal Profile</a> </td> <td> lifecycle-status, patient, target-date patient+lifecycle-status, patient+target-date </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#immunization\">Immunization</a> </td> <td> <a href=\"StructureDefinition-us-core-immunization.html\">US Core Immunization Profile</a> </td> <td> patient, status, date patient+status, patient+date </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#location\">Location</a> </td> <td> <a href=\"StructureDefinition-us-core-location.html\">US Core Location Profile</a> </td> <td> name, address, address-city, address-state, address-postalcode </td> <td> - </td> <td> - </td> <td> - </td> </tr> <tr> <td> <a href=\"#medication\">Medication</a> </td> <td> <a href=\"StructureDefinition-us-core-medication.html\">US Core Medication Profile</a> </td> <td> - </td> <td> - </td> <td> - </td> <td> - </td> </tr> <tr> <td> <a href=\"#medicationrequest\">MedicationRequest</a> </td> <td> <a href=\"StructureDefinition-us-core-medicationrequest.html\">US Core MedicationRequest Profile</a> </td> <td> status, intent, patient, encounter, authoredon patient+intent+status, patient+intent+authoredon, patient+intent+encounter, patient+intent </td> <td> MedicationRequest:medication </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#observation\">Observation</a> </td> <td> <a href=\"StructureDefinition-us-core-observation-lab.html\">US Core Laboratory Result Observation Profile</a>, <a href=\"StructureDefinition-us-core-vital-signs.html\">US Core Vital Signs Profile</a>, <a href=\"StructureDefinition-us-core-blood-pressure.html\">US Core Blood Pressure Profile</a>, <a href=\"StructureDefinition-us-core-bmi.html\">US Core BMI Profile</a>, <a href=\"StructureDefinition-us-core-head-circumference.html\">US Core Head Circumference Profile</a>, <a href=\"StructureDefinition-us-core-body-height.html\">US Core Body Height Profile</a>, <a href=\"StructureDefinition-us-core-body-weight.html\">US Core Body Weight Profile</a>, <a href=\"StructureDefinition-us-core-body-temperature.html\">US Core Body Temperature Profile</a>, <a href=\"StructureDefinition-us-core-heart-rate.html\">US Core Heart Rate Profile</a>, <a href=\"StructureDefinition-pediatric-bmi-for-age.html\">US Core Pediatric BMI for Age Observation Profile</a>, <a href=\"StructureDefinition-head-occipital-frontal-circumference-percentile.html\">US Core Pediatric Head Occipital-frontal Circumference Percentile Profile</a>, <a href=\"StructureDefinition-pediatric-weight-for-height.html\">US Core Pediatric Weight for Height Observation Profile</a>, <a href=\"StructureDefinition-us-core-pulse-oximetry.html\">US Core Pulse Oximetry Profile</a>, <a href=\"StructureDefinition-us-core-respiratory-rate.html\">US Core Respiratory Rate Profile</a>, <a href=\"StructureDefinition-us-core-smokingstatus.html\">US Core Smoking Status Observation Profile</a> </td> <td> status, category, code, date, patient patient+category+status, patient+code, patient+code+date, patient+category+date, patient+category </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#organization\">Organization</a> </td> <td> <a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a> </td> <td> name, address </td> <td> - </td> <td> - </td> <td> - </td> </tr> <tr> <td> <a href=\"#patient\">Patient</a> </td> <td> <a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a> </td> <td> _id, birthdate, family, gender, given, identifier, name gender+name, family+gender, birthdate+family, birthdate+name </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#practitioner\">Practitioner</a> </td> <td> <a href=\"StructureDefinition-us-core-practitioner.html\">US Core Practitioner Profile</a> </td> <td> name, identifier </td> <td> - </td> <td> - </td> <td> - </td> </tr> <tr> <td> <a href=\"#practitionerrole\">PractitionerRole</a> </td> <td> <a href=\"StructureDefinition-us-core-practitionerrole.html\">US Core PractitionerRole Profile</a> </td> <td> specialty, practitioner </td> <td> PractitionerRole:endpoint, PractitionerRole:practitioner </td> <td> - </td> <td> - </td> </tr> <tr> <td> <a href=\"#procedure\">Procedure</a> </td> <td> <a href=\"StructureDefinition-us-core-procedure.html\">US Core Procedure Profile</a> </td> <td> status, patient, date, code patient+code+date, patient+status, patient+date </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href=\"#provenance\">Provenance</a> </td> <td> <a href=\"StructureDefinition-us-core-provenance.html\">US Core Provenance Profile</a> </td> <td> - </td> <td> - </td> <td> - </td> <td> - </td> </tr> <tr> <td> <a href=\"#valueset\">ValueSet</a> </td> <td> - </td> <td> - </td> <td> - </td> <td> - </td> <td> expand </td> </tr> </tbody> </table> <h4 class=\"no_toc\" id=\"allergyintolerance\">AllergyIntolerance</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-allergyintolerance.html\">US Core AllergyIntolerance Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a AllergyIntolerance resource using: <code class=\"highlighter-rouge\">GET [base]/AllergyIntolerance/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/AllergyIntolerance?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-allergyintolerance-clinical-status.html\"> clinical-status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-allergyintolerance-patient.html\"> patient</a> </td> <td> reference </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-clinical-status\"> clinical-status</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-allergyintolerance-clinical-status.html\"> clinical-status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-allergyintolerance-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"careplan\">CarePlan</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>Additional considerations for systems aligning with <a href=\"http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492\">HL7 Consolidated (C-CDA)</a> Care Plan requirements: <ul> <li>US Core Goal <strong>SHOULD</strong> be present in CarePlan.goal</li> <li>US Core Condition <strong>SHOULD</strong> be present in CarePlan.addresses</li> <li>Assement and Plan <strong>MAY</strong> be included as narrative text</li> </ul> </li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-careplan.html\">US Core CarePlan Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a CarePlan resource using: <code class=\"highlighter-rouge\">GET [base]/CarePlan/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/CarePlan?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-careplan-category.html\"> category</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-careplan-date.html\"> date</a> </td> <td> date </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-careplan-patient.html\"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-careplan-status.html\"> status</a> </td> <td> token </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category\"> category</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-date\"> date</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category\"> category</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-status\"> status</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-date\"> date</a> </td> <td>reference+token+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category\"> category</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-status\"> status</a> </td> <td>reference+token+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category\"> category</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-careplan-category.html\"> category</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-careplan-date.html\"> date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li><li><a href=\"SearchParameter-us-core-careplan-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-careplan-status.html\"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"careteam\">CareTeam</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-careteam.html\">US Core CareTeam Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a CareTeam resource using: <code class=\"highlighter-rouge\">GET [base]/CareTeam/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/CareTeam?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-careteam-patient.html\"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-careteam-status.html\"> status</a> </td> <td> token </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-status\"> status</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-careteam-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-careteam-status.html\"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"condition\">Condition</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-condition.html\">US Core Condition Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Condition resource using: <code class=\"highlighter-rouge\">GET [base]/Condition/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/Condition?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-condition-category.html\"> category</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-condition-clinical-status.html\"> clinical-status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-condition-patient.html\"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-condition-onset-date.html\"> onset-date</a> </td> <td> date </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-condition-code.html\"> code</a> </td> <td> token </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-code\"> code</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-onset-date\"> onset-date</a> </td> <td>reference+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-clinical-status\"> clinical-status</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-category\"> category</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-condition-category.html\"> category</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-condition-clinical-status.html\"> clinical-status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-condition-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-condition-onset-date.html\"> onset-date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li><li><a href=\"SearchParameter-us-core-condition-code.html\"> code</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"device\">Device</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li> <p>Implantable medical devices that have UDI information <strong>SHALL</strong> represent the UDI code in <code>Device.udiCarrier.carrierHRF</code>.</p> <ul> <li>All of the five UDI-PI elements that are present in the UDI code <strong>SHALL</strong> be represented in the corresponding US Core Implantable Device Profile element.</li> </ul> <p>UDI may not be present in all scenarios such as historical implantable devices, patient reported implant information, payer reported devices, or improperly documented implants. If UDI is not present and the manufacturer and/or model number information is available, they <strong>SHOULD</strong> be included to support historical reports of implantable medical devices as follows:</p> <table> <thead> <tr class=\"header\"> <th>data element</th> <th>US Core Implantable Device Profile element</th> </tr> </thead> <tbody> <tr class=\"odd\"> <td>manufacturer</td> <td>Device.manufacturer</td> </tr> <tr class=\"even\"> <td>model</td> <td>Device.model</td> </tr> </tbody> </table> </li> <li> <p>Servers <strong>SHOULD</strong> support query by Device.type to allow clients to request the patient's devices by a specific type. Note: The Device.type is too granular to differentiate implantable vs. non-implantable devices.</p> </li> <li> <p>In the Quick Start section below, searching for all devices is described. Records of implanted devices <strong>MAY</strong> be queried against UDI data including:</p> <ul> <li>UDI HRF string (<code>udi-carrier</code>)</li> <li>UDI Device Identifier (<code>udi-di</code>)</li> <li>Manufacturer (<code>manufacturer</code>)</li> <li>Model number (<code>model</code>)</li> </ul> <p>Implementers <strong>MAY</strong> also adopt custom SearchParameters for searching by:</p> <ul> <li>lot numbers</li> <li>serial number</li> <li>expiration date</li> <li>manufacture date</li> <li>distinct identifier</li> </ul> </li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-implantable-device.html\">US Core Implantable Device Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Device resource using: <code class=\"highlighter-rouge\">GET [base]/Device/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/Device?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-device-patient.html\"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-device-type.html\"> type</a> </td> <td> token </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-device-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type\"> type</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-device-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-device-type.html\"> type</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"diagnosticreport\">DiagnosticReport</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-diagnosticreport-lab.html\">US Core DiagnosticReport Profile for Laboratory Results Reporting</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-diagnosticreport-note.html\">US Core DiagnosticReport Profile for Report and Note exchange</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>create</code><sup>&#8224;</sup>, <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <blockquote>create<sup>&#8224;</sup><p>This conformance expectation applies <strong>only</strong> to the <em>US Core DiagnosticReport Profile for Report and Note exchange</em> profile. The conformance expectation for the <em>US Core DiagnosticReport Profile for Laboratory Results Reporting</em> is <strong>MAY</strong>.</p> </blockquote> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a DiagnosticReport resource using: <code class=\"highlighter-rouge\">GET [base]/DiagnosticReport/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/DiagnosticReport?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-diagnosticreport-status.html\"> status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-diagnosticreport-patient.html\"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-diagnosticreport-category.html\"> category</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-diagnosticreport-code.html\"> code</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-diagnosticreport-date.html\"> date</a> </td> <td> date </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-code\"> code</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-code\"> code</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-date\"> date</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-category\"> category</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-date\"> date</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-status\"> status</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-category\"> category</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-diagnosticreport-status.html\"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-diagnosticreport-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-diagnosticreport-category.html\"> category</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-diagnosticreport-code.html\"> code</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-diagnosticreport-date.html\"> date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"documentreference\">DocumentReference</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><p>The DocumentReference.type binding SHALL support at a minimum the <a href=\"ValueSet-us-core-clinical-note-type.html\">5 Common Clinical Notes</a> and may extend to the full US Core DocumentReference Type Value Set</p> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-documentreference.html\">US Core DocumentReference Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>create</code>, <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Operation Summary:</p> <ul> <li><strong>SHOULD</strong> support the <a href=\"OperationDefinition-docref.html\">$docref</a> operation <p>A client <strong>SHOULD</strong> be capable of transacting a $docref operation and capable of receiving at least a reference to a generated CCD document, and <strong>MAY</strong> be able to receive other document types, if available. <strong>SHOULD</strong> be capable of receiving documents as included resources in response to the operation.</p> <p><code>GET [base]/DocumentReference/$docref?patient=[id]</code></p> </li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a DocumentReference resource using: <code class=\"highlighter-rouge\">GET [base]/DocumentReference/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/DocumentReference?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-documentreference-id.html\"> _id</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-documentreference-status.html\"> status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-documentreference-patient.html\"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-documentreference-category.html\"> category</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-documentreference-type.html\"> type</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-documentreference-date.html\"> date</a> </td> <td> date </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-documentreference-period.html\"> period</a> </td> <td> date </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-category\"> category</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-date\"> date</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-status\"> status</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-type\"> type</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-type\"> type</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-period\"> period</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-category\"> category</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-documentreference-status.html\"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-documentreference-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-documentreference-category.html\"> category</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-documentreference-type.html\"> type</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-documentreference-date.html\"> date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li><li><a href=\"SearchParameter-us-core-documentreference-period.html\"> period</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"encounter\">Encounter</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>The Encounter resource can represent a reason using either a code with <code>Encounter.reasonCode</code>, or a reference with <code>Encounter.reasonReference</code> to Condition or other resource. <ul> <li>Although both are marked as must support, the server systems are not required to support both a code and a reference, but they <strong>SHALL</strong> support <em>at least one</em> of these elements.</li> <li>The client application <strong>SHALL</strong> support both elements.</li> <li>if <code>Encounter.reasonReference</code> references an Observation, it <strong>SHOULD</strong> conform to a US Core Observation if applicable. (for example, a laboratory result should conform to the US Core Laboratory Result Observation Profile)</li> </ul> </li> <li>The intent of this profile is to support <em>where the encounter occurred</em>. The location address can be represented by either by the Location referenced by <code>Encounter.location.location</code> or indirectly through the Organization referenced by <code>Encounter.serviceProvider</code>. <ul> <li>Although both are marked as must support, the server systems are not required to support both <code>Encounter.location.location</code> and <code>Encounter.serviceProvider</code>, but they <strong>SHALL</strong> support <em>at least one</em> of these elements.</li> <li>The client application <strong>SHALL</strong> support both elements.</li> <li>if using <code>Encounter.locatison.location</code> it <strong>SHOULD</strong> conform to US Core Location. However, as a result of implementation feedback, it <strong>MAY</strong> reference the base FHIR Location resource. See this guidance on [Referencing US Core Profiles]</li> </ul> </li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-encounter.html\">US Core Encounter Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Encounter resource using: <code class=\"highlighter-rouge\">GET [base]/Encounter/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/Encounter?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-encounter-id.html\"> _id</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-encounter-class.html\"> class</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-encounter-date.html\"> date</a> </td> <td> date </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-encounter-identifier.html\"> identifier</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-encounter-patient.html\"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-encounter-status.html\"> status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-encounter-type.html\"> type</a> </td> <td> token </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-type\"> type</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-status\"> status</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-class\"> class</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient\"> patient</a> </td> <td>token+reference </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-date\"> date</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient\"> patient</a> </td> <td>date+reference </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-encounter-class.html\"> class</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-encounter-date.html\"> date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li><li><a href=\"SearchParameter-us-core-encounter-identifier.html\"> identifier</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-encounter-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-encounter-status.html\"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-encounter-type.html\"> type</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"goal\">Goal</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-goal.html\">US Core Goal Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Goal resource using: <code class=\"highlighter-rouge\">GET [base]/Goal/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/Goal?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-goal-lifecycle-status.html\"> lifecycle-status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-goal-patient.html\"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-goal-target-date.html\"> target-date</a> </td> <td> date </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-lifecycle-status\"> lifecycle-status</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-target-date\"> target-date</a> </td> <td>reference+date </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-goal-lifecycle-status.html\"> lifecycle-status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-goal-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-goal-target-date.html\"> target-date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>day</em>.</p> <p>A server <strong>SHALL</strong> support a value a value precise to the <em>day</em>.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"immunization\">Immunization</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>Based upon the ONC U.S. Core Data for Interoperability (USCDI) v1 requirements, CVX vaccine codes are required and the NDC vaccine codes <strong>SHOULD</strong> be supported as translations to them.</li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-immunization.html\">US Core Immunization Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Immunization resource using: <code class=\"highlighter-rouge\">GET [base]/Immunization/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/Immunization?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-immunization-patient.html\"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-immunization-status.html\"> status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-immunization-date.html\"> date</a> </td> <td> date </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-status\"> status</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-date\"> date</a> </td> <td>reference+date </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-immunization-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-immunization-status.html\"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-immunization-date.html\"> date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"location\">Location</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>The US Core Location and PractitionerRole Profiles are not explicitly referenced in any US Core Profile. However they <strong>SHOULD</strong> be used as the default profile if referenced by another US Core profile.</li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-location.html\">US Core Location Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Location resource using: <code class=\"highlighter-rouge\">GET [base]/Location/[id]</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-location-name.html\"> name</a> </td> <td> string </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-location-address.html\"> address</a> </td> <td> string </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-location-address-city.html\"> address-city</a> </td> <td> string </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-location-address-state.html\"> address-state</a> </td> <td> string </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-location-address-postalcode.html\"> address-postalcode</a> </td> <td> string </td> </tr> </tbody> </table> <hr /> <h4 class=\"no_toc\" id=\"medication\">Medication</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>The MedicationRequest resource can represent a medication, using an external reference to a Medication resource. If an external Medication Resource is used in a MedicationRequest, then the READ <strong>SHALL</strong> be supported.</li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-medication.html\">US Core Medication Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>search-type</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Medication resource using: <code class=\"highlighter-rouge\">GET [base]/Medication/[id]</code> </li> </ul> <hr /> <h4 class=\"no_toc\" id=\"medicationrequest\">MedicationRequest</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>The MedicationRequest resources can represent a medication using either a code or refer to the Medication resource. When referencing Medication, the resource may be <a href=\"http://hl7.org/fhir/R4/references.html#contained\">contained</a> or an external resource. The server application <strong>MAY</strong> choose any one way or more than one method, but if an external reference to Medication is used, the server <strong>SHALL</strong> support the _include` parameter for searching this element. The client application must support all methods.</li> </ul> <p>For example, A server <strong>SHALL</strong> be capable of returning all medications for a patient using one of or both:</p> <p><code>GET /MedicationRequest?patient=[id]</code></p> <p><code>GET /MedicationRequest?patient=[id]&amp;_include=MedicationRequest:medication</code></p> <ul> <li>The MedicationRequest resource can represent that information is from a secondary source using either a boolean flag or reference in <code>MedicationRequest.reportedBoolean</code>, or a reference using <code>MedicationRequest.reportedReference</code> to Practitioner or other resource. <ul> <li>Although both are marked as must support, the server systems are not required to support both a boolean and a reference, but <strong>SHALL</strong> choose to support at least one of these elements.</li> <li>The client application <strong>SHALL</strong> support both elements.</li> </ul> </li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-medicationrequest.html\">US Core MedicationRequest Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a MedicationRequest resource using: <code class=\"highlighter-rouge\">GET [base]/MedicationRequest/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _includes: MedicationRequest:medication - <code class=\"highlighter-rouge\">GET [base]/MedicationRequest?[parameter=value]&amp;_include=MedicationRequest:medication</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/MedicationRequest?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-medicationrequest-status.html\"> status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-medicationrequest-intent.html\"> intent</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-medicationrequest-patient.html\"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-medicationrequest-encounter.html\"> encounter</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-medicationrequest-authoredon.html\"> authoredon</a> </td> <td> date </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent\"> intent</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-status\"> status</a> </td> <td>reference+token+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent\"> intent</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-authoredon\"> authoredon</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent\"> intent</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-encounter\"> encounter</a> </td> <td>reference+token+reference </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent\"> intent</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-medicationrequest-status.html\"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-medicationrequest-intent.html\"> intent</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-medicationrequest-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-medicationrequest-encounter.html\"> encounter</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-medicationrequest-authoredon.html\"> authoredon</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"observation\">Observation</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>Systems <strong>SHOULD</strong> support <code>Observation.effectivePeriod</code> to accurately represent laboratory tests that are collected over a period of time (for example, a 24-Hour Urine Collection test).</li> <li>An Observation without a value, <strong>SHALL</strong> include a reason why the data is absent unless there are component observations, or references to other Observations that are grouped within it.</li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-observation-lab.html\">US Core Laboratory Result Observation Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-vital-signs.html\">US Core Vital Signs Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-blood-pressure.html\">US Core Blood Pressure Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-bmi.html\">US Core BMI Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-head-circumference.html\">US Core Head Circumference Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-body-height.html\">US Core Body Height Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-body-weight.html\">US Core Body Weight Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-body-temperature.html\">US Core Body Temperature Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-heart-rate.html\">US Core Heart Rate Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-pediatric-bmi-for-age.html\">US Core Pediatric BMI for Age Observation Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-head-occipital-frontal-circumference-percentile.html\">US Core Pediatric Head Occipital-frontal Circumference Percentile Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-pediatric-weight-for-height.html\">US Core Pediatric Weight for Height Observation Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-pulse-oximetry.html\">US Core Pulse Oximetry Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-respiratory-rate.html\">US Core Respiratory Rate Profile</a>, </li> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-smokingstatus.html\">US Core Smoking Status Observation Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Observation resource using: <code class=\"highlighter-rouge\">GET [base]/Observation/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/Observation?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-observation-status.html\"> status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-observation-category.html\"> category</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-observation-code.html\"> code</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-observation-date.html\"> date</a> </td> <td> date </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-observation-patient.html\"> patient</a> </td> <td> reference </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category\"> category</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-status\"> status</a> </td> <td>reference+token+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-code\"> code</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-code\"> code</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-date\"> date</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category\"> category</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-date\"> date</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category\"> category</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-observation-status.html\"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-observation-category.html\"> category</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-observation-code.html\"> code</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-observation-date.html\"> date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li><li><a href=\"SearchParameter-us-core-observation-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"organization\">Organization</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-organization.html\">US Core Organization Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Organization resource using: <code class=\"highlighter-rouge\">GET [base]/Organization/[id]</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-organization-name.html\"> name</a> </td> <td> string </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-organization-address.html\"> address</a> </td> <td> string </td> </tr> </tbody> </table> <hr /> <h4 class=\"no_toc\" id=\"patient\">Patient</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>For ONC's USCDI requirements, each Patient must support the following additional elements. These elements are included in the formal definition of the profile. The patient examples include all of these elements.</li> </ul> <ol> <li>contact detail (e.g. a telephone number or an email address)</li> <li>a communication language</li> <li>a race</li> <li>an ethnicity</li> <li>a birth sex*</li> <li>previous name <ul> <li>Previous name is represented by providing an end date in the <code>Patient.name.period</code> element for a previous name.</li> </ul> </li> <li>suffix <ul> <li>Suffix is represented using the <code>Patient.name.suffix</code> element.</li> </ul> </li> </ol> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-patient.html\">US Core Patient Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Patient resource using: <code class=\"highlighter-rouge\">GET [base]/Patient/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/Patient?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-patient-id.html\"> _id</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-patient-birthdate.html\"> birthdate</a> </td> <td> date </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-patient-family.html\"> family</a> </td> <td> string </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-patient-gender.html\"> gender</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-patient-given.html\"> given</a> </td> <td> string </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-patient-identifier.html\"> identifier</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-patient-name.html\"> name</a> </td> <td> string </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender\"> gender</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-name\"> name</a> </td> <td>token+string </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-family\"> family</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender\"> gender</a> </td> <td>string+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-birthdate\"> birthdate</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-family\"> family</a> </td> <td>date+string </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-birthdate\"> birthdate</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-name\"> name</a> </td> <td>date+string </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-patient-birthdate.html\"> birthdate</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>day</em>.</p> <p>A server <strong>SHALL</strong> support a value a value precise to the <em>day</em>.</p> </li><li><a href=\"SearchParameter-us-core-patient-gender.html\"> gender</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-patient-identifier.html\"> identifier</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"practitioner\">Practitioner</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-practitioner.html\">US Core Practitioner Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Practitioner resource using: <code class=\"highlighter-rouge\">GET [base]/Practitioner/[id]</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-practitioner-name.html\"> name</a> </td> <td> string </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-practitioner-identifier.html\"> identifier</a> </td> <td> token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-practitioner-identifier.html\"> identifier</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"practitionerrole\">PractitionerRole</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>The US Core Location and PractitionerRole Profiles are not explicitly referenced in any US Core Profile. However they <strong>SHOULD</strong> be used as the default profile if referenced by another US Core profile.</li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-practitionerrole.html\">US Core PractitionerRole Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a PractitionerRole resource using: <code class=\"highlighter-rouge\">GET [base]/PractitionerRole/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _includes: PractitionerRole:endpoint - <code class=\"highlighter-rouge\">GET [base]/PractitionerRole?[parameter=value]&amp;_include=PractitionerRole:endpoint</code> PractitionerRole:practitioner - <code class=\"highlighter-rouge\">GET [base]/PractitionerRole?[parameter=value]&amp;_include=PractitionerRole:practitioner</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-practitionerrole-specialty.html\"> specialty</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-practitionerrole-practitioner.html\"> practitioner</a> </td> <td> reference </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-practitionerrole-specialty.html\"> specialty</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-practitionerrole-practitioner.html\"> practitioner</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"procedure\">Procedure</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>A procedure including an implantable device <strong>SHOULD</strong> use <code>Procedure.focalDevice</code> with a reference to the [US Core Implantable Device Profile].</li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-procedure.html\">US Core Procedure Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Procedure resource using: <code class=\"highlighter-rouge\">GET [base]/Procedure/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class=\"highlighter-rouge\">GET [base]/Procedure?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-procedure-status.html\"> status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-procedure-patient.html\"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-procedure-date.html\"> date</a> </td> <td> date </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href=\"SearchParameter-us-core-procedure-code.html\"> code</a> </td> <td> token </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class=\"grid\"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-code\"> code</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-date\"> date</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-status\"> status</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient\"> patient</a>+ <a href=\"http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-date\"> date</a> </td> <td>reference+date </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href=\"SearchParameter-us-core-procedure-status.html\"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-procedure-patient.html\"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href=\"SearchParameter-us-core-procedure-date.html\"> date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li><li><a href=\"SearchParameter-us-core-procedure-code.html\"> code</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr /> <h4 class=\"no_toc\" id=\"provenance\">Provenance</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>If a system receives a provider in <code>Provenance.agent.who</code> as free text they must capture who sent them the information as the organization. On request they <strong>SHALL</strong> provide this organization as the source and <strong>MAY</strong> include the free text provider.</li> <li>Systems that need to know the activity has occurred <strong>SHOULD</strong> populate the activity.</li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href=\"StructureDefinition-us-core-provenance.html\">US Core Provenance Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>search-type</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Provenance resource using: <code class=\"highlighter-rouge\">GET [base]/Provenance/[id]</code> </li> </ul> <hr /> <h4 class=\"no_toc\" id=\"valueset\">ValueSet</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Operation Summary:</p> <ul> <li><strong>SHOULD</strong> support the <a href=\"http://hl7.org/fhir/OperationDefinition/ValueSet-expand\">$expand</a> operation <p>A client can determine the note and report types support by a server by invoking the standard FHIR Value Set Expansion ($expand) operation defined in the FHIR R4 specification. Because servers may support different read and write formats, it also is used to determine the formats (for example, text, pdf) the server supports read and write transactions.</p> </li> </ul> <hr /> </div>"
+  },
+  "url": "http://example.org/CapabilityStatement/us-core-client",
+  "version": "3.1.1",
+  "name": "UsCoreClientCapabilityStatement",
+  "title": "US Core Client CapabilityStatement",
+  "status": "active",
+  "experimental": false,
+  "date": "2021-06-17T14:23:50.993763-08:00",
+  "publisher": "HL7 International - US Realm Steering Committee",
+  "contact": [
+    {
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://www.hl7.org/Special/committees/usrealm/index.cfm"
+        }
+      ]
+    }
+  ],
+  "description": "This Section describes the expected capabilities of the US Core Client which is responsible for creating and initiating the queries for information about an individual patient. The complete list of FHIR profiles, RESTful operations, and search parameters supported by US Core Servers are defined in the [Conformance Requirements for Server](CapabilityStatement-us-core-server.html). US Core Clients have the option of choosing from this list to access necessary data based on their local use cases and other contextual requirements.",
+  "jurisdiction": [
+    {
+      "coding": [
+        {
+          "system": "urn:iso:std:iso:3166",
+          "code": "US"
+        }
+      ]
+    }
+  ],
+  "kind": "requirements",
+  "instantiates": [
+    "http://hl7.org/fhir/us/core/CapabilityStatement/us-core-client"
+  ],
+  "_instantiates": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+          "valueCode": "SHALL"
+        }
+      ]
+    }
+  ],
+  "fhirVersion": "4.0.1",
+  "format": [
+    "json",
+    "xml"
+  ],
+  "_format": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+          "valueCode": "SHALL"
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+          "valueCode": "SHOULD"
+        }
+      ]
+    }
+  ],
+  "patchFormat": [
+    "application/json-patch+json"
+  ],
+  "_patchFormat": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+          "valueCode": "SHOULD"
+        }
+      ]
+    }
+  ],
+  "implementationGuide": [
+    "http://fhir-registry.smarthealthit.org",
+    "http://hl7.org/fhir/uv/bulkdata/ImplementationGuide/hl7.fhir.uv.bulkdata"
+  ],
+  "_implementationGuide": [
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+          "valueCode": "SHOULD"
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+          "valueCode": "SHOULD"
+        }
+      ]
+    }
+  ],
+  "rest": [
+    {
+      "mode": "client",
+      "documentation": "The US Core Client **SHALL**:\n\n1. Support fetching and querying of one or more US Core profile(s), using the supported RESTful interactions and search parameters declared in the US Core Server CapabilityStatement.\n",
+      "security": {
+        "description": "1. See the [General Security Considerations] section for requirements and recommendations."
+      },
+      "resource": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "clinical-status"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "AllergyIntolerance",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "clinical-status",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-clinical-status",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "category"
+                },
+                {
+                  "url": "required",
+                  "valueString": "date"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "category"
+                },
+                {
+                  "url": "required",
+                  "valueString": "status"
+                },
+                {
+                  "url": "required",
+                  "valueString": "date"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "category"
+                },
+                {
+                  "url": "required",
+                  "valueString": "status"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "category"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "CarePlan",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "* Additional considerations for systems aligning with [HL7 Consolidated (C-CDA)](http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492) Care Plan requirements:\n    - US Core Goal **SHOULD** be present in CarePlan.goal\n    - US Core Condition **SHOULD** be present in CarePlan.addresses\n    - Assement and Plan **MAY** be included as narrative text",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "category",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "date",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-date",
+              "type": "date",
+              "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "status",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-status",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "status"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "CareTeam",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "status",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-status",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "code"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "onset-date"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "clinical-status"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "category"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "Condition",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "category",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-category",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "clinical-status",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-clinical-status",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "onset-date",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-onset-date",
+              "type": "date",
+              "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "code",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-code",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "type"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "Device",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "* Implantable medical devices that have UDI information **SHALL** represent the UDI code in `Device.udiCarrier.carrierHRF`.\n   - All of the five UDI-PI elements that are present in the UDI code **SHALL** be represented in the corresponding US Core Implantable Device Profile element.\n   \n   UDI may not be present in all scenarios such as historical implantable devices, patient reported implant information, payer reported devices, or improperly documented implants. If UDI is not present and the manufacturer and/or model number information is available, they **SHOULD** be included to support historical reports of implantable medical devices as follows:\n\n    <table>\n    <thead>\n    <tr class=\"header\">\n    <th>data element</th>\n    <th>US Core Implantable Device Profile element</th>\n    </tr>\n    </thead>\n    <tbody>\n    <tr class=\"odd\">\n    <td>manufacturer</td>\n    <td>Device.manufacturer</td>\n    </tr>\n    <tr class=\"even\">\n    <td>model</td>\n    <td>Device.model</td>\n    </tr>\n    </tbody>\n    </table>\n\n* Servers **SHOULD** support query by Device.type to allow clients to request the patient's devices by a specific type. Note: The Device.type is too granular to differentiate implantable vs. non-implantable devices.  \n* In the Quick Start section below, searching for all devices is described. Records of implanted devices **MAY** be queried against UDI data including:\n\n    - UDI HRF string (`udi-carrier`)\n    - UDI Device Identifier (`udi-di`)\n    - Manufacturer (`manufacturer`)\n    - Model number (`model`)\n\n  Implementers **MAY** also adopt custom SearchParameters for searching by:\n\n    - lot numbers\n    - serial number\n    - expiration date\n    - manufacture date\n    - distinct identifier",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "type",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "code"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "code"
+                },
+                {
+                  "url": "required",
+                  "valueString": "date"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "category"
+                },
+                {
+                  "url": "required",
+                  "valueString": "date"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "status"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "category"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "DiagnosticReport",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "create",
+              "documentation": "This conformance expectation applies **only**  to the *US Core DiagnosticReport Profile for Report and Note exchange* profile.  The conformance expectation for the *US Core DiagnosticReport Profile for Laboratory Results Reporting* is  **MAY**."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "status",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-status",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "category",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-category",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "code",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-code",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "date",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-date",
+              "type": "date",
+              "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "category"
+                },
+                {
+                  "url": "required",
+                  "valueString": "date"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "status"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "type"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "type"
+                },
+                {
+                  "url": "required",
+                  "valueString": "period"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "category"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "DocumentReference",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "The DocumentReference.type binding SHALL support at a minimum the [5 Common Clinical Notes](ValueSet-us-core-clinical-note-type.html) and may extend to the full US Core DocumentReference Type Value Set",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "_id",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-id",
+              "type": "token"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "status",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-status",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "category",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-category",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "type",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-type",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "date",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-date",
+              "type": "date",
+              "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "period",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-period",
+              "type": "date",
+              "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+            }
+          ],
+          "operation": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "docref",
+              "definition": "http://hl7.org/fhir/us/core/OperationDefinition/docref",
+              "documentation": "A client **SHOULD** be capable of transacting a $docref operation and capable of receiving at least a reference to a generated CCD document, and  **MAY** be able to receive other document types, if available.   **SHOULD**  be capable of receiving documents as included resources in response to the operation.\n\n`GET [base]/DocumentReference/$docref?patient=[id]`"
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "type"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "status"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "class"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "date"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "Encounter",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "* The Encounter resource can represent a reason using either a code with `Encounter.reasonCode`, or a reference with `Encounter.reasonReference` to  Condition or other resource.\n   * Although both are marked as must support, the server systems are not required to support both a code and a reference, but they **SHALL** support *at least one* of these elements.\n   * The client application **SHALL** support both elements.\n   * if `Encounter.reasonReference` references an Observation, it **SHOULD** conform to a US Core Observation if applicable. (for example, a laboratory result should conform to the US Core Laboratory Result Observation Profile)\n* The intent of this profile is to support *where the encounter occurred*.  The location address can be represented by either by the Location referenced by `Encounter.location.location` or indirectly through the Organization referenced by `Encounter.serviceProvider`.\n  * Although both are marked as must support, the server systems are not required to support both `Encounter.location.location` and `Encounter.serviceProvider`, but they **SHALL** support *at least one* of these elements.\n  * The client application **SHALL** support both elements.\n  * if using `Encounter.locatison.location` it **SHOULD** conform to US Core Location.  However, as a result of implementation feedback, it **MAY**  reference the base FHIR Location resource.  See this guidance on [Referencing US Core Profiles]",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "_id",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-id",
+              "type": "token"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "class",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-class",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "date",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-date",
+              "type": "date",
+              "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "identifier",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-identifier",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "status",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-status",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "type",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-type",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "lifecycle-status"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "target-date"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "Goal",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "lifecycle-status",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-lifecycle-status",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "target-date",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-target-date",
+              "type": "date",
+              "documentation": "A client **SHALL** provide a value precise to the *day*.\n\nA server **SHALL** support a value a value precise to the *day*."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "status"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "date"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "Immunization",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "* Based upon the ONC U.S. Core Data for Interoperability (USCDI) v1 requirements, CVX vaccine codes are required and the NDC vaccine codes **SHOULD** be supported as translations to them.",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "status",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-status",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "date",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-date",
+              "type": "date",
+              "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            }
+          ],
+          "type": "Location",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-location"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "* The US Core Location  and PractitionerRole Profiles are not explicitly referenced in any US Core Profile. However they **SHOULD** be used as the default profile if referenced by another US Core profile.",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "name",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-name",
+              "type": "string"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "address",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address",
+              "type": "string"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "address-city",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-city",
+              "type": "string"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "address-state",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-state",
+              "type": "string"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "address-postalcode",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-postalcode",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            }
+          ],
+          "type": "Medication",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "* The  MedicationRequest resource can represent a medication, using an external reference to a Medication resource. If an external Medication Resource is used in a MedicationRequest, then the READ  **SHALL**  be supported.",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "intent"
+                },
+                {
+                  "url": "required",
+                  "valueString": "status"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "intent"
+                },
+                {
+                  "url": "required",
+                  "valueString": "authoredon"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "intent"
+                },
+                {
+                  "url": "required",
+                  "valueString": "encounter"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "intent"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "MedicationRequest",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "* The MedicationRequest resources can represent a medication using either a code or refer to the Medication resource. When referencing Medication, the resource may be [contained](http://hl7.org/fhir/R4/references.html#contained) or an external resource. The server application **MAY** choose any one way or more than one method, but if an external reference to Medication is used, the server **SHALL** support the _include` parameter for searching this element. The client application must support all methods.\n\n For example, A server **SHALL** be capable of returning all medications for a patient using one of or both:\n\n `GET /MedicationRequest?patient=[id]`\n\n `GET /MedicationRequest?patient=[id]&_include=MedicationRequest:medication`\n\n* The MedicationRequest resource can represent that information is from a secondary source using either a boolean flag or reference in `MedicationRequest.reportedBoolean`, or a reference using `MedicationRequest.reportedReference` to Practitioner or other resource.\n   *   Although both are marked as must support, the server systems are not required to support both a boolean and a reference, but **SHALL** choose to support at least one of these elements.\n   *  The client application **SHALL** support both elements.",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchInclude": [
+            "MedicationRequest:medication"
+          ],
+          "_searchInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "status",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-status",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "intent",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "encounter",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-encounter",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "authoredon",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-authoredon",
+              "type": "date",
+              "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "category"
+                },
+                {
+                  "url": "required",
+                  "valueString": "status"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "code"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "code"
+                },
+                {
+                  "url": "required",
+                  "valueString": "date"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "category"
+                },
+                {
+                  "url": "required",
+                  "valueString": "date"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "category"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "Observation",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-head-circumference",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-temperature",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate",
+            "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age",
+            "http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile",
+            "http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-respiratory-rate",
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "* Systems **SHOULD** support `Observation.effectivePeriod` to accurately represent laboratory tests that are collected over a period of time (for example, a 24-Hour Urine Collection test).\n* An Observation without a value, **SHALL** include a reason why the data is absent unless there are component observations, or references to other Observations that are grouped within it.",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "status",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-status",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "category",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "code",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-code",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "date",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-date",
+              "type": "date",
+              "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            }
+          ],
+          "type": "Organization",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "name",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-name",
+              "type": "string"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "address",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-address",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "gender"
+                },
+                {
+                  "url": "required",
+                  "valueString": "name"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "family"
+                },
+                {
+                  "url": "required",
+                  "valueString": "gender"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "birthdate"
+                },
+                {
+                  "url": "required",
+                  "valueString": "family"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "birthdate"
+                },
+                {
+                  "url": "required",
+                  "valueString": "name"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "Patient",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "* For ONC's USCDI requirements, each Patient must support the following additional elements. These elements are included in the formal definition of the profile. The patient examples include all of these elements.\n\n1. contact detail (e.g. a telephone number or an email address)\n1. a communication language\n1. a race\n1. an ethnicity\n1. a birth sex*\n1. previous name\n   - Previous name is represented by providing an end date in the `Patient.name.period` element for a previous name.\n1. suffix\n   - Suffix is represented using the `Patient.name.suffix` element.\n\n",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "_id",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-id",
+              "type": "token"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "birthdate",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-birthdate",
+              "type": "date",
+              "documentation": "A client **SHALL** provide a value precise to the *day*.\n\nA server **SHALL** support a value a value precise to the *day*."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "family",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-family",
+              "type": "string"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "gender",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "given",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-given",
+              "type": "string"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "identifier",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-identifier",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "name",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-name",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            }
+          ],
+          "type": "Practitioner",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "name",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-name",
+              "type": "string"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "identifier",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-identifier",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            }
+          ],
+          "type": "PractitionerRole",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "* The US Core Location  and PractitionerRole Profiles are not explicitly referenced in any US Core Profile. However they **SHOULD** be used as the default profile if referenced by another US Core profile.",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchInclude": [
+            "PractitionerRole:endpoint",
+            "PractitionerRole:practitioner"
+          ],
+          "_searchInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "specialty",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-specialty",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "practitioner",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-practitioner",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "code"
+                },
+                {
+                  "url": "required",
+                  "valueString": "date"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "status"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                },
+                {
+                  "url": "required",
+                  "valueString": "patient"
+                },
+                {
+                  "url": "required",
+                  "valueString": "date"
+                }
+              ],
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination"
+            }
+          ],
+          "type": "Procedure",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "*  A procedure including an implantable device **SHOULD** use `Procedure.focalDevice` with a reference to the [US Core Implantable Device Profile].",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ],
+          "searchRevInclude": [
+            "Provenance:target"
+          ],
+          "_searchRevInclude": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ]
+            }
+          ],
+          "searchParam": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "status",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-status",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "patient",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient",
+              "type": "reference",
+              "documentation": "The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.\n\nThe server **SHALL** support both."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "date",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-date",
+              "type": "date",
+              "documentation": "A client **SHALL** provide a value precise to the *second + time offset*.\n\nA server **SHALL** support a value precise to the *second + time offset*."
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "code",
+              "definition": "http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-code",
+              "type": "token",
+              "documentation": "The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.\n\nThe server **SHALL** support both."
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            }
+          ],
+          "type": "Provenance",
+          "supportedProfile": [
+            "http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance"
+          ],
+          "_supportedProfile": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ]
+            }
+          ],
+          "documentation": "* If a system receives a provider in `Provenance.agent.who` as free text they must capture who sent them the information as the organization. On request they **SHALL** provide this organization as the source and **MAY** include the free text provider.\n* Systems that need to know the activity has occurred **SHOULD** populate the activity.",
+          "interaction": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "create"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "search-type"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHALL"
+                }
+              ],
+              "code": "read"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "vread"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "update"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "patch"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "delete"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "code": "history-instance"
+            },
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "MAY"
+                }
+              ],
+              "code": "history-type"
+            }
+          ]
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "SHOULD"
+            }
+          ],
+          "type": "ValueSet",
+          "operation": [
+            {
+              "extension": [
+                {
+                  "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+                  "valueCode": "SHOULD"
+                }
+              ],
+              "name": "expand",
+              "definition": "http://hl7.org/fhir/OperationDefinition/ValueSet-expand",
+              "documentation": "A  client can determine the note and report types support by a server by invoking the standard FHIR Value Set Expansion ($expand) operation defined in the FHIR R4 specification. Because servers may support different read and write formats, it also is used to determine the formats (for example, text, pdf) the server supports read and write transactions."
+            }
+          ]
+        }
+      ],
+      "interaction": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "MAY"
+            }
+          ],
+          "code": "transaction"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "MAY"
+            }
+          ],
+          "code": "batch"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "MAY"
+            }
+          ],
+          "code": "search-system"
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation",
+              "valueCode": "MAY"
+            }
+          ],
+          "code": "history-system"
+        }
+      ]
+    }
+  ]
+}

--- a/test/utils/fixtures/instance-files/large-instance.xml
+++ b/test/utils/fixtures/instance-files/large-instance.xml
@@ -1,0 +1,2764 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<CapabilityStatement xmlns="http://hl7.org/fhir">
+  <id value="us-core-client"/>
+  <text>
+    <status value="generated"/><div xmlns="http://www.w3.org/1999/xhtml"> <h2 id="title">US Core Client CapabilityStatement</h2> <ul> <li>Official URL: <code>http://hl7.org/fhir/us/core/CapabilityStatement/us-core-client</code></li> <li>Implementation Guide Version: 3.1.1</li> <li>FHIR Version: 4.0.1</li> <li>Supported formats: <strong>SHALL</strong> support JSON, <strong>SHOULD</strong> support XML </li> <li>Published: 2021-06-17 14:23:50.993763-08:00</li> <li>Published by: HL7 International - US Realm Steering Committee</li> </ul> <p>This Section describes the expected capabilities of the US Core Client which is responsible for creating and initiating the queries for information about an individual patient. The complete list of FHIR profiles, RESTful operations, and search parameters supported by US Core Servers are defined in the <a href="CapabilityStatement-us-core-server.html">Conformance Requirements for Server</a>. US Core Clients have the option of choosing from this list to access necessary data based on their local use cases and other contextual requirements.</p> <h3 id="should_igs" class="no_toc">SHOULD Support the Following Implementation Guides:</h3> <ul> <li><a href="http://hl7.org/fhir/smart-app-launch/index.html">SMART Application Launch Framework Implementation Guide</a></li> </ul> <ul> <li><a href="http://hl7.org/fhir/uv/bulkdata/index.html">Bulk Data Access IG</a></li> </ul> <h3 id="shall_css" class="no_toc">SHALL Implement All Or Parts Of The Following Capability Statements:</h3> <ul> <li><a href="CapabilityStatement-us-core-client.html">US Core Client CapabilityStatement</a></li> </ul> <h3 id="behavior">FHIR RESTful Capabilities</h3> <p>The US Core Client <strong>SHALL</strong>:</p> <ol> <li>Support fetching and querying of one or more US Core profile(s), using the supported RESTful interactions and search parameters declared in the US Core Server CapabilityStatement.</li> </ol> <p id="security"><strong>Security:</strong></p> <ol> <li>See the [General Security Considerations] section for requirements and recommendations.</li> </ol> <p><strong>Summary of System Wide Interactions</strong></p> <ul> <li><strong>MAY</strong> support the <code>transaction</code> interaction.</li> <li><strong>MAY</strong> support the <code>batch</code> interaction.</li> <li><strong>MAY</strong> support the <code>search-system</code> interaction.</li> <li><strong>MAY</strong> support the <code>history-system</code> interaction.</li> </ul> <h3 id="resource-details" class="no_toc">RESTful Capabilities by Resource/Profile:</h3> <h4>Summary</h4> <table class="grid"> <thead> <tr> <th>Resource Type</th> <th>Supported Profiles</th> <th>Supported Searches</th> <th>Supported <code>_includes</code></th> <th>Supported <code>_revincludes</code></th> <th>Supported Operations</th> </tr> </thead> <tbody> <tr> <td> <a href="#allergyintolerance">AllergyIntolerance</a> </td> <td> <a href="StructureDefinition-us-core-allergyintolerance.html">US Core AllergyIntolerance Profile</a> </td> <td> clinical-status, patient patient+clinical-status </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href="#careplan">CarePlan</a> </td> <td> <a href="StructureDefinition-us-core-careplan.html">US Core CarePlan Profile</a> </td> <td> category, date, patient, status patient+category+date, patient+category+status+date, patient+category+status, patient+category </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href="#careteam">CareTeam</a> </td> <td> <a href="StructureDefinition-us-core-careteam.html">US Core CareTeam Profile</a> </td> <td> patient, status patient+status </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href="#condition">Condition</a> </td> <td> <a href="StructureDefinition-us-core-condition.html">US Core Condition Profile</a> </td> <td> category, clinical-status, patient, onset-date, code patient+code, patient+onset-date, patient+clinical-status, patient+category </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href="#device">Device</a> </td> <td> <a href="StructureDefinition-us-core-implantable-device.html">US Core Implantable Device Profile</a> </td> <td> patient, type patient+type </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href="#diagnosticreport">DiagnosticReport</a> </td> <td> <a href="StructureDefinition-us-core-diagnosticreport-lab.html">US Core DiagnosticReport Profile for Laboratory Results Reporting</a>, <a href="StructureDefinition-us-core-diagnosticreport-note.html">US Core DiagnosticReport Profile for Report and Note exchange</a> </td> <td> status, patient, category, code, date patient+code, patient+code+date, patient+category+date, patient+status, patient+category </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href="#documentreference">DocumentReference</a> </td> <td> <a href="StructureDefinition-us-core-documentreference.html">US Core DocumentReference Profile</a> </td> <td> _id, status, patient, category, type, date, period patient+category+date, patient+status, patient+type, patient+type+period, patient+category </td> <td> - </td> <td> Provenance:target </td> <td> docref </td> </tr> <tr> <td> <a href="#encounter">Encounter</a> </td> <td> <a href="StructureDefinition-us-core-encounter.html">US Core Encounter Profile</a> </td> <td> _id, class, date, identifier, patient, status, type patient+type, patient+status, class+patient, date+patient </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href="#goal">Goal</a> </td> <td> <a href="StructureDefinition-us-core-goal.html">US Core Goal Profile</a> </td> <td> lifecycle-status, patient, target-date patient+lifecycle-status, patient+target-date </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href="#immunization">Immunization</a> </td> <td> <a href="StructureDefinition-us-core-immunization.html">US Core Immunization Profile</a> </td> <td> patient, status, date patient+status, patient+date </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href="#location">Location</a> </td> <td> <a href="StructureDefinition-us-core-location.html">US Core Location Profile</a> </td> <td> name, address, address-city, address-state, address-postalcode </td> <td> - </td> <td> - </td> <td> - </td> </tr> <tr> <td> <a href="#medication">Medication</a> </td> <td> <a href="StructureDefinition-us-core-medication.html">US Core Medication Profile</a> </td> <td> - </td> <td> - </td> <td> - </td> <td> - </td> </tr> <tr> <td> <a href="#medicationrequest">MedicationRequest</a> </td> <td> <a href="StructureDefinition-us-core-medicationrequest.html">US Core MedicationRequest Profile</a> </td> <td> status, intent, patient, encounter, authoredon patient+intent+status, patient+intent+authoredon, patient+intent+encounter, patient+intent </td> <td> MedicationRequest:medication </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href="#observation">Observation</a> </td> <td> <a href="StructureDefinition-us-core-observation-lab.html">US Core Laboratory Result Observation Profile</a>, <a href="StructureDefinition-us-core-vital-signs.html">US Core Vital Signs Profile</a>, <a href="StructureDefinition-us-core-blood-pressure.html">US Core Blood Pressure Profile</a>, <a href="StructureDefinition-us-core-bmi.html">US Core BMI Profile</a>, <a href="StructureDefinition-us-core-head-circumference.html">US Core Head Circumference Profile</a>, <a href="StructureDefinition-us-core-body-height.html">US Core Body Height Profile</a>, <a href="StructureDefinition-us-core-body-weight.html">US Core Body Weight Profile</a>, <a href="StructureDefinition-us-core-body-temperature.html">US Core Body Temperature Profile</a>, <a href="StructureDefinition-us-core-heart-rate.html">US Core Heart Rate Profile</a>, <a href="StructureDefinition-pediatric-bmi-for-age.html">US Core Pediatric BMI for Age Observation Profile</a>, <a href="StructureDefinition-head-occipital-frontal-circumference-percentile.html">US Core Pediatric Head Occipital-frontal Circumference Percentile Profile</a>, <a href="StructureDefinition-pediatric-weight-for-height.html">US Core Pediatric Weight for Height Observation Profile</a>, <a href="StructureDefinition-us-core-pulse-oximetry.html">US Core Pulse Oximetry Profile</a>, <a href="StructureDefinition-us-core-respiratory-rate.html">US Core Respiratory Rate Profile</a>, <a href="StructureDefinition-us-core-smokingstatus.html">US Core Smoking Status Observation Profile</a> </td> <td> status, category, code, date, patient patient+category+status, patient+code, patient+code+date, patient+category+date, patient+category </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href="#organization">Organization</a> </td> <td> <a href="StructureDefinition-us-core-organization.html">US Core Organization Profile</a> </td> <td> name, address </td> <td> - </td> <td> - </td> <td> - </td> </tr> <tr> <td> <a href="#patient">Patient</a> </td> <td> <a href="StructureDefinition-us-core-patient.html">US Core Patient Profile</a> </td> <td> _id, birthdate, family, gender, given, identifier, name gender+name, family+gender, birthdate+family, birthdate+name </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href="#practitioner">Practitioner</a> </td> <td> <a href="StructureDefinition-us-core-practitioner.html">US Core Practitioner Profile</a> </td> <td> name, identifier </td> <td> - </td> <td> - </td> <td> - </td> </tr> <tr> <td> <a href="#practitionerrole">PractitionerRole</a> </td> <td> <a href="StructureDefinition-us-core-practitionerrole.html">US Core PractitionerRole Profile</a> </td> <td> specialty, practitioner </td> <td> PractitionerRole:endpoint, PractitionerRole:practitioner </td> <td> - </td> <td> - </td> </tr> <tr> <td> <a href="#procedure">Procedure</a> </td> <td> <a href="StructureDefinition-us-core-procedure.html">US Core Procedure Profile</a> </td> <td> status, patient, date, code patient+code+date, patient+status, patient+date </td> <td> - </td> <td> Provenance:target </td> <td> - </td> </tr> <tr> <td> <a href="#provenance">Provenance</a> </td> <td> <a href="StructureDefinition-us-core-provenance.html">US Core Provenance Profile</a> </td> <td> - </td> <td> - </td> <td> - </td> <td> - </td> </tr> <tr> <td> <a href="#valueset">ValueSet</a> </td> <td> - </td> <td> - </td> <td> - </td> <td> - </td> <td> expand </td> </tr> </tbody> </table> <h4 id="allergyintolerance" class="no_toc">AllergyIntolerance</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-allergyintolerance.html">US Core AllergyIntolerance Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a AllergyIntolerance resource using: <code class="highlighter-rouge">GET [base]/AllergyIntolerance/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class="highlighter-rouge">GET [base]/AllergyIntolerance?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-allergyintolerance-clinical-status.html"> clinical-status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-allergyintolerance-patient.html"> patient</a> </td> <td> reference </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-clinical-status"> clinical-status</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href="SearchParameter-us-core-allergyintolerance-clinical-status.html"> clinical-status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-allergyintolerance-patient.html"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr/> <h4 id="careplan" class="no_toc">CarePlan</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>Additional considerations for systems aligning with <a href="http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492">HL7 Consolidated (C-CDA)</a> Care Plan requirements: <ul> <li>US Core Goal <strong>SHOULD</strong> be present in CarePlan.goal</li> <li>US Core Condition <strong>SHOULD</strong> be present in CarePlan.addresses</li> <li>Assement and Plan <strong>MAY</strong> be included as narrative text</li> </ul> </li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-careplan.html">US Core CarePlan Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a CarePlan resource using: <code class="highlighter-rouge">GET [base]/CarePlan/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class="highlighter-rouge">GET [base]/CarePlan?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-careplan-category.html"> category</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-careplan-date.html"> date</a> </td> <td> date </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-careplan-patient.html"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-careplan-status.html"> status</a> </td> <td> token </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category"> category</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-date"> date</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category"> category</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-status"> status</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-date"> date</a> </td> <td>reference+token+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category"> category</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-status"> status</a> </td> <td>reference+token+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category"> category</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href="SearchParameter-us-core-careplan-category.html"> category</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-careplan-date.html"> date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li><li><a href="SearchParameter-us-core-careplan-patient.html"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-careplan-status.html"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr/> <h4 id="careteam" class="no_toc">CareTeam</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-careteam.html">US Core CareTeam Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a CareTeam resource using: <code class="highlighter-rouge">GET [base]/CareTeam/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class="highlighter-rouge">GET [base]/CareTeam?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-careteam-patient.html"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-careteam-status.html"> status</a> </td> <td> token </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-status"> status</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href="SearchParameter-us-core-careteam-patient.html"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-careteam-status.html"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr/> <h4 id="condition" class="no_toc">Condition</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-condition.html">US Core Condition Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Condition resource using: <code class="highlighter-rouge">GET [base]/Condition/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class="highlighter-rouge">GET [base]/Condition?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-condition-category.html"> category</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-condition-clinical-status.html"> clinical-status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-condition-patient.html"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-condition-onset-date.html"> onset-date</a> </td> <td> date </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-condition-code.html"> code</a> </td> <td> token </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-code"> code</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-onset-date"> onset-date</a> </td> <td>reference+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-clinical-status"> clinical-status</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-category"> category</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href="SearchParameter-us-core-condition-category.html"> category</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-condition-clinical-status.html"> clinical-status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-condition-patient.html"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-condition-onset-date.html"> onset-date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li><li><a href="SearchParameter-us-core-condition-code.html"> code</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr/> <h4 id="device" class="no_toc">Device</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li> <p>Implantable medical devices that have UDI information <strong>SHALL</strong> represent the UDI code in <code>Device.udiCarrier.carrierHRF</code>.</p> <ul> <li>All of the five UDI-PI elements that are present in the UDI code <strong>SHALL</strong> be represented in the corresponding US Core Implantable Device Profile element.</li> </ul> <p>UDI may not be present in all scenarios such as historical implantable devices, patient reported implant information, payer reported devices, or improperly documented implants. If UDI is not present and the manufacturer and/or model number information is available, they <strong>SHOULD</strong> be included to support historical reports of implantable medical devices as follows:</p> <table> <thead> <tr class="header"> <th>data element</th> <th>US Core Implantable Device Profile element</th> </tr> </thead> <tbody> <tr class="odd"> <td>manufacturer</td> <td>Device.manufacturer</td> </tr> <tr class="even"> <td>model</td> <td>Device.model</td> </tr> </tbody> </table> </li> <li> <p>Servers <strong>SHOULD</strong> support query by Device.type to allow clients to request the patient's devices by a specific type. Note: The Device.type is too granular to differentiate implantable vs. non-implantable devices.</p> </li> <li> <p>In the Quick Start section below, searching for all devices is described. Records of implanted devices <strong>MAY</strong> be queried against UDI data including:</p> <ul> <li>UDI HRF string (<code>udi-carrier</code>)</li> <li>UDI Device Identifier (<code>udi-di</code>)</li> <li>Manufacturer (<code>manufacturer</code>)</li> <li>Model number (<code>model</code>)</li> </ul> <p>Implementers <strong>MAY</strong> also adopt custom SearchParameters for searching by:</p> <ul> <li>lot numbers</li> <li>serial number</li> <li>expiration date</li> <li>manufacture date</li> <li>distinct identifier</li> </ul> </li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-implantable-device.html">US Core Implantable Device Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Device resource using: <code class="highlighter-rouge">GET [base]/Device/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class="highlighter-rouge">GET [base]/Device?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-device-patient.html"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-device-type.html"> type</a> </td> <td> token </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-device-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type"> type</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href="SearchParameter-us-core-device-patient.html"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-device-type.html"> type</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr/> <h4 id="diagnosticreport" class="no_toc">DiagnosticReport</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-diagnosticreport-lab.html">US Core DiagnosticReport Profile for Laboratory Results Reporting</a>, </li> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-diagnosticreport-note.html">US Core DiagnosticReport Profile for Report and Note exchange</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>create</code><sup>†</sup>, <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <blockquote>create<sup>†</sup><p>This conformance expectation applies <strong>only</strong> to the <em>US Core DiagnosticReport Profile for Report and Note exchange</em> profile. The conformance expectation for the <em>US Core DiagnosticReport Profile for Laboratory Results Reporting</em> is <strong>MAY</strong>.</p> </blockquote> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a DiagnosticReport resource using: <code class="highlighter-rouge">GET [base]/DiagnosticReport/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class="highlighter-rouge">GET [base]/DiagnosticReport?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-diagnosticreport-status.html"> status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-diagnosticreport-patient.html"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-diagnosticreport-category.html"> category</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-diagnosticreport-code.html"> code</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-diagnosticreport-date.html"> date</a> </td> <td> date </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-code"> code</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-code"> code</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-date"> date</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-category"> category</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-date"> date</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-status"> status</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-category"> category</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href="SearchParameter-us-core-diagnosticreport-status.html"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-diagnosticreport-patient.html"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-diagnosticreport-category.html"> category</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-diagnosticreport-code.html"> code</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-diagnosticreport-date.html"> date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li> </ul> </div> <hr/> <h4 id="documentreference" class="no_toc">DocumentReference</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><p>The DocumentReference.type binding SHALL support at a minimum the <a href="ValueSet-us-core-clinical-note-type.html">5 Common Clinical Notes</a> and may extend to the full US Core DocumentReference Type Value Set</p> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-documentreference.html">US Core DocumentReference Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>create</code>, <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Operation Summary:</p> <ul> <li><strong>SHOULD</strong> support the <a href="OperationDefinition-docref.html">$docref</a> operation <p>A client <strong>SHOULD</strong> be capable of transacting a $docref operation and capable of receiving at least a reference to a generated CCD document, and <strong>MAY</strong> be able to receive other document types, if available. <strong>SHOULD</strong> be capable of receiving documents as included resources in response to the operation.</p> <p><code>GET [base]/DocumentReference/$docref?patient=[id]</code></p> </li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a DocumentReference resource using: <code class="highlighter-rouge">GET [base]/DocumentReference/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class="highlighter-rouge">GET [base]/DocumentReference?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-documentreference-id.html"> _id</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-documentreference-status.html"> status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-documentreference-patient.html"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-documentreference-category.html"> category</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-documentreference-type.html"> type</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-documentreference-date.html"> date</a> </td> <td> date </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-documentreference-period.html"> period</a> </td> <td> date </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-category"> category</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-date"> date</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-status"> status</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-type"> type</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-type"> type</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-period"> period</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-category"> category</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href="SearchParameter-us-core-documentreference-status.html"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-documentreference-patient.html"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-documentreference-category.html"> category</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-documentreference-type.html"> type</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-documentreference-date.html"> date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li><li><a href="SearchParameter-us-core-documentreference-period.html"> period</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li> </ul> </div> <hr/> <h4 id="encounter" class="no_toc">Encounter</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>The Encounter resource can represent a reason using either a code with <code>Encounter.reasonCode</code>, or a reference with <code>Encounter.reasonReference</code> to Condition or other resource. <ul> <li>Although both are marked as must support, the server systems are not required to support both a code and a reference, but they <strong>SHALL</strong> support <em>at least one</em> of these elements.</li> <li>The client application <strong>SHALL</strong> support both elements.</li> <li>if <code>Encounter.reasonReference</code> references an Observation, it <strong>SHOULD</strong> conform to a US Core Observation if applicable. (for example, a laboratory result should conform to the US Core Laboratory Result Observation Profile)</li> </ul> </li> <li>The intent of this profile is to support <em>where the encounter occurred</em>. The location address can be represented by either by the Location referenced by <code>Encounter.location.location</code> or indirectly through the Organization referenced by <code>Encounter.serviceProvider</code>. <ul> <li>Although both are marked as must support, the server systems are not required to support both <code>Encounter.location.location</code> and <code>Encounter.serviceProvider</code>, but they <strong>SHALL</strong> support <em>at least one</em> of these elements.</li> <li>The client application <strong>SHALL</strong> support both elements.</li> <li>if using <code>Encounter.locatison.location</code> it <strong>SHOULD</strong> conform to US Core Location. However, as a result of implementation feedback, it <strong>MAY</strong> reference the base FHIR Location resource. See this guidance on [Referencing US Core Profiles]</li> </ul> </li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-encounter.html">US Core Encounter Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Encounter resource using: <code class="highlighter-rouge">GET [base]/Encounter/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class="highlighter-rouge">GET [base]/Encounter?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-encounter-id.html"> _id</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-encounter-class.html"> class</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-encounter-date.html"> date</a> </td> <td> date </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-encounter-identifier.html"> identifier</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-encounter-patient.html"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-encounter-status.html"> status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-encounter-type.html"> type</a> </td> <td> token </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-type"> type</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-status"> status</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-class"> class</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient"> patient</a> </td> <td>token+reference </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-date"> date</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient"> patient</a> </td> <td>date+reference </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href="SearchParameter-us-core-encounter-class.html"> class</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-encounter-date.html"> date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li><li><a href="SearchParameter-us-core-encounter-identifier.html"> identifier</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-encounter-patient.html"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-encounter-status.html"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-encounter-type.html"> type</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr/> <h4 id="goal" class="no_toc">Goal</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-goal.html">US Core Goal Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Goal resource using: <code class="highlighter-rouge">GET [base]/Goal/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class="highlighter-rouge">GET [base]/Goal?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-goal-lifecycle-status.html"> lifecycle-status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-goal-patient.html"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-goal-target-date.html"> target-date</a> </td> <td> date </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-lifecycle-status"> lifecycle-status</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-target-date"> target-date</a> </td> <td>reference+date </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href="SearchParameter-us-core-goal-lifecycle-status.html"> lifecycle-status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-goal-patient.html"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-goal-target-date.html"> target-date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>day</em>.</p> <p>A server <strong>SHALL</strong> support a value a value precise to the <em>day</em>.</p> </li> </ul> </div> <hr/> <h4 id="immunization" class="no_toc">Immunization</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>Based upon the ONC U.S. Core Data for Interoperability (USCDI) v1 requirements, CVX vaccine codes are required and the NDC vaccine codes <strong>SHOULD</strong> be supported as translations to them.</li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-immunization.html">US Core Immunization Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Immunization resource using: <code class="highlighter-rouge">GET [base]/Immunization/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class="highlighter-rouge">GET [base]/Immunization?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-immunization-patient.html"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-immunization-status.html"> status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-immunization-date.html"> date</a> </td> <td> date </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-status"> status</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-date"> date</a> </td> <td>reference+date </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href="SearchParameter-us-core-immunization-patient.html"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-immunization-status.html"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-immunization-date.html"> date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li> </ul> </div> <hr/> <h4 id="location" class="no_toc">Location</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>The US Core Location and PractitionerRole Profiles are not explicitly referenced in any US Core Profile. However they <strong>SHOULD</strong> be used as the default profile if referenced by another US Core profile.</li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-location.html">US Core Location Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Location resource using: <code class="highlighter-rouge">GET [base]/Location/[id]</code> </li> </ul> <p>Search Parameter Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-location-name.html"> name</a> </td> <td> string </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-location-address.html"> address</a> </td> <td> string </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-location-address-city.html"> address-city</a> </td> <td> string </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-location-address-state.html"> address-state</a> </td> <td> string </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-location-address-postalcode.html"> address-postalcode</a> </td> <td> string </td> </tr> </tbody> </table> <hr/> <h4 id="medication" class="no_toc">Medication</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>The MedicationRequest resource can represent a medication, using an external reference to a Medication resource. If an external Medication Resource is used in a MedicationRequest, then the READ <strong>SHALL</strong> be supported.</li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-medication.html">US Core Medication Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>search-type</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Medication resource using: <code class="highlighter-rouge">GET [base]/Medication/[id]</code> </li> </ul> <hr/> <h4 id="medicationrequest" class="no_toc">MedicationRequest</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>The MedicationRequest resources can represent a medication using either a code or refer to the Medication resource. When referencing Medication, the resource may be <a href="http://hl7.org/fhir/R4/references.html#contained">contained</a> or an external resource. The server application <strong>MAY</strong> choose any one way or more than one method, but if an external reference to Medication is used, the server <strong>SHALL</strong> support the _include` parameter for searching this element. The client application must support all methods.</li> </ul> <p>For example, A server <strong>SHALL</strong> be capable of returning all medications for a patient using one of or both:</p> <p><code>GET /MedicationRequest?patient=[id]</code></p> <p><code>GET /MedicationRequest?patient=[id]&amp;_include=MedicationRequest:medication</code></p> <ul> <li>The MedicationRequest resource can represent that information is from a secondary source using either a boolean flag or reference in <code>MedicationRequest.reportedBoolean</code>, or a reference using <code>MedicationRequest.reportedReference</code> to Practitioner or other resource. <ul> <li>Although both are marked as must support, the server systems are not required to support both a boolean and a reference, but <strong>SHALL</strong> choose to support at least one of these elements.</li> <li>The client application <strong>SHALL</strong> support both elements.</li> </ul> </li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-medicationrequest.html">US Core MedicationRequest Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a MedicationRequest resource using: <code class="highlighter-rouge">GET [base]/MedicationRequest/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _includes: MedicationRequest:medication - <code class="highlighter-rouge">GET [base]/MedicationRequest?[parameter=value]&amp;_include=MedicationRequest:medication</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class="highlighter-rouge">GET [base]/MedicationRequest?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-medicationrequest-status.html"> status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-medicationrequest-intent.html"> intent</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-medicationrequest-patient.html"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-medicationrequest-encounter.html"> encounter</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-medicationrequest-authoredon.html"> authoredon</a> </td> <td> date </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent"> intent</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-status"> status</a> </td> <td>reference+token+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent"> intent</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-authoredon"> authoredon</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent"> intent</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-encounter"> encounter</a> </td> <td>reference+token+reference </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent"> intent</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href="SearchParameter-us-core-medicationrequest-status.html"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-medicationrequest-intent.html"> intent</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-medicationrequest-patient.html"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-medicationrequest-encounter.html"> encounter</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-medicationrequest-authoredon.html"> authoredon</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li> </ul> </div> <hr/> <h4 id="observation" class="no_toc">Observation</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>Systems <strong>SHOULD</strong> support <code>Observation.effectivePeriod</code> to accurately represent laboratory tests that are collected over a period of time (for example, a 24-Hour Urine Collection test).</li> <li>An Observation without a value, <strong>SHALL</strong> include a reason why the data is absent unless there are component observations, or references to other Observations that are grouped within it.</li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-observation-lab.html">US Core Laboratory Result Observation Profile</a>, </li> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-vital-signs.html">US Core Vital Signs Profile</a>, </li> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-blood-pressure.html">US Core Blood Pressure Profile</a>, </li> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-bmi.html">US Core BMI Profile</a>, </li> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-head-circumference.html">US Core Head Circumference Profile</a>, </li> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-body-height.html">US Core Body Height Profile</a>, </li> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-body-weight.html">US Core Body Weight Profile</a>, </li> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-body-temperature.html">US Core Body Temperature Profile</a>, </li> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-heart-rate.html">US Core Heart Rate Profile</a>, </li> <li><strong>SHALL</strong> support: <a href="StructureDefinition-pediatric-bmi-for-age.html">US Core Pediatric BMI for Age Observation Profile</a>, </li> <li><strong>SHALL</strong> support: <a href="StructureDefinition-head-occipital-frontal-circumference-percentile.html">US Core Pediatric Head Occipital-frontal Circumference Percentile Profile</a>, </li> <li><strong>SHALL</strong> support: <a href="StructureDefinition-pediatric-weight-for-height.html">US Core Pediatric Weight for Height Observation Profile</a>, </li> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-pulse-oximetry.html">US Core Pulse Oximetry Profile</a>, </li> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-respiratory-rate.html">US Core Respiratory Rate Profile</a>, </li> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-smokingstatus.html">US Core Smoking Status Observation Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Observation resource using: <code class="highlighter-rouge">GET [base]/Observation/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class="highlighter-rouge">GET [base]/Observation?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-observation-status.html"> status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-observation-category.html"> category</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-observation-code.html"> code</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-observation-date.html"> date</a> </td> <td> date </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-observation-patient.html"> patient</a> </td> <td> reference </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category"> category</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-status"> status</a> </td> <td>reference+token+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-code"> code</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-code"> code</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-date"> date</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category"> category</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-date"> date</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category"> category</a> </td> <td>reference+token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href="SearchParameter-us-core-observation-status.html"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-observation-category.html"> category</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-observation-code.html"> code</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-observation-date.html"> date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li><li><a href="SearchParameter-us-core-observation-patient.html"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr/> <h4 id="organization" class="no_toc">Organization</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-organization.html">US Core Organization Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Organization resource using: <code class="highlighter-rouge">GET [base]/Organization/[id]</code> </li> </ul> <p>Search Parameter Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-organization-name.html"> name</a> </td> <td> string </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-organization-address.html"> address</a> </td> <td> string </td> </tr> </tbody> </table> <hr/> <h4 id="patient" class="no_toc">Patient</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>For ONC's USCDI requirements, each Patient must support the following additional elements. These elements are included in the formal definition of the profile. The patient examples include all of these elements.</li> </ul> <ol> <li>contact detail (e.g. a telephone number or an email address)</li> <li>a communication language</li> <li>a race</li> <li>an ethnicity</li> <li>a birth sex*</li> <li>previous name <ul> <li>Previous name is represented by providing an end date in the <code>Patient.name.period</code> element for a previous name.</li> </ul> </li> <li>suffix <ul> <li>Suffix is represented using the <code>Patient.name.suffix</code> element.</li> </ul> </li> </ol> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-patient.html">US Core Patient Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Patient resource using: <code class="highlighter-rouge">GET [base]/Patient/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class="highlighter-rouge">GET [base]/Patient?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-patient-id.html"> _id</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-patient-birthdate.html"> birthdate</a> </td> <td> date </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-patient-family.html"> family</a> </td> <td> string </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-patient-gender.html"> gender</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-patient-given.html"> given</a> </td> <td> string </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-patient-identifier.html"> identifier</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-patient-name.html"> name</a> </td> <td> string </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender"> gender</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-name"> name</a> </td> <td>token+string </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-family"> family</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender"> gender</a> </td> <td>string+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-birthdate"> birthdate</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-family"> family</a> </td> <td>date+string </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-birthdate"> birthdate</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-name"> name</a> </td> <td>date+string </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href="SearchParameter-us-core-patient-birthdate.html"> birthdate</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>day</em>.</p> <p>A server <strong>SHALL</strong> support a value a value precise to the <em>day</em>.</p> </li><li><a href="SearchParameter-us-core-patient-gender.html"> gender</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-patient-identifier.html"> identifier</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr/> <h4 id="practitioner" class="no_toc">Practitioner</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-practitioner.html">US Core Practitioner Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Practitioner resource using: <code class="highlighter-rouge">GET [base]/Practitioner/[id]</code> </li> </ul> <p>Search Parameter Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-practitioner-name.html"> name</a> </td> <td> string </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-practitioner-identifier.html"> identifier</a> </td> <td> token </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href="SearchParameter-us-core-practitioner-identifier.html"> identifier</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr/> <h4 id="practitionerrole" class="no_toc">PractitionerRole</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>The US Core Location and PractitionerRole Profiles are not explicitly referenced in any US Core Profile. However they <strong>SHOULD</strong> be used as the default profile if referenced by another US Core profile.</li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-practitionerrole.html">US Core PractitionerRole Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a PractitionerRole resource using: <code class="highlighter-rouge">GET [base]/PractitionerRole/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _includes: PractitionerRole:endpoint - <code class="highlighter-rouge">GET [base]/PractitionerRole?[parameter=value]&amp;_include=PractitionerRole:endpoint</code> PractitionerRole:practitioner - <code class="highlighter-rouge">GET [base]/PractitionerRole?[parameter=value]&amp;_include=PractitionerRole:practitioner</code> </li> </ul> <p>Search Parameter Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-practitionerrole-specialty.html"> specialty</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-practitionerrole-practitioner.html"> practitioner</a> </td> <td> reference </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href="SearchParameter-us-core-practitionerrole-specialty.html"> specialty</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-practitionerrole-practitioner.html"> practitioner</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr/> <h4 id="procedure" class="no_toc">Procedure</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>A procedure including an implantable device <strong>SHOULD</strong> use <code>Procedure.focalDevice</code> with a reference to the [US Core Implantable Device Profile].</li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-procedure.html">US Core Procedure Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>search-type</code>, <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Procedure resource using: <code class="highlighter-rouge">GET [base]/Procedure/[id]</code> </li> <li> A Client <strong>SHOULD</strong> be capable of supporting the following _revincludes: Provenance:target - <code class="highlighter-rouge">GET [base]/Procedure?[parameter=value]&amp;_revinclude=Provenance:target</code> </li> </ul> <p>Search Parameter Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter</th> <th>Type</th> </tr> </thead> <tbody><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-procedure-status.html"> status</a> </td> <td> token </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-procedure-patient.html"> patient</a> </td> <td> reference </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-procedure-date.html"> date</a> </td> <td> date </td> </tr><tr> <td> <strong>SHOULD</strong> </td> <td> <a href="SearchParameter-us-core-procedure-code.html"> code</a> </td> <td> token </td> </tr> </tbody> </table> <p>Search Parameter Combination Summary:</p> <table class="grid"> <thead> <tr> <th>Conformance</th> <th>Parameter Combination</th> <th>Types</th> </tr> </thead> <tbody> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-code"> code</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-date"> date</a> </td> <td>reference+token+date </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-status"> status</a> </td> <td>reference+token </td> </tr> <tr> <td><strong>SHOULD</strong> </td> <td> <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient"> patient</a>+ <a href="http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-date"> date</a> </td> <td>reference+date </td> </tr> </tbody> </table> <div> <p>Search Parameter Requirements (When Used Alone or in Combination):</p> <ul><li><a href="SearchParameter-us-core-procedure-status.html"> status</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-procedure-patient.html"> patient</a> (reference):<p>The client <strong>SHALL</strong> provide at least a id value and <strong>MAY</strong> provide both the Type and id values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li><li><a href="SearchParameter-us-core-procedure-date.html"> date</a> (date):<p>A client <strong>SHALL</strong> provide a value precise to the <em>second + time offset</em>.</p> <p>A server <strong>SHALL</strong> support a value precise to the <em>second + time offset</em>.</p> </li><li><a href="SearchParameter-us-core-procedure-code.html"> code</a> (token):<p>The client <strong>SHALL</strong> provide at least a code value and <strong>MAY</strong> provide both the system and code values.</p> <p>The server <strong>SHALL</strong> support both.</p> </li> </ul> </div> <hr/> <h4 id="provenance" class="no_toc">Provenance</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Resource Specific Documentation:</p> <blockquote><ul> <li>If a system receives a provider in <code>Provenance.agent.who</code> as free text they must capture who sent them the information as the organization. On request they <strong>SHALL</strong> provide this organization as the source and <strong>MAY</strong> include the free text provider.</li> <li>Systems that need to know the activity has occurred <strong>SHOULD</strong> populate the activity.</li> </ul> </blockquote> <p>Supported Profiles:</p> <ul> <li><strong>SHALL</strong> support: <a href="StructureDefinition-us-core-provenance.html">US Core Provenance Profile</a> </li> </ul> <p>Profile Interaction Summary:</p> <ul> <li><strong>SHALL</strong> support <code>read</code>.</li><li><strong>SHOULD</strong> support <code>vread</code>, <code>history-instance</code>.</li><li><strong>MAY</strong> support <code>create</code>, <code>search-type</code>, <code>update</code>, <code>patch</code>, <code>delete</code>, <code>history-type</code>.</li> </ul> <p>Fetch and Search Criteria:</p> <ul> <li> A Client <strong>SHALL</strong> be capable of fetching a Provenance resource using: <code class="highlighter-rouge">GET [base]/Provenance/[id]</code> </li> </ul> <hr/> <h4 id="valueset" class="no_toc">ValueSet</h4> <p>Conformance Expectation: <strong>SHOULD</strong></p> <p>Operation Summary:</p> <ul> <li><strong>SHOULD</strong> support the <a href="http://hl7.org/fhir/OperationDefinition/ValueSet-expand">$expand</a> operation <p>A client can determine the note and report types support by a server by invoking the standard FHIR Value Set Expansion ($expand) operation defined in the FHIR R4 specification. Because servers may support different read and write formats, it also is used to determine the formats (for example, text, pdf) the server supports read and write transactions.</p> </li> </ul> <hr/> </div>
+  </text>
+  <url value="http://hl7.org/fhir/us/core/CapabilityStatement/us-core-client"/>
+  <version value="4.0.0"/>
+  <name value="UsCoreClientCapabilityStatement"/>
+  <title value="US Core Client CapabilityStatement"/>
+  <status value="active"/>
+  <experimental value="false"/>
+  <date value="2021-06-17T14:23:50.993763-08:00"/>
+  <publisher value="HL7 International - US Realm Steering Committee"/>
+  <contact>
+    <name value="HL7 International - US Realm Steering Committee"/>
+    <telecom>
+      <system value="url"/>
+      <value value="http://www.hl7.org/Special/committees/usrealm/index.cfm"/>
+    </telecom>
+  </contact>
+  <description value="This Section describes the expected capabilities of the US Core Client which is responsible for creating and initiating the queries for information about an individual patient. The complete list of FHIR profiles, RESTful operations, and search parameters supported by US Core Servers are defined in the [Conformance Requirements for Server](CapabilityStatement-us-core-server.html). US Core Clients have the option of choosing from this list to access necessary data based on their local use cases and other contextual requirements."/>
+  <jurisdiction>
+    <coding>
+      <system value="urn:iso:std:iso:3166"/>
+      <code value="US"/>
+    </coding>
+  </jurisdiction>
+  <copyright value="Used by permission of HL7 International, all rights reserved Creative Commons License"/>
+  <kind value="requirements"/>
+  <instantiates value="http://hl7.org/fhir/us/core/CapabilityStatement/us-core-client">
+    <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+      <valueCode value="SHALL"/>
+    </extension>
+  </instantiates>
+  <fhirVersion value="4.0.1"/>
+  <format value="json">
+    <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+      <valueCode value="SHALL"/>
+    </extension>
+  </format>
+  <format value="xml">
+    <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+      <valueCode value="SHOULD"/>
+    </extension>
+  </format>
+  <patchFormat value="application/json-patch+json">
+    <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+      <valueCode value="SHOULD"/>
+    </extension>
+  </patchFormat>
+  <implementationGuide value="http://fhir-registry.smarthealthit.org">
+    <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+      <valueCode value="SHOULD"/>
+    </extension>
+  </implementationGuide>
+  <implementationGuide value="http://hl7.org/fhir/uv/bulkdata/ImplementationGuide/hl7.fhir.uv.bulkdata">
+    <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+      <valueCode value="SHOULD"/>
+    </extension>
+  </implementationGuide>
+  <rest>
+    <mode value="client"/>
+    <documentation value="The US Core Client **SHALL**:&#xA;&#xA;1. Support fetching and querying of one or more US Core profile(s), using the supported RESTful interactions and search parameters declared in the US Core Server CapabilityStatement.&#xA;"/>
+    <security>
+      <description value="1. See the [General Security Considerations] section for requirements and recommendations."/>
+    </security>
+    <resource>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="SHOULD"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="clinical-status"/>
+        </extension>
+      </extension>
+      <type value="AllergyIntolerance"/>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="create"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="search-type"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="read"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="vread"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="update"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="patch"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="delete"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="history-instance"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="history-type"/>
+      </interaction>
+      <searchRevInclude value="Provenance:target">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+      </searchRevInclude>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="clinical-status"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-clinical-status"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="patient"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-allergyintolerance-patient"/>
+        <type value="reference"/>
+        <documentation value="The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+    </resource>
+    <resource>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="SHOULD"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="category"/>
+        </extension>
+        <extension url="required">
+          <valueString value="date"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="category"/>
+        </extension>
+        <extension url="required">
+          <valueString value="status"/>
+        </extension>
+        <extension url="required">
+          <valueString value="date"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="category"/>
+        </extension>
+        <extension url="required">
+          <valueString value="status"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="category"/>
+        </extension>
+      </extension>
+      <type value="CarePlan"/>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="* Additional considerations for systems aligning with [HL7 Consolidated (C-CDA)](http://www.hl7.org/implement/standards/product_brief.cfm?product_id=492) Care Plan requirements:&#xA;    - US Core Goal **SHOULD** be present in CarePlan.goal&#xA;    - US Core Condition **SHOULD** be present in CarePlan.addresses&#xA;    - Assement and Plan **MAY** be included as narrative text"/>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="create"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="search-type"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="read"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="vread"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="update"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="patch"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="delete"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="history-instance"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="history-type"/>
+      </interaction>
+      <searchRevInclude value="Provenance:target">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+      </searchRevInclude>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="category"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-category"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="date"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-date"/>
+        <type value="date"/>
+        <documentation value="A client **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A server **SHALL** support a value precise to the *second + time offset*."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="patient"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-patient"/>
+        <type value="reference"/>
+        <documentation value="The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="status"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-careplan-status"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+    </resource>
+    <resource>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="SHOULD"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="status"/>
+        </extension>
+      </extension>
+      <type value="CareTeam"/>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="create"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="search-type"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="read"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="vread"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="update"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="patch"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="delete"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="history-instance"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="history-type"/>
+      </interaction>
+      <searchRevInclude value="Provenance:target">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+      </searchRevInclude>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="patient"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-patient"/>
+        <type value="reference"/>
+        <documentation value="The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="status"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-careteam-status"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+    </resource>
+    <resource>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="SHOULD"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="code"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="onset-date"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="clinical-status"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="category"/>
+        </extension>
+      </extension>
+      <type value="Condition"/>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="create"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="search-type"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="read"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="vread"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="update"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="patch"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="delete"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="history-instance"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="history-type"/>
+      </interaction>
+      <searchRevInclude value="Provenance:target">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+      </searchRevInclude>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="category"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-category"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="clinical-status"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-clinical-status"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="patient"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-patient"/>
+        <type value="reference"/>
+        <documentation value="The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="onset-date"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-onset-date"/>
+        <type value="date"/>
+        <documentation value="A client **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A server **SHALL** support a value precise to the *second + time offset*."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="code"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-condition-code"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+    </resource>
+    <resource>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="SHOULD"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="type"/>
+        </extension>
+      </extension>
+      <type value="Device"/>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="* Implantable medical devices that have UDI information **SHALL** represent the UDI code in `Device.udiCarrier.carrierHRF`.&#xA;   - All of the five UDI-PI elements that are present in the UDI code **SHALL** be represented in the corresponding US Core Implantable Device Profile element.&#xA;   &#xA;   UDI may not be present in all scenarios such as historical implantable devices, patient reported implant information, payer reported devices, or improperly documented implants. If UDI is not present and the manufacturer and/or model number information is available, they **SHOULD** be included to support historical reports of implantable medical devices as follows:&#xA;&#xA;    &lt;table&gt;&#xA;    &lt;thead&gt;&#xA;    &lt;tr class=&quot;header&quot;&gt;&#xA;    &lt;th&gt;data element&lt;/th&gt;&#xA;    &lt;th&gt;US Core Implantable Device Profile element&lt;/th&gt;&#xA;    &lt;/tr&gt;&#xA;    &lt;/thead&gt;&#xA;    &lt;tbody&gt;&#xA;    &lt;tr class=&quot;odd&quot;&gt;&#xA;    &lt;td&gt;manufacturer&lt;/td&gt;&#xA;    &lt;td&gt;Device.manufacturer&lt;/td&gt;&#xA;    &lt;/tr&gt;&#xA;    &lt;tr class=&quot;even&quot;&gt;&#xA;    &lt;td&gt;model&lt;/td&gt;&#xA;    &lt;td&gt;Device.model&lt;/td&gt;&#xA;    &lt;/tr&gt;&#xA;    &lt;/tbody&gt;&#xA;    &lt;/table&gt;&#xA;&#xA;* Servers **SHOULD** support query by Device.type to allow clients to request the patient&#39;s devices by a specific type. Note: The Device.type is too granular to differentiate implantable vs. non-implantable devices.  &#xA;* In the Quick Start section below, searching for all devices is described. Records of implanted devices **MAY** be queried against UDI data including:&#xA;&#xA;    - UDI HRF string (`udi-carrier`)&#xA;    - UDI Device Identifier (`udi-di`)&#xA;    - Manufacturer (`manufacturer`)&#xA;    - Model number (`model`)&#xA;&#xA;  Implementers **MAY** also adopt custom SearchParameters for searching by:&#xA;&#xA;    - lot numbers&#xA;    - serial number&#xA;    - expiration date&#xA;    - manufacture date&#xA;    - distinct identifier"/>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="create"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="search-type"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="read"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="vread"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="update"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="patch"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="delete"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="history-instance"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="history-type"/>
+      </interaction>
+      <searchRevInclude value="Provenance:target">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+      </searchRevInclude>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="patient"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-device-patient"/>
+        <type value="reference"/>
+        <documentation value="The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="type"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-device-type"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+    </resource>
+    <resource>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="SHOULD"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="code"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="code"/>
+        </extension>
+        <extension url="required">
+          <valueString value="date"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="category"/>
+        </extension>
+        <extension url="required">
+          <valueString value="date"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="status"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="category"/>
+        </extension>
+      </extension>
+      <type value="DiagnosticReport"/>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="create"/>
+        <documentation value="This conformance expectation applies **only**  to the *US Core DiagnosticReport Profile for Report and Note exchange* profile.  The conformance expectation for the *US Core DiagnosticReport Profile for Laboratory Results Reporting* is  **MAY**."/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="search-type"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="read"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="vread"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="update"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="patch"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="delete"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="history-instance"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="history-type"/>
+      </interaction>
+      <searchRevInclude value="Provenance:target">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+      </searchRevInclude>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="status"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-status"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="patient"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-patient"/>
+        <type value="reference"/>
+        <documentation value="The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="category"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-category"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="code"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-code"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="date"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-diagnosticreport-date"/>
+        <type value="date"/>
+        <documentation value="A client **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A server **SHALL** support a value precise to the *second + time offset*."/>
+      </searchParam>
+    </resource>
+    <resource>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="SHOULD"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="category"/>
+        </extension>
+        <extension url="required">
+          <valueString value="date"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="status"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="type"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="type"/>
+        </extension>
+        <extension url="required">
+          <valueString value="period"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="category"/>
+        </extension>
+      </extension>
+      <type value="DocumentReference"/>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="The DocumentReference.type binding SHALL support at a minimum the [5 Common Clinical Notes](ValueSet-us-core-clinical-note-type.html) and may extend to the full US Core DocumentReference Type Value Set"/>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="create"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="search-type"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="read"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="vread"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="update"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="patch"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="delete"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="history-instance"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="history-type"/>
+      </interaction>
+      <searchRevInclude value="Provenance:target">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+      </searchRevInclude>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="_id"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-id"/>
+        <type value="token"/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="status"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-status"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="patient"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-patient"/>
+        <type value="reference"/>
+        <documentation value="The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="category"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-category"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="type"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-type"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="date"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-date"/>
+        <type value="date"/>
+        <documentation value="A client **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A server **SHALL** support a value precise to the *second + time offset*."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="period"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-documentreference-period"/>
+        <type value="date"/>
+        <documentation value="A client **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A server **SHALL** support a value precise to the *second + time offset*."/>
+      </searchParam>
+      <operation>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="docref"/>
+        <definition value="http://hl7.org/fhir/us/core/OperationDefinition/docref"/>
+        <documentation value="A client **SHOULD** be capable of transacting a $docref operation and capable of receiving at least a reference to a generated CCD document, and  **MAY** be able to receive other document types, if available.   **SHOULD**  be capable of receiving documents as included resources in response to the operation.&#xA;&#xA;`GET [base]/DocumentReference/$docref?patient=[id]`"/>
+      </operation>
+    </resource>
+    <resource>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="SHOULD"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="type"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="status"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="class"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="date"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+      </extension>
+      <type value="Encounter"/>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="* The Encounter resource can represent a reason using either a code with `Encounter.reasonCode`, or a reference with `Encounter.reasonReference` to  Condition or other resource.&#xA;   * Although both are marked as must support, the server systems are not required to support both a code and a reference, but they **SHALL** support *at least one* of these elements.&#xA;   * The client application **SHALL** support both elements.&#xA;   * if `Encounter.reasonReference` references an Observation, it **SHOULD** conform to a US Core Observation if applicable. (for example, a laboratory result should conform to the US Core Laboratory Result Observation Profile)&#xA;* The intent of this profile is to support *where the encounter occurred*.  The location address can be represented by either by the Location referenced by `Encounter.location.location` or indirectly through the Organization referenced by `Encounter.serviceProvider`.&#xA;  * Although both are marked as must support, the server systems are not required to support both `Encounter.location.location` and `Encounter.serviceProvider`, but they **SHALL** support *at least one* of these elements.&#xA;  * The client application **SHALL** support both elements.&#xA;  * if using `Encounter.locatison.location` it **SHOULD** conform to US Core Location.  However, as a result of implementation feedback, it **MAY**  reference the base FHIR Location resource.  See this guidance on [Referencing US Core Profiles]"/>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="create"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="search-type"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="read"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="vread"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="update"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="patch"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="delete"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="history-instance"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="history-type"/>
+      </interaction>
+      <searchRevInclude value="Provenance:target">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+      </searchRevInclude>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="_id"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-id"/>
+        <type value="token"/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="class"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-class"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="date"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-date"/>
+        <type value="date"/>
+        <documentation value="A client **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A server **SHALL** support a value precise to the *second + time offset*."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="identifier"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-identifier"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="patient"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-patient"/>
+        <type value="reference"/>
+        <documentation value="The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="status"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-status"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="type"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-encounter-type"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+    </resource>
+    <resource>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="SHOULD"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="lifecycle-status"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="target-date"/>
+        </extension>
+      </extension>
+      <type value="Goal"/>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="create"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="search-type"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="read"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="vread"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="update"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="patch"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="delete"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="history-instance"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="history-type"/>
+      </interaction>
+      <searchRevInclude value="Provenance:target">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+      </searchRevInclude>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="lifecycle-status"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-lifecycle-status"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="patient"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-patient"/>
+        <type value="reference"/>
+        <documentation value="The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="target-date"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-goal-target-date"/>
+        <type value="date"/>
+        <documentation value="A client **SHALL** provide a value precise to the *day*.&#xA;&#xA;A server **SHALL** support a value a value precise to the *day*."/>
+      </searchParam>
+    </resource>
+    <resource>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="SHOULD"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="status"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="date"/>
+        </extension>
+      </extension>
+      <type value="Immunization"/>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="* Based upon the ONC U.S. Core Data for Interoperability (USCDI) v1 requirements, CVX vaccine codes are required and the NDC vaccine codes **SHOULD** be supported as translations to them."/>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="create"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="search-type"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="read"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="vread"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="update"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="patch"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="delete"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="history-instance"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="history-type"/>
+      </interaction>
+      <searchRevInclude value="Provenance:target">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+      </searchRevInclude>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="patient"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-patient"/>
+        <type value="reference"/>
+        <documentation value="The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="status"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-status"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="date"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-immunization-date"/>
+        <type value="date"/>
+        <documentation value="A client **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A server **SHALL** support a value precise to the *second + time offset*."/>
+      </searchParam>
+    </resource>
+    <resource>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="SHOULD"/>
+      </extension>
+      <type value="Location"/>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-location">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="* The US Core Location  and PractitionerRole Profiles are not explicitly referenced in any US Core Profile. However they **SHOULD** be used as the default profile if referenced by another US Core profile."/>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="create"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="search-type"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="read"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="vread"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="update"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="patch"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="delete"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="history-instance"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="history-type"/>
+      </interaction>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="name"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-location-name"/>
+        <type value="string"/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="address"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address"/>
+        <type value="string"/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="address-city"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-city"/>
+        <type value="string"/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="address-state"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-state"/>
+        <type value="string"/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="address-postalcode"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-location-address-postalcode"/>
+        <type value="string"/>
+      </searchParam>
+    </resource>
+    <resource>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="SHOULD"/>
+      </extension>
+      <type value="Medication"/>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="* The  MedicationRequest resource can represent a medication, using an external reference to a Medication resource. If an external Medication Resource is used in a MedicationRequest, then the READ  **SHALL**  be supported."/>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="create"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="search-type"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="read"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="vread"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="update"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="patch"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="delete"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="history-instance"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="history-type"/>
+      </interaction>
+    </resource>
+    <resource>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="SHOULD"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="intent"/>
+        </extension>
+        <extension url="required">
+          <valueString value="status"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="intent"/>
+        </extension>
+        <extension url="required">
+          <valueString value="authoredon"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="intent"/>
+        </extension>
+        <extension url="required">
+          <valueString value="encounter"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="intent"/>
+        </extension>
+      </extension>
+      <type value="MedicationRequest"/>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="* The MedicationRequest resources can represent a medication using either a code or refer to the Medication resource. When referencing Medication, the resource may be [contained](http://hl7.org/fhir/R4/references.html#contained) or an external resource. The server application **MAY** choose any one way or more than one method, but if an external reference to Medication is used, the server **SHALL** support the _include` parameter for searching this element. The client application must support all methods.&#xA;&#xA; For example, A server **SHALL** be capable of returning all medications for a patient using one of or both:&#xA;&#xA; `GET /MedicationRequest?patient=[id]`&#xA;&#xA; `GET /MedicationRequest?patient=[id]&amp;_include=MedicationRequest:medication`&#xA;&#xA;* The MedicationRequest resource can represent that information is from a secondary source using either a boolean flag or reference in `MedicationRequest.reportedBoolean`, or a reference using `MedicationRequest.reportedReference` to Practitioner or other resource.&#xA;   *   Although both are marked as must support, the server systems are not required to support both a boolean and a reference, but **SHALL** choose to support at least one of these elements.&#xA;   *  The client application **SHALL** support both elements."/>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="create"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="search-type"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="read"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="vread"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="update"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="patch"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="delete"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="history-instance"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="history-type"/>
+      </interaction>
+      <searchInclude value="MedicationRequest:medication">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+      </searchInclude>
+      <searchRevInclude value="Provenance:target">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+      </searchRevInclude>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="status"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-status"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="intent"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-intent"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="patient"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-patient"/>
+        <type value="reference"/>
+        <documentation value="The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="encounter"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-encounter"/>
+        <type value="reference"/>
+        <documentation value="The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="authoredon"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-medicationrequest-authoredon"/>
+        <type value="date"/>
+        <documentation value="A client **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A server **SHALL** support a value precise to the *second + time offset*."/>
+      </searchParam>
+    </resource>
+    <resource>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="SHOULD"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="category"/>
+        </extension>
+        <extension url="required">
+          <valueString value="status"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="code"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="code"/>
+        </extension>
+        <extension url="required">
+          <valueString value="date"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="category"/>
+        </extension>
+        <extension url="required">
+          <valueString value="date"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="category"/>
+        </extension>
+      </extension>
+      <type value="Observation"/>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-vital-signs">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-blood-pressure">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-bmi">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-head-circumference">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-height">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-weight">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-body-temperature">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-heart-rate">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-respiratory-rate">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="* Systems **SHOULD** support `Observation.effectivePeriod` to accurately represent laboratory tests that are collected over a period of time (for example, a 24-Hour Urine Collection test).&#xA;* An Observation without a value, **SHALL** include a reason why the data is absent unless there are component observations, or references to other Observations that are grouped within it."/>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="create"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="search-type"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="read"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="vread"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="update"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="patch"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="delete"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="history-instance"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="history-type"/>
+      </interaction>
+      <searchRevInclude value="Provenance:target">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+      </searchRevInclude>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="status"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-status"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="category"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-category"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="code"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-code"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="date"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-date"/>
+        <type value="date"/>
+        <documentation value="A client **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A server **SHALL** support a value precise to the *second + time offset*."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="patient"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-observation-patient"/>
+        <type value="reference"/>
+        <documentation value="The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+    </resource>
+    <resource>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="SHOULD"/>
+      </extension>
+      <type value="Organization"/>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="create"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="search-type"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="read"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="vread"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="update"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="patch"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="delete"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="history-instance"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="history-type"/>
+      </interaction>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="name"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-name"/>
+        <type value="string"/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="address"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-organization-address"/>
+        <type value="string"/>
+      </searchParam>
+    </resource>
+    <resource>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="SHOULD"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="gender"/>
+        </extension>
+        <extension url="required">
+          <valueString value="name"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="family"/>
+        </extension>
+        <extension url="required">
+          <valueString value="gender"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="birthdate"/>
+        </extension>
+        <extension url="required">
+          <valueString value="family"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="birthdate"/>
+        </extension>
+        <extension url="required">
+          <valueString value="name"/>
+        </extension>
+      </extension>
+      <type value="Patient"/>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="* For ONC&#39;s USCDI requirements, each Patient must support the following additional elements. These elements are included in the formal definition of the profile. The patient examples include all of these elements.&#xA;&#xA;1. contact detail (e.g. a telephone number or an email address)&#xA;1. a communication language&#xA;1. a race&#xA;1. an ethnicity&#xA;1. a birth sex*&#xA;1. previous name&#xA;   - Previous name is represented by providing an end date in the `Patient.name.period` element for a previous name.&#xA;1. suffix&#xA;   - Suffix is represented using the `Patient.name.suffix` element.&#xA;&#xA;"/>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="create"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="search-type"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="read"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="vread"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="update"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="patch"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="delete"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="history-instance"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="history-type"/>
+      </interaction>
+      <searchRevInclude value="Provenance:target">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+      </searchRevInclude>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="_id"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-id"/>
+        <type value="token"/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="birthdate"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-birthdate"/>
+        <type value="date"/>
+        <documentation value="A client **SHALL** provide a value precise to the *day*.&#xA;&#xA;A server **SHALL** support a value a value precise to the *day*."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="family"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-family"/>
+        <type value="string"/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="gender"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-gender"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="given"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-given"/>
+        <type value="string"/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="identifier"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-identifier"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="name"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-patient-name"/>
+        <type value="string"/>
+      </searchParam>
+    </resource>
+    <resource>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="SHOULD"/>
+      </extension>
+      <type value="Practitioner"/>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="create"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="search-type"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="read"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="vread"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="update"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="patch"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="delete"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="history-instance"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="history-type"/>
+      </interaction>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="name"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-name"/>
+        <type value="string"/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="identifier"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-practitioner-identifier"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+    </resource>
+    <resource>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="SHOULD"/>
+      </extension>
+      <type value="PractitionerRole"/>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="* The US Core Location  and PractitionerRole Profiles are not explicitly referenced in any US Core Profile. However they **SHOULD** be used as the default profile if referenced by another US Core profile."/>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="create"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="search-type"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="read"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="vread"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="update"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="patch"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="delete"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="history-instance"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="history-type"/>
+      </interaction>
+      <searchInclude value="PractitionerRole:endpoint">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+      </searchInclude>
+      <searchInclude value="PractitionerRole:practitioner">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+      </searchInclude>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="specialty"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-specialty"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="practitioner"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-practitionerrole-practitioner"/>
+        <type value="reference"/>
+        <documentation value="The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+    </resource>
+    <resource>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="SHOULD"/>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="code"/>
+        </extension>
+        <extension url="required">
+          <valueString value="date"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="status"/>
+        </extension>
+      </extension>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-search-parameter-combination">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <extension url="required">
+          <valueString value="patient"/>
+        </extension>
+        <extension url="required">
+          <valueString value="date"/>
+        </extension>
+      </extension>
+      <type value="Procedure"/>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="*  A procedure including an implantable device **SHOULD** use `Procedure.focalDevice` with a reference to the [US Core Implantable Device Profile]."/>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="create"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="search-type"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="read"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="vread"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="update"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="patch"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="delete"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="history-instance"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="history-type"/>
+      </interaction>
+      <searchRevInclude value="Provenance:target">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+      </searchRevInclude>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="status"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-status"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="patient"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-patient"/>
+        <type value="reference"/>
+        <documentation value="The client **SHALL** provide at least a id value and **MAY** provide both the Type and id values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="date"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-date"/>
+        <type value="date"/>
+        <documentation value="A client **SHALL** provide a value precise to the *second + time offset*.&#xA;&#xA;A server **SHALL** support a value precise to the *second + time offset*."/>
+      </searchParam>
+      <searchParam>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="code"/>
+        <definition value="http://hl7.org/fhir/us/core/SearchParameter/us-core-procedure-code"/>
+        <type value="token"/>
+        <documentation value="The client **SHALL** provide at least a code value and **MAY** provide both the system and code values.&#xA;&#xA;The server **SHALL** support both."/>
+      </searchParam>
+    </resource>
+    <resource>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="SHOULD"/>
+      </extension>
+      <type value="Provenance"/>
+      <supportedProfile value="http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance">
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+      </supportedProfile>
+      <documentation value="* If a system receives a provider in `Provenance.agent.who` as free text they must capture who sent them the information as the organization. On request they **SHALL** provide this organization as the source and **MAY** include the free text provider.&#xA;* Systems that need to know the activity has occurred **SHOULD** populate the activity."/>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="create"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="search-type"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHALL"/>
+        </extension>
+        <code value="read"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="vread"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="update"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="patch"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="delete"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <code value="history-instance"/>
+      </interaction>
+      <interaction>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="MAY"/>
+        </extension>
+        <code value="history-type"/>
+      </interaction>
+    </resource>
+    <resource>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="SHOULD"/>
+      </extension>
+      <type value="ValueSet"/>
+      <operation>
+        <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+          <valueCode value="SHOULD"/>
+        </extension>
+        <name value="expand"/>
+        <definition value="http://hl7.org/fhir/OperationDefinition/ValueSet-expand"/>
+        <documentation value="A  client can determine the note and report types support by a server by invoking the standard FHIR Value Set Expansion ($expand) operation defined in the FHIR R4 specification. Because servers may support different read and write formats, it also is used to determine the formats (for example, text, pdf) the server supports read and write transactions."/>
+      </operation>
+    </resource>
+    <interaction>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="MAY"/>
+      </extension>
+      <code value="transaction"/>
+    </interaction>
+    <interaction>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="MAY"/>
+      </extension>
+      <code value="batch"/>
+    </interaction>
+    <interaction>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="MAY"/>
+      </extension>
+      <code value="search-system"/>
+    </interaction>
+    <interaction>
+      <extension url="http://hl7.org/fhir/StructureDefinition/capabilitystatement-expectation">
+        <valueCode value="MAY"/>
+      </extension>
+      <code value="history-system"/>
+    </interaction>
+  </rest>
+</CapabilityStatement>


### PR DESCRIPTION
Addresses [CIMPL-780](https://standardhealthrecord.atlassian.net/browse/CIMPL-780), adding a debug message for especially large Instances with the potential to appear stalled out during processing. A file is considered "large" if the length of its buffer array exceeds 200,000 entries when its file is first read in, in which case a `large` property is added to the corresponding WildFHIR object. This `large` property triggers the warning when instances are being processed.

This can be tested by running GoFSH against the [UTG IG](https://github.com/HL7/UTG) with the debug flag turned on. 