### PR TITLE
GoFSH now recognizes Profiles of Logical Models

### DIFF
--- a/src/extractor/CaretValueRuleExtractor.ts
+++ b/src/extractor/CaretValueRuleExtractor.ts
@@ -102,7 +102,8 @@ export class CaretValueRuleExtractor {
         utils.Type.Resource,
         utils.Type.Type,
         utils.Type.Profile,
-        utils.Type.Extension
+        utils.Type.Extension,
+        utils.Type.Logical
       )
     );
 

--- a/src/extractor/MappingExtractor.ts
+++ b/src/extractor/MappingExtractor.ts
@@ -24,7 +24,8 @@ export class MappingExtractor {
       utils.Type.Resource,
       utils.Type.Type,
       utils.Type.Profile,
-      utils.Type.Extension
+      utils.Type.Extension,
+      utils.Type.Logical
     );
 
     // If there is no parent found, all the mappings should be exported.

--- a/src/processor/LakeOfFHIR.ts
+++ b/src/processor/LakeOfFHIR.ts
@@ -94,7 +94,7 @@ export class LakeOfFHIR implements utils.Fishable {
   // The first four are handled by the StructureDefinitionProcessor, but Instances are handled by InstanceProcessor.
   // Thus, splitting the categories based on that is useful.
   // The important fields here are kind and derivation.
-  // A Profile has kind "resource", "complex-type", or "primitive-type" and derivation "constraint".
+  // A Profile has kind "resource", "complex-type", "logical", or "primitive-type" and derivation "constraint".
   // An Extension has kind "complex-type", derivation "constraint", and type "Extension". It's a special case of Profile.
   // A Logical has kind "logical" and derivation "specialization".
   // A Resource has kind "resource" and derivation "specialization".
@@ -104,7 +104,7 @@ export class LakeOfFHIR implements utils.Fishable {
       if (d.content.derivation === 'specialization') {
         return ['primitive-type', 'complex-type'].includes(d.content.kind);
       } else {
-        return d.content.kind === 'logical';
+        return false;
       }
     } else {
       return false;

--- a/src/processor/StructureDefinitionProcessor.ts
+++ b/src/processor/StructureDefinitionProcessor.ts
@@ -52,7 +52,7 @@ export class StructureDefinitionProcessor {
         input.type === 'Extension'
       ) {
         sd = new ExportableExtension(name);
-      } else if (input.kind !== 'logical' && input.derivation === 'constraint') {
+      } else if (input.derivation === 'constraint') {
         sd = new ExportableProfile(name);
       } else {
         // this should never be encountered when running normally, hopefully,

--- a/test/processor/LakeOfFHIR.test.ts
+++ b/test/processor/LakeOfFHIR.test.ts
@@ -10,6 +10,7 @@ describe('LakeOfHIR', () => {
   beforeAll(() => {
     lake = new LakeOfFHIR(
       getWildFHIRs(
+        'logical-profile.json',
         'simple-profile.json',
         'simple-extension.json',
         'simple-logical-model.json',
@@ -31,30 +32,32 @@ describe('LakeOfHIR', () => {
 
   describe('#constructor', () => {
     it('should store all the passed in values', () => {
-      expect(lake.docs).toHaveLength(11);
-      expect(lake.docs[0].content.id).toBe('simple.profile');
-      expect(lake.docs[1].content.id).toBe('simple.extension');
-      expect(lake.docs[2].content.id).toBe('simple.logical');
-      expect(lake.docs[3].content.id).toBe('simple.resource');
-      expect(lake.docs[4].content.id).toBe('simple.codesystem');
-      expect(lake.docs[5].content.id).toBe('simple.valueset');
-      expect(lake.docs[6].content.id).toBe('simple.ig');
-      expect(lake.docs[7].content.id).toBe('rocky.balboa');
-      expect(lake.docs[8].content.id).toBe('unsupported.valueset');
-      expect(lake.docs[9].content.id).toBe(undefined);
-      expect(lake.docs[10].content.id).toBe('my.string.profile');
+      expect(lake.docs).toHaveLength(12);
+      expect(lake.docs[0].content.id).toBe('logical.profile');
+      expect(lake.docs[1].content.id).toBe('simple.profile');
+      expect(lake.docs[2].content.id).toBe('simple.extension');
+      expect(lake.docs[3].content.id).toBe('simple.logical');
+      expect(lake.docs[4].content.id).toBe('simple.resource');
+      expect(lake.docs[5].content.id).toBe('simple.codesystem');
+      expect(lake.docs[6].content.id).toBe('simple.valueset');
+      expect(lake.docs[7].content.id).toBe('simple.ig');
+      expect(lake.docs[8].content.id).toBe('rocky.balboa');
+      expect(lake.docs[9].content.id).toBe('unsupported.valueset');
+      expect(lake.docs[10].content.id).toBe(undefined);
+      expect(lake.docs[11].content.id).toBe('my.string.profile');
     });
   });
 
   describe('#getAllStructureDefinitions', () => {
     it('should get all structure definitions', () => {
       const results = lake.getAllStructureDefinitions();
-      expect(results).toHaveLength(5);
-      expect(results[0].content.id).toBe('simple.profile');
-      expect(results[1].content.id).toBe('simple.extension');
-      expect(results[2].content.id).toBe('simple.logical');
-      expect(results[3].content.id).toBe('simple.resource');
-      expect(results[4].content.id).toBe('my.string.profile');
+      expect(results).toHaveLength(6);
+      expect(results[0].content.id).toBe('logical.profile');
+      expect(results[1].content.id).toBe('simple.profile');
+      expect(results[2].content.id).toBe('simple.extension');
+      expect(results[3].content.id).toBe('simple.logical');
+      expect(results[4].content.id).toBe('simple.resource');
+      expect(results[5].content.id).toBe('my.string.profile');
     });
   });
 

--- a/test/processor/fixtures/logical-profile.json
+++ b/test/processor/fixtures/logical-profile.json
@@ -1,0 +1,10 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "logical.profile",
+  "url": "http://example.org/tests/StructureDefinition/logical.profile",
+  "kind": "logical",
+  "type": "http://example.org/StructureDefinition/SimpleLogicalModel",
+  "name": "SimpleLogicalProfile",
+  "derivation": "constraint",
+  "baseDefinition": "http://example.org/StructureDefinition/SimpleLogicalModel"
+}


### PR DESCRIPTION
Fixes #149, making it so that a Structure Definition of `"kind" : "logical"` and `"derivation": "constraint"` is properly recognized and exported as a `Profile`, rather than as an `Instance`. This handy [FSHOnline link](https://fshschool.org/FSHOnline/#/share/3CY7ECD) that @jafeltra cooked up illustrates the problem.  