### PR TITLE
Better handle unusual extensions

### DIFF
--- a/src/optimizer/plugins/RemoveExtensionURLAssignmentRules.ts
+++ b/src/optimizer/plugins/RemoveExtensionURLAssignmentRules.ts
@@ -44,9 +44,19 @@ export default {
               } else if (urlRule.value !== item.name) {
                 logger.error(
                   `${sd.name}: Inline extension at "${rule.path}[${item.name}]" has sliceName "${item.name}" but "${urlRule.value}" is assigned to url. ` +
-                    'SUSHI requires that these values match exactly, so the url assignment will be ignored, ' +
-                    `and the sliceName of "${item.name}" will be assigned to the url.`
+                    'SUSHI requires that these values match exactly, so the value assigned to the url will be used as the sliceName.'
                 );
+                // If the value set by the url rule and the sliceName do not match, prefer the value set by the url rule
+                // and replace all occurrences of the old sliceName in other rules
+                const newSliceName = urlRule.value as string;
+                [...sd.rules, ...rule.cardRules, ...rule.flagRules].forEach(r => {
+                  r.path = r.path.replace(
+                    new RegExp(`^${rule.path}\\[${item.name}\\]`),
+                    `${rule.path}[${newSliceName}]`
+                  );
+                });
+
+                item.name = newSliceName;
               }
             }
           });

--- a/src/optimizer/plugins/RemoveExtensionURLAssignmentRules.ts
+++ b/src/optimizer/plugins/RemoveExtensionURLAssignmentRules.ts
@@ -1,7 +1,10 @@
 import { OptimizerPlugin } from '../OptimizerPlugin';
 import { Package } from '../../processor';
 import { ExportableAssignmentRule, ExportableContainsRule } from '../../exportable';
+import { logger } from '../../utils';
 import { pullAt } from 'lodash';
+import { isUri } from 'valid-url';
+import { utils } from 'fsh-sushi';
 
 // Loop over all profiles and extensions, removing assignment rules on inline extensions
 // NOTE: Inline extensions on a profile are allowed by SUSHI, but they are technically not
@@ -11,7 +14,7 @@ export default {
   description:
     'Remove assignment rules on inline extension "url" paths since SUSHI automatically applies these',
 
-  optimize(pkg: Package): void {
+  optimize(pkg: Package, fisher: utils.Fishable): void {
     [...pkg.profiles, ...pkg.extensions].forEach(sd => {
       const rulesToRemove: number[] = [];
       sd.rules.forEach(rule => {
@@ -20,11 +23,31 @@ export default {
             const assignmentRuleIdx = sd.rules.findIndex(
               other =>
                 other instanceof ExportableAssignmentRule &&
-                other.path === `${rule.path}[${item.name}].url` &&
-                other.value === item.name
+                other.path === `${rule.path}[${item.name}].url`
             );
             if (assignmentRuleIdx >= 0) {
               rulesToRemove.push(assignmentRuleIdx);
+              const urlRule = sd.rules[assignmentRuleIdx] as ExportableAssignmentRule;
+              if (!item.type && isUri(urlRule.value as string)) {
+                item.type = fisher.fishForMetadata(
+                  urlRule.value as string,
+                  utils.Type.Extension
+                )?.name;
+                if (item.type) {
+                  logger.error(
+                    `${sd.name}: Extension at "${rule.path}[${item.name}]" refers to ${urlRule.value} but does not set this value in type.profile. ` +
+                      'The generated "contains" rule will be updated to use the "named" syntax so that SUSHI can process it without error. ' +
+                      'This will cause type.profile to be set on the SUSHI output, which is likely the desired behavior. If this is not desired, ' +
+                      'the generated FSH will have to be manually updated.'
+                  );
+                }
+              } else if (urlRule.value !== item.name) {
+                logger.error(
+                  `${sd.name}: Inline extension at "${rule.path}[${item.name}]" has sliceName "${item.name}" but "${urlRule.value}" is assigned to url. ` +
+                    'SUSHI requires that these values match exactly, so the url assignment will be ignored, ' +
+                    `and the sliceName of "${item.name}" will be assigned to the url.`
+                );
+              }
             }
           });
         }

--- a/src/optimizer/plugins/RemoveExtensionURLAssignmentRules.ts
+++ b/src/optimizer/plugins/RemoveExtensionURLAssignmentRules.ts
@@ -34,7 +34,7 @@ export default {
                   utils.Type.Extension
                 )?.name;
                 if (item.type) {
-                  logger.error(
+                  logger.warn(
                     `${sd.name}: Extension at "${rule.path}[${item.name}]" refers to ${urlRule.value} but does not set this value in type.profile. ` +
                       'The generated "contains" rule will be updated to use the "named" syntax so that SUSHI can process it without error. ' +
                       'This will cause type.profile to be set on the SUSHI output, which is likely the desired behavior. If this is not desired, ' +

--- a/src/processor/StructureDefinitionProcessor.ts
+++ b/src/processor/StructureDefinitionProcessor.ts
@@ -46,11 +46,13 @@ export class StructureDefinitionProcessor {
         sd = new ExportableLogical(name);
       } else if (input.kind === 'resource' && input.derivation === 'specialization') {
         sd = new ExportableResource(name);
-      } else if (
-        input.kind === 'complex-type' &&
-        input.derivation === 'constraint' &&
-        input.type === 'Extension'
-      ) {
+      } else if (input.derivation === 'constraint' && input.type === 'Extension') {
+        if (input.kind !== 'complex-type') {
+          logger.error(
+            `Extension "${name}" should have "kind" set to "complex-type" but has "${input.kind}" instead. The generated FSH will set "kind" to "complex-type".`
+          );
+          input.kind = 'complex-type';
+        }
         sd = new ExportableExtension(name);
       } else if (input.derivation === 'constraint') {
         sd = new ExportableProfile(name);

--- a/test/optimizer/plugins/RemoveExtensionURLAssignmentRulesOptimizer.test.ts
+++ b/test/optimizer/plugins/RemoveExtensionURLAssignmentRulesOptimizer.test.ts
@@ -168,7 +168,7 @@ describe('optimizer', () => {
       optimizer.optimize(myPackage, fisher);
       // The url rule is ignored, and the sliceName will be used
       expect(extension.rules).toEqual([containsRule]);
-      expect(loggerSpy.getLastMessage('error')).toMatch(
+      expect(loggerSpy.getLastMessage('warn')).toMatch(
         /refers to .*geolocation but does not set this value in type\.profile/
       );
     });

--- a/test/processor/StructureDefinitionProcessor.test.ts
+++ b/test/processor/StructureDefinitionProcessor.test.ts
@@ -198,6 +198,21 @@ describe('StructureDefinitionProcessor', () => {
       expect(result).toHaveLength(0);
     });
 
+    it('should log an error and fix an incorrect "kind" value on an extension', () => {
+      const input = JSON.parse(
+        fs.readFileSync(path.join(__dirname, 'fixtures', 'invalid-kind-extension.json'), 'utf-8')
+      );
+      const result = StructureDefinitionProcessor.process(input, defs, config);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toBeInstanceOf(ExportableExtension);
+      expect(result[0].name).toBe('SimpleExtension');
+      expect(result[0].rules).toHaveLength(0);
+      expect(loggerSpy.getLastMessage('error')).toMatch(
+        /Extension \"SimpleExtension\" should have \"kind\" set to \"complex-type\"/
+      );
+    });
+
     it('should convert a Profile whose name includes whitespace', () => {
       const input = JSON.parse(
         fs.readFileSync(path.join(__dirname, 'fixtures', 'simple-profile.json'), 'utf-8')

--- a/test/processor/fixtures/invalid-kind-extension.json
+++ b/test/processor/fixtures/invalid-kind-extension.json
@@ -1,0 +1,9 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "simple.extension",
+  "kind": "resource",
+  "type": "Extension",
+  "name": "SimpleExtension",
+  "derivation": "constraint",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension"
+}


### PR DESCRIPTION
## Description

Fixes https://github.com/FHIR/GoFSH/issues/157.

This PR adds two special cases to the `RemoveExtensionURLAssignmentRulesOptimizer`.

The first case occurs when the JSON processed by GoFSH has the pattern:
```json
{
  "id": "Extension.extension:date-month-absent-reason.url",
  "path": "Extension.extension.url",
  "type": [{ "code": "uri" }],
  "fixedUri": "month-absent-reason"
}
```
where the `url` of an inline extension is fixed to a value different that the `sliceName` of the element. This will result in a line of FSH like:
```
* extension[date-year-absent-reason].url = "year-absent-reason" (exactly)
```
which causes an error in SUSHI, since `url` has already been automatically fixed by SUSHI to be `data-year-absent-reason`. This PR updates the optimizer to log an error, and prefer the `sliceName` by removing the rule which fixes `url`. So no rule like the line of FSH above will be generated. Note that this doesn't change the JSON generated by SUSHI, since this rule was ignored by SUSHI as an error anyway. But this change places the error in GoFSH instead of SUSHI, and makes it more clear.

The second case occurs when the JSON processed by GoFSH has the pattern:
```json
{
  "id": "Observation.extension:injuryLocation",
  "path": "Observation.extension",
  "sliceName": "injuryLocation",
  "min": 0,
  "max": "1"
},
{
  "id": "Observation.extension:injuryLocation.url",
  "path": "Observation.extension.url",
  "min": 1,
  "max": "1",
  "fixedUri": "http://hl7.org/fhir/us/vrdr/StructureDefinition/Observation-Location"
},
```
In this case, the URL of the extension is being indicated by the `fixedUri`. This will result in FSH like:
```
* extension contains injuryLocation 0..1
* extension[injuryLocation].url = "http://hl7.org/fhir/us/vrdr/StructureDefinition/Observation-Location" (exactly)
```
But SUSHI processes this as if you are trying to set an inline extension, which is not allowed on profiles, and results in errors. Instead the FSH should look like:
```
extension contains ObservationLocation named injuryLocation 0..1
```
where `ObservationLocation` is the name of the extension with url `http://hl7.org/fhir/us/vrdr/StructureDefinition/Observation-Location`. This PR updates GoFSH to log an error when it encounters this situation, and generate FSH using the `named` keyword, which allows SUSHI to process without error. Note that this is a little unusual, because we are purposefully creating FSH which generates JSON which will differ from the original JSON. But the JSON generated by SUSHI will have the same meaning as the original, and uses the preferred style, so I think it is justified in this case.

## Testing

To test this, I suggest downloading the [VRDR package](https://build.fhir.org/ig/HL7/vrdr/downloads.html). Then on `master`, run `gofsh -f -o build-master` on it. You should see a clean `gofsh` run, but `sushi` errors. Then on this branch, run `gofsh -f -o build-branch`. You should see the errors added in this PR logged from `gofsh`, and `sushi` should finish with only two errors (unrelated to this PR).

Then compare the generated FSH in `build-master` and `build-branch` and ensure it makes sense.

Then compare the SUSHI generated JSON in `build-master` and `build-branch` and ensure it also makes sense. 