### PR TITLE
1.3.1 version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gofsh",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2907,9 +2907,9 @@
       "optional": true
     },
     "fsh-sushi": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-2.0.0.tgz",
-      "integrity": "sha512-ONpWk2GEKTf0TpzSDvvSXtMed1D/47yDY2B42YsXNqvbg7mtmeYwjD8TSPLxsh13OXf0iKA9DccESyYsUZC38A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-2.0.1.tgz",
+      "integrity": "sha512-KoCjjdrqfHO2wEynqt6AyZgVFRJj0qOA5J3n6xlH2m4Mw2eeQ78+2aRkxFPKPDAmGqycqacqSJ15Oa7NGF+kOA==",
       "requires": {
         "antlr4": "~4.8.0",
         "axios": "^0.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gofsh",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "GoFSH is a FHIR Shorthand (FSH) decompiler, able to convert formal FHIR definitions from JSON to FSH.",
   "main": "dist/index.js",
   "scripts": {
@@ -68,7 +68,7 @@
     "fhir": "^4.8.3",
     "flat": "^5.0.2",
     "fs-extra": "^9.0.1",
-    "fsh-sushi": "^2.0.0",
+    "fsh-sushi": "^2.0.1",
     "ini": "^1.3.8",
     "lodash": "^4.17.21",
     "readline-sync": "^1.4.10",

--- a/test/exportable/ExportableAssignmentRule.test.ts
+++ b/test/exportable/ExportableAssignmentRule.test.ts
@@ -50,7 +50,7 @@ describe('ExportableAssignmentRule', () => {
       'speed setting \\"high\\"'
     );
     expect(rule.toFSH()).toEqual(
-      '* code = http://example.com/codes#573 "speed setting \\"high\\""'
+      '* code = http://example.com/codes#573 "speed setting \\\\\\"high\\\\\\""'
     );
   });
 


### PR DESCRIPTION
Bumps GoFSH's version to `1.3.1`, also updates the `fsh-sushi` package to version `2.0.1`. Consequently, I had to make a small update to an `ExportableAssignmentRule` test case to account for [changes made on the sushi side](https://github.com/FHIR/sushi/pull/896) to the `toString` method on FshCodes.