### PR TITLE
Add options for handling meta.profile on instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,17 @@ $ gofsh --help
 Usage: goFSH [path-to-fhir-resources] [options]
 
 Options:
-  -o, --out <out>                  the path to the output folder
-  -l, --log-level <level>          specify the level of log messages: error, warn, info (default), debug
-  -d, --dependency <dependency...> specify dependencies to be loaded using format dependencyId@version (FHIR R4 included by default)
-  -v, --version                    print goFSH version
-  -h, --help                       display help for command
-  -s, --style                      specify how the output is organized into files: file-per-definition (default), group-by-fsh-type, group-by-profile, single-file
-  -f, --fshing-trip                run SUSHI on the output of GoFSH and generate a comparison of the round trip results
-  -t, --file-type                  specify which file types GoFSH should accept as input: json-only (default), xml-only, json-and-xml
-  -i, --installed-sushi            use the locally installed version of SUSHI when generating comparisons with the "-f" option
+  -o, --out <out>                   the path to the output folder
+  -l, --log-level <level>           specify the level of log messages: error, warn, info (default), debug
+  -d, --dependency <dependency...>  specify dependencies to be loaded using format dependencyId@version (FHIR R4 included by default)
+  -s, --style <style>               specify how the output is organized into files: file-per-definition (default), group-by-fsh-type, group-by-profile, single-file
+  -f, --fshing-trip                 run SUSHI on the output of GoFSH and generate a comparison of the round trip results
+  -i, --installed-sushi             use the locally installed version of SUSHI when generating comparisons with the "-f" option
+  -t, --file-type <type>            specify which file types GoFSH should accept as input: json-only (default), xml-only, json-and-xml
+  --indent                          output FSH with indented rules using context paths
+  --meta-profile <mode>             specify how meta.profile on Instances should be applied to the InstanceOf keyword: only-one (default), first, none
+  -v, --version                     print goFSH version
+  -h, --help                        display help for command
 ```
 
 # Installation for Developers

--- a/src/optimizer/OptimizerPlugin.ts
+++ b/src/optimizer/OptimizerPlugin.ts
@@ -34,7 +34,7 @@ export interface OptimizerPlugin {
    * @param pkg - the Package containing all of the definitions that can potentially be optimized
    * @param fisher - a fisher that can be used to look up definitions from local files, FHIR core, and dependencies
    */
-  optimize(pkg: Package, fisher?: MasterFisher): void;
+  optimize(pkg: Package, fisher?: MasterFisher, options?: ProcessingOptions): void;
 
   /**
    * Determines whether to run the optimizer based on provided options. If this function is not present, the optimizer will always run.

--- a/src/processor/FHIRProcessor.ts
+++ b/src/processor/FHIRProcessor.ts
@@ -1,5 +1,5 @@
 import semver from 'semver';
-import { MasterFisher, logger } from '../utils';
+import { MasterFisher, logger, ProcessingOptions } from '../utils';
 import {
   StructureDefinitionProcessor,
   CodeSystemProcessor,
@@ -87,7 +87,7 @@ export class FHIRProcessor {
     }
   }
 
-  process(config: ExportableConfiguration): Package {
+  process(config: ExportableConfiguration, options: ProcessingOptions = {}): Package {
     const resources = new Package();
     const igForConfig =
       this.lake.getAllImplementationGuides().find(doc => doc.path === this.igPath) ??
@@ -139,7 +139,9 @@ export class FHIRProcessor {
             `Instance ${wild.content.id} is especially large. Processing may take a while.`
           );
         }
-        resources.add(InstanceProcessor.process(wild.content, igForConfig?.content, this.fisher));
+        resources.add(
+          InstanceProcessor.process(wild.content, igForConfig?.content, this.fisher, options)
+        );
         this.outputCount(instances, index, 'Instance');
       } catch (ex) {
         logger.error(`Could not process Instance at ${wild.path}: ${ex.message}`);

--- a/src/processor/InstanceProcessor.ts
+++ b/src/processor/InstanceProcessor.ts
@@ -2,13 +2,32 @@ import { cloneDeep, compact, isEmpty } from 'lodash';
 import { fhirtypes, utils } from 'fsh-sushi';
 import { ExportableAssignmentRule, ExportableInstance } from '../exportable';
 import { removeUnderscoreForPrimitiveChildPath } from '../exportable/common';
-import { getFSHValue, isFSHValueEmpty, getPathValuePairs, logger } from '../utils';
+import {
+  getFSHValue,
+  isFSHValueEmpty,
+  getPathValuePairs,
+  logger,
+  ProcessingOptions
+} from '../utils';
 import { switchQuantityRules } from '.';
 
 export class InstanceProcessor {
-  static extractKeywords(input: any, target: ExportableInstance, implementationGuide: any): void {
-    target.instanceOf =
-      input.meta?.profile?.length === 1 ? input.meta.profile[0] : input.resourceType;
+  static extractKeywords(
+    input: any,
+    target: ExportableInstance,
+    implementationGuide: any,
+    options: ProcessingOptions = {}
+  ): void {
+    if (options.metaProfile === 'first') {
+      target.instanceOf =
+        input.meta?.profile?.length > 0 ? input.meta.profile[0] : input.resourceType;
+    } else if (options.metaProfile === 'none') {
+      target.instanceOf = input.resourceType;
+    } else {
+      target.instanceOf =
+        input.meta?.profile?.length === 1 ? input.meta.profile[0] : input.resourceType;
+    }
+
     const resource: fhirtypes.ImplementationGuideDefinitionResource = implementationGuide?.definition?.resource?.find(
       (resource: fhirtypes.ImplementationGuideDefinitionResource) =>
         resource.reference?.reference === `${input.resourceType}/${input.id}`
@@ -30,7 +49,12 @@ export class InstanceProcessor {
     }
   }
 
-  static extractRules(input: any, target: ExportableInstance, fisher: utils.Fishable): void {
+  static extractRules(
+    input: any,
+    target: ExportableInstance,
+    fisher: utils.Fishable,
+    options: ProcessingOptions
+  ): void {
     const newRules: ExportableInstance['rules'] = [];
     // Clone input so it can be modified
     const inputJSON = cloneDeep(input);
@@ -43,7 +67,7 @@ export class InstanceProcessor {
     );
 
     if (instanceOfJSON == null) {
-      if (input.meta?.profile?.length === 1) {
+      if (input.meta?.profile?.length > 0) {
         logger.warn(
           `InstanceOf definition not found for ${input.id}. The ResourceType of the instance will be used as a base.`
         );
@@ -62,9 +86,16 @@ export class InstanceProcessor {
         );
         return;
       }
-    } else if (inputJSON.meta?.profile?.length === 1) {
-      // If we found JSON for exactly one profile, delete meta.profile.
-      delete inputJSON.meta?.profile;
+    } else if (
+      (inputJSON.meta?.profile?.length === 1 && options.metaProfile !== 'none') ||
+      (inputJSON.meta?.profile?.length > 0 && options.metaProfile === 'first')
+    ) {
+      // If we found JSON for the profile, delete it from meta.profile.
+      inputJSON.meta.profile.splice(0, 1);
+      if (isEmpty(inputJSON.meta.profile)) {
+        delete inputJSON.meta.profile;
+      }
+
       if (isEmpty(inputJSON.meta)) {
         delete inputJSON.meta;
       }
@@ -96,10 +127,15 @@ export class InstanceProcessor {
     switchQuantityRules(target.rules);
   }
 
-  static process(input: any, implementationGuide: any, fisher: utils.Fishable): ExportableInstance {
+  static process(
+    input: any,
+    implementationGuide: any,
+    fisher: utils.Fishable,
+    options: ProcessingOptions = {}
+  ): ExportableInstance {
     const instance = new ExportableInstance(input.id);
-    InstanceProcessor.extractKeywords(input, instance, implementationGuide);
-    InstanceProcessor.extractRules(input, instance, fisher);
+    InstanceProcessor.extractKeywords(input, instance, implementationGuide, options);
+    InstanceProcessor.extractRules(input, instance, fisher, options);
     return instance;
   }
 }

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -70,14 +70,14 @@ export async function getResources(
   options: ProcessingOptions = {}
 ): Promise<Package> {
   const fisher = processor.getFisher();
-  const resources = processor.process(config);
+  const resources = processor.process(config, options);
   // Dynamically load and run the optimizers
   logger.info('Optimizing FSH definitions to follow best practices...');
   const optimizers = await loadOptimizers();
   optimizers.forEach(opt => {
     if (typeof opt.isEnabled !== 'function' || opt.isEnabled(options)) {
       logger.debug(`Running optimizer ${opt.name}: ${opt.description}`);
-      opt.optimize(resources, fisher);
+      opt.optimize(resources, fisher, options);
     } else {
       logger.debug(`Skipping optimizer ${opt.name}: ${opt.description}`);
     }
@@ -308,6 +308,8 @@ const IGNORED_NON_RESOURCE_DIRECTORIES = [
 ];
 
 export type ProcessingOptions = {
+  indent?: boolean;
+  metaProfile?: 'only-one' | 'first' | 'none';
   [key: string]: boolean | number | string;
 };
 

--- a/test/processor/InstanceProcessor.test.ts
+++ b/test/processor/InstanceProcessor.test.ts
@@ -30,18 +30,66 @@ describe('InstanceProcessor', () => {
     expect(result.usage).toBe('Example');
   });
 
-  it('should convert an example Instance with a meta.profile', () => {
+  it('should convert an example Instance with one entry in meta.profile as the InstanceOf when that entry resolves to an SD', () => {
     const input = JSON.parse(
       fs.readFileSync(path.join(__dirname, 'fixtures', 'profiled-patient.json'), 'utf-8')
     );
     const result = InstanceProcessor.process(input, simpleIg, defs);
     expect(result).toBeInstanceOf(ExportableInstance);
     expect(result.name).toBe(
-      'profiled-patient-of-http://example.org/StructureDefinition/profiled-patient'
+      'profiled-patient-of-http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'
     );
     expect(result.id).toBe('profiled-patient');
-    expect(result.instanceOf).toBe('http://example.org/StructureDefinition/profiled-patient');
+    expect(result.instanceOf).toBe(
+      'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'
+    );
     expect(result.usage).toBe('Example');
+  });
+
+  it('should convert an example Instance with one entry in meta.profile using the base resource when that entry does not resolve to an SD', () => {
+    const input = JSON.parse(
+      fs.readFileSync(path.join(__dirname, 'fixtures', 'profiled-patient.json'), 'utf-8')
+    );
+    input.meta.profile[0] = 'http://example.org/StructureDefinition/some-unknown-profile';
+    const result = InstanceProcessor.process(input, simpleIg, defs);
+    expect(result).toBeInstanceOf(ExportableInstance);
+    expect(result.name).toBe(
+      'profiled-patient-of-http://example.org/StructureDefinition/some-unknown-profile'
+    );
+    expect(result.id).toBe('profiled-patient');
+    expect(result.instanceOf).toBe('Patient');
+    expect(result.usage).toBe('Example');
+
+    const expectedMetaProfile = new ExportableAssignmentRule('meta.profile[0]');
+    expectedMetaProfile.value = 'http://example.org/StructureDefinition/some-unknown-profile';
+    expect(result.rules).toContainEqual(expectedMetaProfile);
+
+    expect(loggerSpy.getLastMessage('warn')).toMatch(
+      /InstanceOf definition not found for profiled-patient/s
+    );
+  });
+
+  it('should convert an example Instance with multiple entries in meta.profile using the base resource as the InstanceOf', () => {
+    const input = JSON.parse(
+      fs.readFileSync(path.join(__dirname, 'fixtures', 'profiled-patient.json'), 'utf-8')
+    );
+    input.meta.profile.push('http://example.org/StructureDefinition/some-unknown-profile');
+    const result = InstanceProcessor.process(input, simpleIg, defs);
+    expect(result).toBeInstanceOf(ExportableInstance);
+    expect(result.name).toBe('profiled-patient-of-Patient');
+    expect(result.id).toBe('profiled-patient');
+    expect(result.instanceOf).toBe('Patient');
+    expect(result.usage).toBe('Example');
+
+    const firstProfile = new ExportableAssignmentRule('meta.profile[0]');
+    firstProfile.value = 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient';
+    const secondProfile = new ExportableAssignmentRule('meta.profile[1]');
+    secondProfile.value = 'http://example.org/StructureDefinition/some-unknown-profile';
+    expect(result.rules).toContainEqual(firstProfile);
+    expect(result.rules).toContainEqual(secondProfile);
+
+    // Even though the second entry in meta.profile won't resolve, we don't try to resolve them when there is more than one.
+    expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);
   });
 
   it('should convert the simplest vocabulary Instance', () => {
@@ -250,7 +298,7 @@ describe('InstanceProcessor', () => {
       expect(result.rules).toContainEqual(status);
     });
 
-    it('should use ResourceType and add assignment rules when InstanceOf is a profile that is not found', () => {
+    it('should use ResourceType and add assignment rules when there is one entry in meta.profile that is not found', () => {
       const input = JSON.parse(
         fs.readFileSync(
           path.join(__dirname, 'fixtures', 'invalid-parent-profile-patient.json'),
@@ -265,7 +313,18 @@ describe('InstanceProcessor', () => {
       expect(result.id).toBe('invalid-patient-parent');
       expect(loggerSpy.getAllMessages()).toHaveLength(1);
       expect(loggerSpy.getLastMessage('warn')).toMatch(/InstanceOf definition not found/s);
-      expect(result.rules).toHaveLength(2); // Add rules after using ResourceType as parent
+      expect(result.rules).toHaveLength(3); // Add rules after using ResourceType as parent
+
+      const expectedMetaProfile = new ExportableAssignmentRule('meta.profile[0]');
+      expectedMetaProfile.value = 'http://hl7.org/fhir/us/core/StructureDefinition/fake-parent';
+      const expectedGender = new ExportableAssignmentRule('gender');
+      expectedGender.value = new fshtypes.FshCode('female');
+      const expectedBirthDate = new ExportableAssignmentRule('birthDate');
+      expectedBirthDate.value = '1955-05-20';
+
+      expect(result.rules).toContainEqual(expectedMetaProfile);
+      expect(result.rules).toContainEqual(expectedGender);
+      expect(result.rules).toContainEqual(expectedBirthDate);
     });
 
     it('should not add assignment rules when ResourceType of Instance is not found', () => {

--- a/test/processor/fixtures/profiled-patient.json
+++ b/test/processor/fixtures/profiled-patient.json
@@ -1,6 +1,8 @@
 {
   "meta": {
-    "profile": ["http://example.org/StructureDefinition/profiled-patient"]
+    "profile": [
+      "http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient"
+    ]
   },
   "resourceType": "Patient",
   "id": "profiled-patient"


### PR DESCRIPTION
Fixes #136 and completes task [CIMPL-778](https://standardhealthrecord.atlassian.net/browse/CIMPL-778).

A new command line option is added so that the user can specify their desired strategy for dealing with the `meta.profile` array on Instances. The strategies are:

* `only-one`: If there is exactly one entry in the `meta.profile` array, try to use it as InstanceOf. If it is found when fishing, do not add an assignment rule to set it in the Instance's `meta.profile` array. If it is not found when fishing, log a warning and use `resourceType` as InstanceOf. If there is not exactly one entry in the `meta.profile` array, use the `resourceType` as InstanceOf. This is the default strategy used when the command line option is not provided.
* `first`: If there is at least one entry in the `meta.profile` array, try to use it as InstanceOf. If it is found when fishing, do not add an assignment rule to set it in the Instance's `meta.profile` array. If it is not found when fishing, log a warning and use `resourceType` as InstanceOf. If there are no entries in the `meta.profile` array, use the `resourceType` as InstanceOf.
* `none`: Ignore `meta.profile` when determining InstanceOf. Always use `resourceType` as InstanceOf.

The two places where we construct Instances are `InstanceProcessor.process` and `ConstructInlineInstanceOptimizer.optimize`. These functions now receive the processing options as an argument so that they can use the selected strategy.