### PR TITLE
Add option to generate FSH without Aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For more information about the evolving FSH syntax see the [FHIR Shorthand Refer
 
 # Installation for GoFSH Users
 
-GoFSH requires [Node.js](https://nodejs.org/) to be installed on the user's system.  Users should install Node.js 12 (LTS), although the previous LTS version (Node.js 10) is also expected to work.
+GoFSH requires [Node.js](https://nodejs.org/) to be installed on the user's system. Users should install Node.js 12 (LTS), although the previous LTS version (Node.js 10) is also expected to work.
 
 Once Node.js is installed, run the following command to install or update GoFSH:
 
@@ -33,13 +33,14 @@ Options:
   -t, --file-type <type>            specify which file types GoFSH should accept as input: json-only (default), xml-only, json-and-xml
   --indent                          output FSH with indented rules using context paths
   --meta-profile <mode>             specify how meta.profile on Instances should be applied to the InstanceOf keyword: only-one (default), first, none
+  --no-alias                        output FSH without generating Aliases
   -v, --version                     print goFSH version
   -h, --help                        display help for command
 ```
 
 # Installation for Developers
 
-GoFSH is a [TypeScript](https://www.typescriptlang.org/) project.  At a minimum, GoFSH requires [Node.js](https://nodejs.org/) to build, test, and run the CLI.  Developers should install Node.js 12 (LTS), although the previous LTS version (Node.js 10) is also expected to work.
+GoFSH is a [TypeScript](https://www.typescriptlang.org/) project. At a minimum, GoFSH requires [Node.js](https://nodejs.org/) to build, test, and run the CLI. Developers should install Node.js 12 (LTS), although the previous LTS version (Node.js 10) is also expected to work.
 
 Once Node.js is installed, run the following command from this project's root folder:
 
@@ -51,21 +52,21 @@ $ npm install
 
 The following NPM tasks are useful in development:
 
-| Task | Description |
-| ---- | ----------- |
-| **build** | compiles `src/**/*.ts` files to `dist/**/*.js` files using the TypeScript compiler (tsc) |
-| **test** | runs all unit tests using Jest |
-| **test:watch** | similar to _test_, but automatically runs affected tests when changes are detected in src files |
-| **coverage** | launches your browser to display the test coverage report |
-| **lint** | checks all src files to ensure they follow project code styles and rules |
-| **lint:fix** | fixes lint errors when automatic fixes are available for them |
-| **prettier** | checks all src files to ensure they follow project formatting conventions |
-| **prettier:fix** | fixes prettier errors by rewriting files using project formatting conventions |
-| **check** | runs all the checks performed as part of ci (test, lint, prettier) |
-| **prepare** | runs the build task before this project is packed or published |
-| **prepublishOnly** | runs the check task before this project is published |
+| Task               | Description                                                                                     |
+| ------------------ | ----------------------------------------------------------------------------------------------- |
+| **build**          | compiles `src/**/*.ts` files to `dist/**/*.js` files using the TypeScript compiler (tsc)        |
+| **test**           | runs all unit tests using Jest                                                                  |
+| **test:watch**     | similar to _test_, but automatically runs affected tests when changes are detected in src files |
+| **coverage**       | launches your browser to display the test coverage report                                       |
+| **lint**           | checks all src files to ensure they follow project code styles and rules                        |
+| **lint:fix**       | fixes lint errors when automatic fixes are available for them                                   |
+| **prettier**       | checks all src files to ensure they follow project formatting conventions                       |
+| **prettier:fix**   | fixes prettier errors by rewriting files using project formatting conventions                   |
+| **check**          | runs all the checks performed as part of ci (test, lint, prettier)                              |
+| **prepare**        | runs the build task before this project is packed or published                                  |
+| **prepublishOnly** | runs the check task before this project is published                                            |
 
-To run any of these tasks, use `npm run`.  For example:
+To run any of these tasks, use `npm run`. For example:
 
 ```sh
 $ npm run check
@@ -75,15 +76,15 @@ $ npm run check
 
 For the best experience, developers should use [Visual Studio Code](https://code.visualstudio.com/) with the following plugins:
 
-* [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
-* [Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
-  * Consider configuring the formatOnSave feature in VS Code settings:
+- [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
+- [Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
+  - Consider configuring the formatOnSave feature in VS Code settings:
     ```json
     "[typescript]": {
         "editor.formatOnSave": true
     }
     ```
-* [vscode-language-fsh](https://marketplace.visualstudio.com/items?itemName=kmahalingam.vscode-language-fsh)
+- [vscode-language-fsh](https://marketplace.visualstudio.com/items?itemName=kmahalingam.vscode-language-fsh)
 
 # License
 

--- a/src/optimizer/plugins/ResolveBindingRuleURLsOptimizer.ts
+++ b/src/optimizer/plugins/ResolveBindingRuleURLsOptimizer.ts
@@ -2,18 +2,24 @@ import { utils } from 'fsh-sushi';
 import { OptimizerPlugin } from '../OptimizerPlugin';
 import { Package } from '../../processor';
 import { ExportableBindingRule } from '../../exportable';
-import { MasterFisher } from '../../utils';
+import { MasterFisher, ProcessingOptions } from '../../utils';
 import { optimizeURL } from '../utils';
 
 export default {
   name: 'resolve_binding_rule_urls',
   description: 'Replace URLs in binding rules with their names or aliases',
 
-  optimize(pkg: Package, fisher: MasterFisher): void {
+  optimize(pkg: Package, fisher: MasterFisher, options: ProcessingOptions = {}): void {
     [...pkg.profiles, ...pkg.extensions].forEach(resource => {
       resource.rules.forEach(rule => {
         if (rule instanceof ExportableBindingRule) {
-          rule.valueSet = optimizeURL(rule.valueSet, pkg.aliases, [utils.Type.ValueSet], fisher);
+          rule.valueSet = optimizeURL(
+            rule.valueSet,
+            pkg.aliases,
+            [utils.Type.ValueSet],
+            fisher,
+            options.alias ?? true
+          );
         }
       });
     });

--- a/src/optimizer/plugins/ResolveInstanceOfURLsOptimizer.ts
+++ b/src/optimizer/plugins/ResolveInstanceOfURLsOptimizer.ts
@@ -1,7 +1,7 @@
 import { utils } from 'fsh-sushi';
 import { OptimizerPlugin } from '../OptimizerPlugin';
 import { Package } from '../../processor';
-import { MasterFisher } from '../../utils';
+import { MasterFisher, ProcessingOptions } from '../../utils';
 import { optimizeURL } from '../utils';
 
 const FISHER_TYPES = [
@@ -15,10 +15,16 @@ export default {
   name: 'resolve_instanceof_urls',
   description: 'Replace declared instanceOf URLs with their names or aliases',
 
-  optimize(pkg: Package, fisher: MasterFisher): void {
+  optimize(pkg: Package, fisher: MasterFisher, options: ProcessingOptions = {}): void {
     pkg.instances.forEach(instance => {
       if (instance.instanceOf) {
-        instance.instanceOf = optimizeURL(instance.instanceOf, pkg.aliases, FISHER_TYPES, fisher);
+        instance.instanceOf = optimizeURL(
+          instance.instanceOf,
+          pkg.aliases,
+          FISHER_TYPES,
+          fisher,
+          options.alias ?? true
+        );
       }
     });
   }

--- a/src/optimizer/plugins/ResolveOnlyRuleURLsOptimizer.ts
+++ b/src/optimizer/plugins/ResolveOnlyRuleURLsOptimizer.ts
@@ -3,7 +3,7 @@ import { OptimizerPlugin } from '../OptimizerPlugin';
 import { optimizeURL } from '../utils';
 import { Package } from '../../processor';
 import { ExportableOnlyRule } from '../../exportable';
-import { MasterFisher } from '../../utils';
+import { MasterFisher, ProcessingOptions } from '../../utils';
 
 const FISHER_TYPES = [
   utils.Type.Resource,
@@ -16,12 +16,18 @@ export default {
   name: 'resolve_only_rule_urls',
   description: 'Replace URLs in "only" rules with their names or aliases',
 
-  optimize(pkg: Package, fisher: MasterFisher): void {
+  optimize(pkg: Package, fisher: MasterFisher, options: ProcessingOptions = {}): void {
     [...pkg.profiles, ...pkg.extensions].forEach(sd => {
       sd.rules.forEach(rule => {
         if (rule instanceof ExportableOnlyRule) {
           rule.types.forEach(onlyRuleType => {
-            onlyRuleType.type = optimizeURL(onlyRuleType.type, pkg.aliases, FISHER_TYPES, fisher);
+            onlyRuleType.type = optimizeURL(
+              onlyRuleType.type,
+              pkg.aliases,
+              FISHER_TYPES,
+              fisher,
+              options.alias ?? true
+            );
           });
         }
       });

--- a/src/optimizer/plugins/ResolveParentURLsOptimizer.ts
+++ b/src/optimizer/plugins/ResolveParentURLsOptimizer.ts
@@ -2,7 +2,7 @@ import { utils } from 'fsh-sushi';
 import { OptimizerPlugin } from '../OptimizerPlugin';
 import { optimizeURL } from '../utils';
 import { Package } from '../../processor';
-import { MasterFisher } from '../../utils';
+import { MasterFisher, ProcessingOptions } from '../../utils';
 
 const FISHER_TYPES = [
   utils.Type.Resource,
@@ -16,7 +16,7 @@ export default {
   name: 'resolve_parent_urls',
   description: 'Replace declared parent URLs with their names or aliases',
 
-  optimize(pkg: Package, fisher: MasterFisher): void {
+  optimize(pkg: Package, fisher: MasterFisher, options: ProcessingOptions = {}): void {
     for (const resource of [
       ...pkg.profiles,
       ...pkg.extensions,
@@ -24,7 +24,13 @@ export default {
       ...pkg.resources
     ]) {
       if (resource.parent) {
-        resource.parent = optimizeURL(resource.parent, pkg.aliases, FISHER_TYPES, fisher);
+        resource.parent = optimizeURL(
+          resource.parent,
+          pkg.aliases,
+          FISHER_TYPES,
+          fisher,
+          options.alias ?? true
+        );
       }
     }
   }

--- a/src/optimizer/plugins/ResolveValueRuleURLsOptimizer.ts
+++ b/src/optimizer/plugins/ResolveValueRuleURLsOptimizer.ts
@@ -8,6 +8,7 @@ import {
 } from '../../exportable';
 import { resolveAliasFromURL } from '../utils';
 import CombineCodingAndQuantityValuesOptimizer from './CombineCodingAndQuantityValuesOptimizer';
+import { ProcessingOptions } from '../../utils';
 
 export default {
   name: 'resolve_value_rule_urls',
@@ -32,5 +33,8 @@ export default {
         }
       });
     });
+  },
+  isEnabled(options: ProcessingOptions): boolean {
+    return options.alias === true;
   }
 } as OptimizerPlugin;

--- a/src/optimizer/plugins/ResolveValueSetComponentRuleURLsOptimizer.ts
+++ b/src/optimizer/plugins/ResolveValueSetComponentRuleURLsOptimizer.ts
@@ -2,7 +2,7 @@ import { utils } from 'fsh-sushi';
 import { OptimizerPlugin } from '../OptimizerPlugin';
 import { optimizeURL } from '../utils';
 import { Package } from '../../processor';
-import { MasterFisher } from '../../utils';
+import { MasterFisher, ProcessingOptions } from '../../utils';
 import {
   ExportableValueSetConceptComponentRule,
   ExportableValueSetFilterComponentRule
@@ -12,7 +12,7 @@ export default {
   name: 'resolve_value_set_component_rule_urls',
   description: 'Replace URLs in value set rules with their names or aliases',
 
-  optimize(pkg: Package, fisher: MasterFisher): void {
+  optimize(pkg: Package, fisher: MasterFisher, options: ProcessingOptions = {}): void {
     pkg.valueSets.forEach(vs => {
       vs.rules.forEach(rule => {
         if (
@@ -24,12 +24,19 @@ export default {
               rule.from.system,
               pkg.aliases,
               [utils.Type.CodeSystem],
-              fisher
+              fisher,
+              options.alias ?? true
             );
           }
           if (rule.from.valueSets) {
             rule.from.valueSets = rule.from.valueSets.map(vsURL => {
-              return optimizeURL(vsURL, pkg.aliases, [utils.Type.ValueSet], fisher);
+              return optimizeURL(
+                vsURL,
+                pkg.aliases,
+                [utils.Type.ValueSet],
+                fisher,
+                options.alias ?? true
+              );
             });
           }
           if (rule instanceof ExportableValueSetConceptComponentRule) {
@@ -39,7 +46,8 @@ export default {
                   concept.system,
                   pkg.aliases,
                   [utils.Type.CodeSystem],
-                  fisher
+                  fisher,
+                  options.alias ?? true
                 );
               }
             });

--- a/src/optimizer/utils.ts
+++ b/src/optimizer/utils.ts
@@ -15,9 +15,13 @@ export function optimizeURL(
   url: string,
   aliases: ExportableAlias[],
   types: utils.Type[],
-  fisher: MasterFisher
+  fisher: MasterFisher,
+  makeAlias = true
 ): string {
-  return resolveURL(url, types, fisher) ?? resolveAliasFromURL(url, aliases) ?? url;
+  if (makeAlias) {
+    return resolveURL(url, types, fisher) ?? resolveAliasFromURL(url, aliases) ?? url;
+  }
+  return resolveURL(url, types, fisher) ?? url;
 }
 
 /**

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -323,6 +323,7 @@ const IGNORED_NON_RESOURCE_DIRECTORIES = [
 export type ProcessingOptions = {
   indent?: boolean;
   metaProfile?: 'only-one' | 'first' | 'none';
+  alias?: boolean;
   [key: string]: boolean | number | string;
 };
 

--- a/test/optimizer/plugins/ResolveBindingRuleURLsOptimizer.test.ts
+++ b/test/optimizer/plugins/ResolveBindingRuleURLsOptimizer.test.ts
@@ -39,7 +39,23 @@ describe('optimizer', () => {
       expect(profile.rules[0]).toEqual(expectedRule);
     });
 
-    it('should alias the valueSet url on a binding rule if it cannot be resolved', () => {
+    it('should alias the valueSet url on a binding rule if it cannot be resolved and alias is true', () => {
+      const profile = new ExportableProfile('Foo');
+      profile.parent = 'Observation';
+      const codeRule = new ExportableBindingRule('code');
+      codeRule.valueSet = 'http://loinc.org';
+      profile.rules = [codeRule];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      optimizer.optimize(myPackage, fisher, { alias: true });
+
+      const expectedRule = cloneDeep(codeRule);
+      expectedRule.valueSet = '$loinc';
+      expect(profile.rules[0]).toEqual(expectedRule);
+      expect(myPackage.aliases).toEqual([{ alias: '$loinc', url: 'http://loinc.org' }]);
+    });
+
+    it('should alias the valueSet url on a binding rule if it cannot be resolved and alias is undefined', () => {
       const profile = new ExportableProfile('Foo');
       profile.parent = 'Observation';
       const codeRule = new ExportableBindingRule('code');
@@ -53,6 +69,20 @@ describe('optimizer', () => {
       expectedRule.valueSet = '$loinc';
       expect(profile.rules[0]).toEqual(expectedRule);
       expect(myPackage.aliases).toEqual([{ alias: '$loinc', url: 'http://loinc.org' }]);
+    });
+
+    it('should not alias the valueSet url on a binding rule if alias is false', () => {
+      const profile = new ExportableProfile('Foo');
+      profile.parent = 'Observation';
+      const codeRule = new ExportableBindingRule('code');
+      codeRule.valueSet = 'http://loinc.org';
+      profile.rules = [codeRule];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      optimizer.optimize(myPackage, fisher, { alias: false });
+
+      expect(profile.rules[0]).toEqual(codeRule);
+      expect(myPackage.aliases).toHaveLength(0);
     });
 
     it('should maintain the original value when it cannot be aliased', () => {

--- a/test/optimizer/plugins/ResolveInstanceOfURLsOptimizer.test.ts
+++ b/test/optimizer/plugins/ResolveInstanceOfURLsOptimizer.test.ts
@@ -32,7 +32,19 @@ describe('optimizer', () => {
       expect(instance.instanceOf).toBe('Patient');
     });
 
-    it('should alias the instanceOf url if the instanceOf is not found', () => {
+    it('should alias the instanceOf url if the instanceOf is not found and alias is true', () => {
+      const instance = new ExportableInstance('Foo');
+      instance.instanceOf = 'https://demo.org/StructureDefinition/MediumProfile';
+      const myPackage = new Package();
+      myPackage.add(instance);
+      optimizer.optimize(myPackage, fisher, { alias: true });
+      expect(instance.instanceOf).toBe('$MediumProfile');
+      expect(myPackage.aliases).toEqual([
+        { alias: '$MediumProfile', url: 'https://demo.org/StructureDefinition/MediumProfile' }
+      ]);
+    });
+
+    it('should alias the instanceOf url if the instanceOf is not found and alias is undefined', () => {
       const instance = new ExportableInstance('Foo');
       instance.instanceOf = 'https://demo.org/StructureDefinition/MediumProfile';
       const myPackage = new Package();
@@ -42,6 +54,16 @@ describe('optimizer', () => {
       expect(myPackage.aliases).toEqual([
         { alias: '$MediumProfile', url: 'https://demo.org/StructureDefinition/MediumProfile' }
       ]);
+    });
+
+    it('should not alias the instanceOf url if the instanceOf is not found and alias is false', () => {
+      const instance = new ExportableInstance('Foo');
+      instance.instanceOf = 'https://demo.org/StructureDefinition/MediumProfile';
+      const myPackage = new Package();
+      myPackage.add(instance);
+      optimizer.optimize(myPackage, fisher, { alias: false });
+      expect(instance.instanceOf).toBe('https://demo.org/StructureDefinition/MediumProfile');
+      expect(myPackage.aliases).toHaveLength(0);
     });
   });
 });

--- a/test/optimizer/plugins/ResolveParentURLsOptimizer.test.ts
+++ b/test/optimizer/plugins/ResolveParentURLsOptimizer.test.ts
@@ -107,7 +107,19 @@ describe('optimizer', () => {
       expect(resource.parent).toBe('Resource');
     });
 
-    it('should alias a core FHIR resource if it shares a name with a local StructureDefinition', () => {
+    it('should alias a core FHIR resource if it shares a name with a local StructureDefinition and alias is true', () => {
+      const profile = new ExportableProfile('MyPatient');
+      profile.parent = 'http://hl7.org/fhir/StructureDefinition/Patient';
+      const myPackage = new Package();
+      myPackage.add(profile);
+      optimizer.optimize(myPackage, fisher, { alias: true });
+      expect(profile.parent).toBe('$Patient');
+      expect(myPackage.aliases).toEqual([
+        { alias: '$Patient', url: 'http://hl7.org/fhir/StructureDefinition/Patient' }
+      ]);
+    });
+
+    it('should alias a core FHIR resource if it shares a name with a local StructureDefinition and alias is undefined', () => {
       const profile = new ExportableProfile('MyPatient');
       profile.parent = 'http://hl7.org/fhir/StructureDefinition/Patient';
       const myPackage = new Package();
@@ -119,7 +131,29 @@ describe('optimizer', () => {
       ]);
     });
 
-    it('should alias the profile parent url if the parent is not found', () => {
+    it('should not alias a core FHIR resource if it shares a name with a local StructureDefinition and alias is false', () => {
+      const profile = new ExportableProfile('MyPatient');
+      profile.parent = 'http://hl7.org/fhir/StructureDefinition/Patient';
+      const myPackage = new Package();
+      myPackage.add(profile);
+      optimizer.optimize(myPackage, fisher, { alias: false });
+      expect(profile.parent).toBe('http://hl7.org/fhir/StructureDefinition/Patient');
+      expect(myPackage.aliases).toHaveLength(0);
+    });
+
+    it('should alias the profile parent url if the parent is not found and alias is true', () => {
+      const profile = new ExportableProfile('ExtraProfile');
+      profile.parent = 'https://demo.org/StructureDefinition/MediumProfile';
+      const myPackage = new Package();
+      myPackage.add(profile);
+      optimizer.optimize(myPackage, fisher, { alias: true });
+      expect(profile.parent).toBe('$MediumProfile');
+      expect(myPackage.aliases).toEqual([
+        { alias: '$MediumProfile', url: 'https://demo.org/StructureDefinition/MediumProfile' }
+      ]);
+    });
+
+    it('should alias the profile parent url if the parent is not found and alias is undefined', () => {
       const profile = new ExportableProfile('ExtraProfile');
       profile.parent = 'https://demo.org/StructureDefinition/MediumProfile';
       const myPackage = new Package();
@@ -129,6 +163,16 @@ describe('optimizer', () => {
       expect(myPackage.aliases).toEqual([
         { alias: '$MediumProfile', url: 'https://demo.org/StructureDefinition/MediumProfile' }
       ]);
+    });
+
+    it('should not alias the profile parent url if the parent is not found and alias is false', () => {
+      const profile = new ExportableProfile('ExtraProfile');
+      profile.parent = 'https://demo.org/StructureDefinition/MediumProfile';
+      const myPackage = new Package();
+      myPackage.add(profile);
+      optimizer.optimize(myPackage, fisher, { alias: false });
+      expect(profile.parent).toBe('https://demo.org/StructureDefinition/MediumProfile');
+      expect(myPackage.aliases).toHaveLength(0);
     });
   });
 });

--- a/test/optimizer/plugins/ResolveValueSetComponentRuleURLsOptimizer.test.ts
+++ b/test/optimizer/plugins/ResolveValueSetComponentRuleURLsOptimizer.test.ts
@@ -79,7 +79,28 @@ describe('optimizer', () => {
       expect(valueset.rules).toContainEqual(expectedRule);
     });
 
-    it('should alias filter rule system url when it is same as local code system name', () => {
+    it('should alias filter rule system url when it is same as local code system name when alias is true', () => {
+      const valueset = new ExportableValueSet('MyValueSet');
+      const rule = new ExportableValueSetFilterComponentRule(true);
+      rule.from = { system: 'http://hl7.org/fhir/observation-status' };
+      valueset.rules.push(rule);
+      const myPackage = new Package();
+      myPackage.add(valueset);
+
+      // Use a modified lake and fisher to force the local CS to have the same name
+      const modLake = cloneDeep(lake);
+      modLake.docs[0].content.name = 'ObservationStatus';
+      optimizer.optimize(myPackage, new MasterFisher(modLake, defs), { alias: true });
+
+      const expectedRule = new ExportableValueSetFilterComponentRule(true);
+      expectedRule.from = { system: '$observation-status' };
+      expect(valueset.rules).toContainEqual(expectedRule);
+      expect(myPackage.aliases).toEqual([
+        { alias: '$observation-status', url: 'http://hl7.org/fhir/observation-status' }
+      ]);
+    });
+
+    it('should alias filter rule system url when it is same as local code system name when alias is undefined', () => {
       const valueset = new ExportableValueSet('MyValueSet');
       const rule = new ExportableValueSetFilterComponentRule(true);
       rule.from = { system: 'http://hl7.org/fhir/observation-status' };
@@ -98,6 +119,23 @@ describe('optimizer', () => {
       expect(myPackage.aliases).toEqual([
         { alias: '$observation-status', url: 'http://hl7.org/fhir/observation-status' }
       ]);
+    });
+
+    it('should not alias filter rule system url when it is same as local code system name when alias is false', () => {
+      const valueset = new ExportableValueSet('MyValueSet');
+      const rule = new ExportableValueSetFilterComponentRule(true);
+      rule.from = { system: 'http://hl7.org/fhir/observation-status' };
+      valueset.rules.push(rule);
+      const myPackage = new Package();
+      myPackage.add(valueset);
+
+      // Use a modified lake and fisher to force the local CS to have the same name
+      const modLake = cloneDeep(lake);
+      modLake.docs[0].content.name = 'ObservationStatus';
+      optimizer.optimize(myPackage, new MasterFisher(modLake, defs), { alias: false });
+
+      expect(valueset.rules).toContainEqual(rule);
+      expect(myPackage.aliases).toHaveLength(0);
     });
 
     // TODO: Revisit this when SUSHI supports fishing for Instance CodeSystems by name/id
@@ -157,7 +195,28 @@ describe('optimizer', () => {
       expect(valueset.rules).toContainEqual(expectedRule);
     });
 
-    it('should alias the filter rule system url when it is same as local code system name', () => {
+    it('should alias the filter rule system url when it is same as local code system name when alias is true', () => {
+      const valueset = new ExportableValueSet('MyValueSet');
+      const rule = new ExportableValueSetFilterComponentRule(true);
+      rule.from = { valueSets: ['http://hl7.org/fhir/ValueSet/observation-status'] };
+      valueset.rules.push(rule);
+      const myPackage = new Package();
+      myPackage.add(valueset);
+
+      // Use a modified lake and fisher to force the local CS to have the same name
+      const modLake = cloneDeep(lake);
+      modLake.docs[2].content.name = 'ObservationStatus';
+      optimizer.optimize(myPackage, new MasterFisher(modLake, defs), { alias: true });
+
+      const expectedRule = new ExportableValueSetFilterComponentRule(true);
+      expectedRule.from = { valueSets: ['$observation-status'] };
+      expect(valueset.rules).toContainEqual(expectedRule);
+      expect(myPackage.aliases).toEqual([
+        { alias: '$observation-status', url: 'http://hl7.org/fhir/ValueSet/observation-status' }
+      ]);
+    });
+
+    it('should alias the filter rule system url when it is same as local code system name when alias is undefined', () => {
       const valueset = new ExportableValueSet('MyValueSet');
       const rule = new ExportableValueSetFilterComponentRule(true);
       rule.from = { valueSets: ['http://hl7.org/fhir/ValueSet/observation-status'] };
@@ -176,6 +235,23 @@ describe('optimizer', () => {
       expect(myPackage.aliases).toEqual([
         { alias: '$observation-status', url: 'http://hl7.org/fhir/ValueSet/observation-status' }
       ]);
+    });
+
+    it('should not alias the filter rule system url when it is same as local code system name when alias is false', () => {
+      const valueset = new ExportableValueSet('MyValueSet');
+      const rule = new ExportableValueSetFilterComponentRule(true);
+      rule.from = { valueSets: ['http://hl7.org/fhir/ValueSet/observation-status'] };
+      valueset.rules.push(rule);
+      const myPackage = new Package();
+      myPackage.add(valueset);
+
+      // Use a modified lake and fisher to force the local CS to have the same name
+      const modLake = cloneDeep(lake);
+      modLake.docs[2].content.name = 'ObservationStatus';
+      optimizer.optimize(myPackage, new MasterFisher(modLake, defs), { alias: false });
+
+      expect(valueset.rules[0]).toEqual(rule);
+      expect(myPackage.aliases).toHaveLength(0);
     });
 
     // TODO: Revisit this when SUSHI supports fishing for Instance ValueSets by name/id

--- a/test/optimizer/utils.test.ts
+++ b/test/optimizer/utils.test.ts
@@ -40,6 +40,19 @@ describe('optimizer', () => {
       ]);
     });
 
+    it('should return the original URL if it can not be resolved and makeAlias is false', () => {
+      const aliases: ExportableAlias[] = [];
+      const result = optimizeURL(
+        'https://not-resolved/StructureDefinition/Patient',
+        aliases,
+        [utils.Type.Resource, utils.Type.Profile, utils.Type.Extension],
+        fisher,
+        false
+      );
+      expect(result).toBe('https://not-resolved/StructureDefinition/Patient');
+      expect(aliases).toHaveLength(0);
+    });
+
     it('should return the original URL if it can not be resolved or aliased', () => {
       const aliases: ExportableAlias[] = [];
       const result = optimizeURL(


### PR DESCRIPTION
Fixes #156 and completes task [CIMPL-846](https://standardhealthrecord.atlassian.net/browse/CIMPL-846).

When the "--no-alias" flag is specified, FSH is produced without any aliases. URLs that do not resolve to a name will be used directly rather than being replaced by an alias.

Due to some normally helpful features of commander, do not add command-line options directly to the Command instance as properties. Instead, retrieve the options using the provided opts() method. This is done to avoid colliding with the existing "alias" property on the Command instance.