### PR TITLE
Skip IG Publisher validation bundle

### DIFF
--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -237,6 +237,10 @@ export function isProcessableContent(content: any, source?: string): content is 
     // The IG Publisher creates weird "Intersection" and "Union" SD files, so this check filters them out
     logger.debug(`Skipping temporary "comparison" resource created by IG Publisher: ${source}`);
     return false;
+  } else if (source?.endsWith(path.join('other', 'validation-oo.json'))) {
+    // The IG Publisher creates a Bundle of OperationOutcome resources based on validation results, which we don't want
+    logger.debug(`Skipping validation outcome resource created by IG Publisher: ${source}`);
+    return false;
   } else {
     return true;
   }

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -197,6 +197,9 @@ describe('Processing', () => {
         /Skipping non-FHIR input: .*non-fhir\.json/
       );
       expect(loggerSpy.getMessageAtIndex(1, 'debug')).toMatch(
+        /Skipping validation outcome resource created by IG Publisher: .*validation-oo\.json/
+      );
+      expect(loggerSpy.getMessageAtIndex(2, 'debug')).toMatch(
         /Skipping temporary "comparison" resource created by IG Publisher: .*sd-us-core-observation-lab-mcode-cancer-disease-status-intersection\.json/
       );
       expect(result.profiles).toHaveLength(1);

--- a/test/utils/fixtures/some-non-fhir/other/validation-oo.json
+++ b/test/utils/fixtures/some-non-fhir/other/validation-oo.json
@@ -1,0 +1,21 @@
+{
+  "resourceType": "Bundle",
+  "type": "collection",
+  "timestamp": "2021-07-26T15:16:17.018+00:00",
+  "entry": [
+    {
+      "fullUrl": "http://example.org/fhir/OperationOutcome/StructureDefinition-some-profile",
+      "resource": {
+        "resourceType": "OperationOutcome",
+        "id": "StructureDefinition-some-profile"
+      }
+    },
+    {
+      "fullUrl": "http://example.org/fhir/OperationOutcome/StructureDefinition-some-extension",
+      "resource": {
+        "resourceType": "OperationOutcome",
+        "id": "StructureDefinition-some-extension"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #142 and completes task [CIMPL-799](https://standardhealthrecord.atlassian.net/browse/CIMPL-799).

The IG publisher puts some validation information into the package it produces. One of the files with validation information is a Bundle resource. However, it should be ignored when processing input.