### PR TITLE
Add option to load existing aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Options:
   -t, --file-type <type>            specify which file types GoFSH should accept as input: json-only (default), xml-only, json-and-xml
   --indent                          output FSH with indented rules using context paths
   --meta-profile <mode>             specify how meta.profile on Instances should be applied to the InstanceOf keyword: only-one (default), first, none
+  -a, --alias-file <alias-filePath> specify an existing FSH file containing aliases to be loaded.
   --no-alias                        output FSH without generating Aliases
   -v, --version                     print goFSH version
   -h, --help                        display help for command

--- a/package-lock.json
+++ b/package-lock.json
@@ -1089,6 +1089,12 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@types/antlr4": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@types/antlr4/-/antlr4-4.7.2.tgz",
+      "integrity": "sha512-v6NASzZa4pUgO2QJJqGHTRRBfZDTOk2savuugSfCLatRTd2q+UtW0I7ub9mjzERhm7aWqGxBi886HnJkLYiIEA==",
+      "dev": true
+    },
     "@types/babel__core": {
       "version": "7.1.17",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.17.tgz",
@@ -1724,6 +1730,11 @@
         "@types/color-name": "^1.1.1",
         "color-convert": "^2.0.1"
       }
+    },
+    "antlr4": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.8.0.tgz",
+      "integrity": "sha512-en/MxQ4OkPgGJQ3wD/muzj1uDnFSzdFIhc2+c6bHZokWkuBb6RRvFjpWhPxWLbgQvaEzldJZ0GSQpfSAaE3hqg=="
     },
     "anymatch": {
       "version": "3.1.2",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "typescript": "^3.8.3"
   },
   "dependencies": {
+    "antlr4": "~4.8.0",
     "chalk": "^4.1.0",
     "commander": "^6.0.0",
     "diff": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   ],
   "license": "Apache-2.0",
   "devDependencies": {
+    "@types/antlr4": "^4.7.2",
     "@types/diff": "^4.0.2",
     "@types/flat": "^5.0.1",
     "@types/fs-extra": "^9.0.1",

--- a/src/app.ts
+++ b/src/app.ts
@@ -134,8 +134,8 @@ async function app() {
 
   // Load alias file
   let aliases: ExportableAlias[];
-  if (program.aliasFile) {
-    const aliasFile = getAliasFile(program.aliasFile);
+  if (programOptions.aliasFile) {
+    const aliasFile = getAliasFile(programOptions.aliasFile);
     aliases = AliasProcessor.process(aliasFile);
   }
   // Get options for processors and optimizers
@@ -206,7 +206,7 @@ async function app() {
     clr('║') + ` │ ${    instNum    } │ ${    invNum    } │ ${    mapNum     } │ ` + clr('║'),
     clr('║') + ' ╰────────────────────┴───────────────────┴────────────────────╯ ' + clr('║'),
     clr('║') + ' ╭────────────────────┬───────────────────┬────────────────────╮ ' + clr('║'),
-    clr('║') + ' │     Aliases        │                   │                    │ ' + clr('║'),
+    clr('║') + ' │      Aliases       │                   │                    │ ' + clr('║'),
     clr('║') + ' ├────────────────────┼───────────────────┼────────────────────┤ ' + clr('║'),
     clr('║') + ` │ ${    aliasNum   } │                   │                    │ ` + clr('║'),
     clr('║') + ' ╰────────────────────┴───────────────────┴────────────────────╯ ' + clr('║'),

--- a/src/exportable/ExportableAlias.ts
+++ b/src/exportable/ExportableAlias.ts
@@ -12,13 +12,4 @@ export class ExportableAlias implements Exportable {
   toFSH(): string {
     return `Alias: ${this.alias} = ${this.url}`;
   }
-
-  static fromFSH(fshLine: string): ExportableAlias {
-    const regex = /^Alias:\s+(?<alias>\S+)\s+=\s+(?<url>\S+).*/;
-    const match = regex.exec(fshLine);
-    if (match != null) {
-      return new ExportableAlias(match.groups.alias, match.groups.url);
-    }
-    return null;
-  }
 }

--- a/src/exportable/ExportableAlias.ts
+++ b/src/exportable/ExportableAlias.ts
@@ -12,4 +12,13 @@ export class ExportableAlias implements Exportable {
   toFSH(): string {
     return `Alias: ${this.alias} = ${this.url}`;
   }
+
+  static fromFSH(fshLine: string): ExportableAlias {
+    const regex = /^Alias:\s+(?<alias>\S+)\s+=\s+(?<url>\S+).*/;
+    const match = regex.exec(fshLine);
+    if (match != null) {
+      return new ExportableAlias(match.groups.alias, match.groups.url);
+    }
+    return null;
+  }
 }

--- a/src/processor/AliasProcessor.ts
+++ b/src/processor/AliasProcessor.ts
@@ -1,53 +1,79 @@
 import fs from 'fs-extra';
+import { sushiImport } from 'fsh-sushi';
 import { ExportableAlias } from '../exportable';
 import { logger } from '../utils/GoFSHLogger';
+import { InputStream, CommonTokenStream } from 'antlr4';
+// digging up the lexer/parser so that we can implement with less code duplication
+// it's a little risky, but such is the nature of the sea
+import { FSHLexer } from 'fsh-sushi/dist/import/generated/FSHLexer';
+import { FSHParser } from 'fsh-sushi/dist/import/generated/FSHParser';
 
 export class AliasProcessor {
   static process(aliasFile: string): ExportableAlias[] {
-    const aliases: ExportableAlias[] = [];
-
     // Load aliases from alias-file option.
-    if (this.isProcessableAliasFile(aliasFile)) {
-      let aliasFileContent;
+    if (AliasProcessor.isProcessableAliasFile(aliasFile)) {
+      let aliasFileContent: string;
       try {
         aliasFileContent = fs.readFileSync(aliasFile, 'utf8');
       } catch (e) {
-        logger.warn(`Alias file read failed with error: ${e.message}`);
+        logger.error(`Alias file read failed with error: ${e.message}`);
       }
       if (aliasFileContent != null) {
-        const matches = this.yieldAliases(aliasFileContent);
-        const matchesArray = Array.from(matches);
-        logger.info(matchesArray);
-        matchesArray.map(match => aliases.push(ExportableAlias.fromFSH(match)));
+        const aliases = AliasProcessor.parseAliases(aliasFileContent);
+        if (aliases.length === 0) {
+          logger.warn(`No aliases present in ${aliasFile}.`);
+        }
+        return aliases;
       }
     }
-    if (aliases.length == 0) {
-      logger.warn(`Could not load aliases from ${aliasFile}.`);
-    }
-
-    return aliases;
+    return [];
   }
 
-  // Ensures that a CodeSystem instance is fully representable using the CodeSystem syntax in FSH.
-  // If there is no name or id we cannot process it.
   static isProcessableAliasFile(input: string) {
     return input != null && input.length > 0 && input.endsWith('.fsh');
   }
-  static *yieldAliases(aliasFileContent: string) {
-    const startsWithRegex = /^Alias:\s+(?<alias>\S+)\s+=/;
-    let aliasLines: string[] = [];
-    const aliasFileContentLines = aliasFileContent.split('\n');
-    for (const line of aliasFileContentLines) {
-      if (startsWithRegex.test(line)) {
-        if (aliasLines.length > 0) {
-          yield aliasLines.join('\n');
-          aliasLines = [];
+
+  // This implementation is more or less copied out of SUSHI to just get the aliases
+  static parseAliases(aliasFileContent: string): ExportableAlias[] {
+    const input = aliasFileContent.endsWith('\n') ? aliasFileContent : aliasFileContent + '\n';
+    const aliases: Map<string, string> = new Map();
+    // parse that fsh, citizen
+    const chars = new InputStream(input);
+    const lexer = new FSHLexer(chars);
+    // @ts-ignore
+    const tokens = new CommonTokenStream(lexer);
+    const parser = new FSHParser(tokens);
+    // @ts-ignore
+    parser.buildParseTrees = true;
+    // @ts-ignore
+    const ctx = parser.doc() as sushiImport.DocContext;
+    ctx.entity().forEach(entity => {
+      if (entity.alias()) {
+        const name = entity.alias().SEQUENCE()[0].getText();
+        let value = entity.alias().SEQUENCE()[1]?.getText();
+        // When the url contains a fragment (http://example.org#fragment), the grammar will read it as a
+        // CODE, so we also accept that for the value here
+        if (!value && entity.alias().CODE()) {
+          value = entity.alias().CODE().getText();
         }
-        aliasLines.push(line);
-      } else if (aliasLines.length > 0) {
-        aliasLines.push(line);
+        if (name.includes('|')) {
+          logger.error(
+            `Alias ${name} cannot include "|" since the "|" character is reserved for indicating a version`
+          );
+          return;
+        }
+        if (aliases.has(name) && aliases.get(name) !== value) {
+          logger.error(
+            `Alias ${name} cannot be redefined to ${value}; it is already defined as ${aliases.get(
+              name
+            )}.`
+          );
+          // don't set it -- just keep the original definition
+        } else {
+          aliases.set(name, value);
+        }
       }
-    }
-    yield aliasLines.join('\n');
+    });
+    return Array.from(aliases.entries()).map(([name, value]) => new ExportableAlias(name, value));
   }
 }

--- a/src/processor/AliasProcessor.ts
+++ b/src/processor/AliasProcessor.ts
@@ -1,0 +1,53 @@
+import fs from 'fs-extra';
+import { ExportableAlias } from '../exportable';
+import { logger } from '../utils/GoFSHLogger';
+
+export class AliasProcessor {
+  static process(aliasFile: string): ExportableAlias[] {
+    const aliases: ExportableAlias[] = [];
+
+    // Load aliases from alias-file option.
+    if (this.isProcessableAliasFile(aliasFile)) {
+      let aliasFileContent;
+      try {
+        aliasFileContent = fs.readFileSync(aliasFile, 'utf8');
+      } catch (e) {
+        logger.warn(`Alias file read failed with error: ${e.message}`);
+      }
+      if (aliasFileContent != null) {
+        const matches = this.yieldAliases(aliasFileContent);
+        const matchesArray = Array.from(matches);
+        logger.info(matchesArray);
+        matchesArray.map(match => aliases.push(ExportableAlias.fromFSH(match)));
+      }
+    }
+    if (aliases.length == 0) {
+      logger.warn(`Could not load aliases from ${aliasFile}.`);
+    }
+
+    return aliases;
+  }
+
+  // Ensures that a CodeSystem instance is fully representable using the CodeSystem syntax in FSH.
+  // If there is no name or id we cannot process it.
+  static isProcessableAliasFile(input: string) {
+    return input != null && input.length > 0 && input.endsWith('.fsh');
+  }
+  static *yieldAliases(aliasFileContent: string) {
+    const startsWithRegex = /^Alias:\s+(?<alias>\S+)\s+=/;
+    let aliasLines: string[] = [];
+    const aliasFileContentLines = aliasFileContent.split('\n');
+    for (const line of aliasFileContentLines) {
+      if (startsWithRegex.test(line)) {
+        if (aliasLines.length > 0) {
+          yield aliasLines.join('\n');
+          aliasLines = [];
+        }
+        aliasLines.push(line);
+      } else if (aliasLines.length > 0) {
+        aliasLines.push(line);
+      }
+    }
+    yield aliasLines.join('\n');
+  }
+}

--- a/src/processor/FHIRProcessor.ts
+++ b/src/processor/FHIRProcessor.ts
@@ -9,6 +9,7 @@ import {
   WildFHIR
 } from '.';
 import { ExportableConfiguration } from '../exportable';
+import { ExportableAlias } from '../exportable';
 import { ConfigurationExtractor } from '../extractor';
 import { InstanceProcessor } from './InstanceProcessor';
 
@@ -87,12 +88,18 @@ export class FHIRProcessor {
     }
   }
 
-  process(config: ExportableConfiguration, options: ProcessingOptions = {}): Package {
+  process(
+    config: ExportableConfiguration,
+    options: ProcessingOptions = {},
+    aliases: ExportableAlias[] = []
+  ): Package {
     const resources = new Package();
     const igForConfig =
       this.lake.getAllImplementationGuides().find(doc => doc.path === this.igPath) ??
       this.lake.getAllImplementationGuides()[0];
     resources.add(config);
+    if (aliases.length > 0) logger.info('Processing Aliases...');
+    aliases.forEach(alias => resources.add(alias));
     const structureDefs = this.lake.getAllStructureDefinitions();
     if (structureDefs.length > 0) logger.info('Processing StructureDefinitions...');
     structureDefs.forEach((wild, index) => {

--- a/src/processor/Package.ts
+++ b/src/processor/Package.ts
@@ -71,12 +71,16 @@ export class Package {
       checkDuplicateDefinition(this.mappings, resource, 'mapping');
       this.mappings.push(resource);
     } else if (resource instanceof ExportableAlias) {
-      if (this.aliases.find(e => e.alias === resource.alias)) {
-        logger.error(
-          `Encountered alias with a duplicate name, ${resource.alias}, which GoFSH cannot make unique. Fix the source file to resolve this error or update the resulting FSH definition.`
-        );
+      const duplicateAlias = this.aliases.find(e => e.alias === resource.alias);
+      if (duplicateAlias != null) {
+        if (duplicateAlias.url !== resource.url) {
+          logger.error(
+            `Encountered alias with a duplicate name, ${resource.alias}, which GoFSH cannot make unique. Fix the source file to resolve this error or update the resulting FSH definition.`
+          );
+        }
+      } else {
+        this.aliases.push(resource);
       }
-      this.aliases.push(resource);
     } else if (resource instanceof ExportableConfiguration) {
       if (this.configuration) {
         logger.warn(

--- a/src/processor/Package.ts
+++ b/src/processor/Package.ts
@@ -41,6 +41,7 @@ export class Package {
       | ExportableInvariant
       | ExportableConfiguration
       | ExportableMapping
+      | ExportableAlias
   ) {
     if (resource instanceof ExportableProfile) {
       checkDuplicateDefinition(this.profiles, resource, 'profile');
@@ -69,6 +70,13 @@ export class Package {
     } else if (resource instanceof ExportableMapping) {
       checkDuplicateDefinition(this.mappings, resource, 'mapping');
       this.mappings.push(resource);
+    } else if (resource instanceof ExportableAlias) {
+      if (this.aliases.find(e => e.alias === resource.alias)) {
+        logger.error(
+          `Encountered alias with a duplicate name, ${resource.alias}, which GoFSH cannot make unique. Fix the source file to resolve this error or update the resulting FSH definition.`
+        );
+      }
+      this.aliases.push(resource);
     } else if (resource instanceof ExportableConfiguration) {
       if (this.configuration) {
         logger.warn(

--- a/src/processor/index.ts
+++ b/src/processor/index.ts
@@ -1,6 +1,7 @@
 // processors are responsible for transforming FHIR types (ex. StructureDefinition) into FSH types (ex. Profile)
 export * from './Package';
 export * from './FHIRProcessor';
+export * from './AliasProcessor';
 export * from './CodeSystemProcessor';
 export * from './ValueSetProcessor';
 export * from './ProcessableElementDefinition';

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -15,6 +15,7 @@ import {
 import { FSHExporter } from '../export/FSHExporter';
 import { loadOptimizers } from '../optimizer';
 import { MasterFisher } from '../utils';
+import { ExportableAlias } from '../exportable';
 import { ExportableConfiguration } from '../exportable';
 import { Fhir as FHIR } from 'fhir/fhir';
 
@@ -23,6 +24,11 @@ const FHIRConverter = new FHIR();
 export function getInputDir(input = '.'): string {
   // default to current directory
   logger.info(`Using input directory: ${input}`);
+  return input;
+}
+
+export function getAliasFile(input = ''): string {
+  logger.info(`Using alias file: ${input}`);
   return input;
 }
 
@@ -67,10 +73,11 @@ export function getFhirProcessor(inDir: string, defs: fhirdefs.FHIRDefinitions, 
 export async function getResources(
   processor: FHIRProcessor,
   config: ExportableConfiguration,
-  options: ProcessingOptions = {}
+  options: ProcessingOptions = {},
+  aliases: ExportableAlias[] = []
 ): Promise<Package> {
   const fisher = processor.getFisher();
-  const resources = processor.process(config, options);
+  const resources = processor.process(config, options, aliases);
   // Dynamically load and run the optimizers
   logger.info('Optimizing FSH definitions to follow best practices...');
   const optimizers = await loadOptimizers();

--- a/test/processor/AliasProcessor.test.ts
+++ b/test/processor/AliasProcessor.test.ts
@@ -40,27 +40,59 @@ describe('AliasProcessor', () => {
     expect(result[7].url).toBe('http://example.org/third');
   });
 
-  describe('yieldAliases', () => {
-    it('should yield the simplest example Alias', () => {
-      const aliasFile = path.join(__dirname, 'fixtures', 'simple-aliases.fsh');
-      const fileContents = fs.readFileSync(aliasFile).toString();
+  it('should not attempt to parse a file that does not have the fsh extension', () => {
+    const aliasFile = path.join(__dirname, 'fixtures', 'small-profile.json');
+    const result = AliasProcessor.process(aliasFile);
+    expect(result).toHaveLength(0);
+  });
 
-      const resultGenerator = AliasProcessor.yieldAliases(fileContents);
-      const result = Array.from(resultGenerator);
+  it('should log an error when the path provided does not exist', () => {
+    const aliasFile = path.join(__dirname, 'fixtures', 'not-a-real-file.fsh');
+    const result = AliasProcessor.process(aliasFile);
+    expect(result).toHaveLength(0);
+    expect(loggerSpy.getLastMessage('error')).toMatch(/^Alias file read failed with error/s);
+  });
 
-      expect(result.length).toBe(1);
-      expect(result[0]).toStrictEqual('Alias: $sct = http://snomed.info/sct\r\n');
-    });
+  it('should log a warning when the fsh file contains no aliases', () => {
+    const aliasFile = path.join(__dirname, 'fixtures', 'no-aliases.fsh');
+    const result = AliasProcessor.process(aliasFile);
+    expect(result).toHaveLength(0);
+    expect(loggerSpy.getLastMessage('warn')).toMatch(/^No aliases present/s);
+  });
 
-    it('should yield the complex example Alias', () => {
+  describe('parseAliases', () => {
+    it('should find all aliases in the specified fsh file', () => {
       const aliasFile = path.join(__dirname, 'fixtures', 'custom-aliases.fsh');
       const fileContents = fs.readFileSync(aliasFile).toString();
 
-      const resultGenerator = AliasProcessor.yieldAliases(fileContents);
-      const result = Array.from(resultGenerator);
+      const result = AliasProcessor.parseAliases(fileContents);
+      expect(result).toHaveLength(8);
+      expect(result[0]).toStrictEqual(new ExportableAlias('$sct', 'http://snomed.info/sct'));
+      expect(result[1]).toStrictEqual(
+        new ExportableAlias('V2-0203', 'http://terminology.hl7.org/CodeSystem/v2-0203')
+      );
+      expect(result[2].alias).toBe('US-NPI');
+      expect(result[2].url).toBe('http://hl7.org/fhir/sid/us-npi');
+      expect(result[3].alias).toBe('invalid-url');
+      expect(result[3].url).toBe('http://invalid-url');
+      expect(result[4].alias).toBe('comments');
+      expect(result[4].url).toBe('http://comments');
+      expect(result[5].alias).toBe('$first');
+      expect(result[5].url).toBe('http://example.org/first');
+      expect(result[6].alias).toBe('$second');
+      expect(result[6].url).toBe('http://example.org/second');
+      expect(result[7].alias).toBe('$third');
+      expect(result[7].url).toBe('http://example.org/third');
+    });
 
-      expect(result.length).toBe(8);
-      expect(result[0]).toContain('Alias: $sct = http://snomed.info/sct\r\n');
+    it('should log errors for invalid aliases', () => {
+      const aliasFile = path.join(__dirname, 'fixtures', 'invalid-alias.fsh');
+      const result = AliasProcessor.process(aliasFile);
+      expect(result).toHaveLength(2);
+      expect(loggerSpy.getMessageAtIndex(0, 'error')).toMatch(
+        /Alias \$not\|valid cannot include "\|"/s
+      );
+      expect(loggerSpy.getMessageAtIndex(1, 'error')).toMatch(/Alias \$valid cannot be redefined/s);
     });
   });
 });

--- a/test/processor/AliasProcessor.test.ts
+++ b/test/processor/AliasProcessor.test.ts
@@ -1,0 +1,66 @@
+import fs from 'fs-extra';
+import path from 'path';
+import { AliasProcessor } from '../../src/processor';
+import { ExportableAlias } from '../../src/exportable';
+import { loggerSpy } from '../helpers/loggerSpy';
+
+describe('AliasProcessor', () => {
+  beforeEach(() => {
+    loggerSpy.reset();
+  });
+
+  it('should convert the simplest example Alias', () => {
+    const aliasFile = path.join(__dirname, 'fixtures', 'simple-aliases.fsh');
+    const result = AliasProcessor.process(aliasFile);
+    expect(result).toBeInstanceOf(Array);
+    expect(result.length).toBe(1);
+    expect(result[0]).toStrictEqual(new ExportableAlias('$sct', 'http://snomed.info/sct'));
+  });
+
+  it('should convert the custom example Alias', () => {
+    const aliasFile = path.join(__dirname, 'fixtures', 'custom-aliases.fsh');
+    const result = AliasProcessor.process(aliasFile);
+    expect(result).toBeInstanceOf(Array);
+    expect(result.length).toBe(8);
+    expect(result[0]).toStrictEqual(new ExportableAlias('$sct', 'http://snomed.info/sct'));
+    expect(result[1]).toStrictEqual(
+      new ExportableAlias('V2-0203', 'http://terminology.hl7.org/CodeSystem/v2-0203')
+    );
+    expect(result[2].alias).toBe('US-NPI');
+    expect(result[2].url).toBe('http://hl7.org/fhir/sid/us-npi');
+    expect(result[3].alias).toBe('invalid-url');
+    expect(result[3].url).toBe('http://invalid-url');
+    expect(result[4].alias).toBe('comments');
+    expect(result[4].url).toBe('http://comments');
+    expect(result[5].alias).toBe('$first');
+    expect(result[5].url).toBe('http://example.org/first');
+    expect(result[6].alias).toBe('$second');
+    expect(result[6].url).toBe('http://example.org/second');
+    expect(result[7].alias).toBe('$third');
+    expect(result[7].url).toBe('http://example.org/third');
+  });
+
+  describe('yieldAliases', () => {
+    it('should yield the simplest example Alias', () => {
+      const aliasFile = path.join(__dirname, 'fixtures', 'simple-aliases.fsh');
+      const fileContents = fs.readFileSync(aliasFile).toString();
+
+      const resultGenerator = AliasProcessor.yieldAliases(fileContents);
+      const result = Array.from(resultGenerator);
+
+      expect(result.length).toBe(1);
+      expect(result[0]).toStrictEqual('Alias: $sct = http://snomed.info/sct\r\n');
+    });
+
+    it('should yield the complex example Alias', () => {
+      const aliasFile = path.join(__dirname, 'fixtures', 'custom-aliases.fsh');
+      const fileContents = fs.readFileSync(aliasFile).toString();
+
+      const resultGenerator = AliasProcessor.yieldAliases(fileContents);
+      const result = Array.from(resultGenerator);
+
+      expect(result.length).toBe(8);
+      expect(result[0]).toContain('Alias: $sct = http://snomed.info/sct\r\n');
+    });
+  });
+});

--- a/test/processor/Package.test.ts
+++ b/test/processor/Package.test.ts
@@ -7,7 +7,8 @@ import {
   ExportableCodeSystem,
   ExportableConfiguration,
   ExportableInvariant,
-  ExportableMapping
+  ExportableMapping,
+  ExportableAlias
 } from '../../src/exportable';
 import { loggerSpy } from '../helpers/loggerSpy';
 
@@ -60,6 +61,12 @@ describe('Package', () => {
       const myMapping = new ExportableMapping('MyMapping');
       myPackage.add(myMapping);
       expect(myPackage.mappings[0]).toBe(myMapping);
+    });
+
+    it('should add an ExportableAlias to the aliases array', () => {
+      const myAlias = new ExportableAlias('MyAlias', 'http://example.org/');
+      myPackage.add(myAlias);
+      expect(myPackage.aliases[0]).toBe(myAlias);
     });
 
     it('should set the configuration when adding an ExportableConfiguration', () => {
@@ -167,6 +174,39 @@ describe('Package', () => {
       expect(loggerSpy.getMessageAtIndex(6, 'error')).toMatch(
         /Encountered mapping with a duplicate name, MyMapping/
       );
+    });
+
+    it('should not log an error when a second alias is added with a different name', () => {
+      const myAlias = new ExportableAlias('MyAlias', 'http://example.org/');
+      const anotherAlias = new ExportableAlias('AnotherAlias', 'http://different-example.org/');
+      myPackage.add(myAlias);
+      myPackage.add(anotherAlias);
+      expect(myPackage.aliases).toHaveLength(2);
+      expect(myPackage.aliases[0]).toBe(myAlias);
+      expect(myPackage.aliases[1]).toBe(anotherAlias);
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+    });
+
+    it('should log an error and not add the alias when an alias with a duplicate name and different url is added', () => {
+      const myAlias = new ExportableAlias('MyAlias', 'http://example.org/');
+      const duplicateAlias = new ExportableAlias('MyAlias', 'http://different-example.org/');
+      myPackage.add(myAlias);
+      myPackage.add(duplicateAlias);
+      expect(myPackage.aliases).toHaveLength(1);
+      expect(myPackage.aliases[0]).toBe(myAlias);
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Encountered alias with a duplicate name, MyAlias/s
+      );
+    });
+
+    it('should not log an error and not add the alias when an alias with a duplicate name and matching url is added', () => {
+      const myAlias = new ExportableAlias('MyAlias', 'http://example.org/');
+      const duplicateAlias = new ExportableAlias('MyAlias', 'http://example.org/');
+      myPackage.add(myAlias);
+      myPackage.add(duplicateAlias);
+      expect(myPackage.aliases).toHaveLength(1);
+      expect(myPackage.aliases[0]).toBe(myAlias);
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
     });
   });
 });

--- a/test/processor/fixtures/custom-aliases.fsh
+++ b/test/processor/fixtures/custom-aliases.fsh
@@ -1,0 +1,17 @@
+// Standard way aliases are generated
+Alias: $sct = http://snomed.info/sct
+
+// Comments
+// Alias: $v2-0487 = http://terminology.hl7.org/CodeSystem/v2-0487
+// Alias: $administrative-gender = http://hl7.org/fhir/administrative-gender
+
+// Custom alias names
+Alias: V2-0203 = http://terminology.hl7.org/CodeSystem/v2-0203
+Alias: US-NPI = http://hl7.org/fhir/sid/us-npi
+Alias: invalid-url = http://invalid-url
+Alias: comments = http://comments // Comment
+
+Alias: $first =		http://example.org/first
+Alias: $second =	http://example.org/second
+Alias:	$third  =
+					http://example.org/third

--- a/test/processor/fixtures/custom-aliases.fsh
+++ b/test/processor/fixtures/custom-aliases.fsh
@@ -6,12 +6,13 @@ Alias: $sct = http://snomed.info/sct
 // Alias: $administrative-gender = http://hl7.org/fhir/administrative-gender
 
 // Custom alias names
-Alias: V2-0203 = http://terminology.hl7.org/CodeSystem/v2-0203
-Alias: US-NPI = http://hl7.org/fhir/sid/us-npi
+Alias: V2-0203 = http://terminology.hl7.org/CodeSystem/v2-0203 Alias: US-NPI = http://hl7.org/fhir/sid/us-npi
 Alias: invalid-url = http://invalid-url
 Alias: comments = http://comments // Comment
 
 Alias: $first =		http://example.org/first
-Alias: $second =	http://example.org/second
+Alias: $second =
+		http://example.org/second
 Alias:	$third  =
+// this is in the middle of the definition of $third
 					http://example.org/third

--- a/test/processor/fixtures/invalid-alias.fsh
+++ b/test/processor/fixtures/invalid-alias.fsh
@@ -1,0 +1,8 @@
+// this alias is valid
+Alias: $valid = http://example.org/CodeSystem/valid
+// this alias is invalid, since the name contains |
+Alias: $not|valid = http://example.org/CodeSystem/not-valid
+// this alias is valid
+Alias: somethingGood = http://example.org/ValueSet/something-good
+// this alias is invalid, since it is already defined
+Alias: $valid = http://example.org/already-defined

--- a/test/processor/fixtures/no-aliases.fsh
+++ b/test/processor/fixtures/no-aliases.fsh
@@ -1,0 +1,3 @@
+Profile: MyObservation
+Parent: Observation
+Title: "My Observation"

--- a/test/processor/fixtures/simple-aliases.fsh
+++ b/test/processor/fixtures/simple-aliases.fsh
@@ -1,0 +1,1 @@
+Alias: $sct = http://snomed.info/sct

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -14,7 +14,8 @@ import {
   getIgPathFromIgIni,
   getFhirProcessor,
   getLakeOfFHIR,
-  readJSONorXML
+  readJSONorXML,
+  getAliasFile
 } from '../../src/utils/Processing';
 import { Package } from '../../src/processor';
 import { loadTestDefinitions } from '../helpers/loadTestDefinitions';
@@ -485,6 +486,22 @@ describe('Processing', () => {
       const jsonFileImport = readJSONorXML(JSONFilePath);
       expect(jsonFileImport.content).toEqual(fs.readJSONSync(JSONFilePath));
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+    });
+  });
+
+  describe('getAliasFile', () => {
+    beforeEach(() => {
+      loggerSpy.reset();
+    });
+
+    it('should get specified alias file', () => {
+      const programAliasFile = 'alias.fsh';
+      const aliasFile = getAliasFile(programAliasFile);
+      return Promise.all(aliasFile).then(() => {
+        expect(aliasFile).toBe(programAliasFile);
+        expect(loggerSpy.getLastMessage('info')).toMatch('Using alias file: ' + programAliasFile);
+        expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+      });
     });
   });
 


### PR DESCRIPTION
GoFSH automatically generates an ```aliases.fsh``` file from the urls discovered during the parsing of FHIR resources to convert. The ```-a, --alias-file``` option allows users to specify an existing FSH file to preload aliases in order to generate consistent, predefined alias references.