### PR TITLE
Reserved path characters removed from filenames

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13270,6 +13270,14 @@
         }
       }
     },
+    "sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "requires": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
     "saxes": {
       "version": "3.1.11",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
@@ -13983,6 +13991,14 @@
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
+    "truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha1-QFkjkJWS1W94pYGENLC3hInKXys=",
+      "requires": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
     "ts-jest": {
       "version": "25.5.1",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-25.5.1.tgz",
@@ -14173,6 +14189,11 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "utf8-byte-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.4.tgz",
+      "integrity": "sha1-9F8VDExm7uloGGUFq5P8u4rWv2E="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "ini": "^1.3.8",
     "lodash": "^4.17.21",
     "readline-sync": "^1.4.10",
+    "sanitize-filename": "^1.6.3",
     "semver": "^7.3.2",
     "temp": "^0.9.1",
     "text-table": "^0.2.0",

--- a/test/export/FSHExporter.test.ts
+++ b/test/export/FSHExporter.test.ts
@@ -545,6 +545,43 @@ describe('FSHExporter', () => {
           )
       );
     });
+
+    it('should remove reserved file name characters when style is "group-by-profile"', () => {
+      const profile1 = new ExportableProfile('Some/Profile');
+      myPackage.add(profile1);
+
+      const instance = new ExportableInstance('SomeInstance');
+      instance.instanceOf = 'Some/Profile';
+      myPackage.add(instance);
+
+      const result = exporter.export('group-by-profile');
+      expect(result).toEqual(
+        new Map()
+          .set(
+            'Some-Profile.fsh',
+            [
+              'Profile: Some/Profile',
+              EOL,
+              'Id: Some/Profile',
+              EOL,
+              EOL,
+              'Instance: SomeInstance',
+              EOL,
+              'InstanceOf: Some/Profile',
+              EOL,
+              'Usage: #example'
+            ].join('')
+          )
+          .set(
+            'index.txt',
+            table([
+              ['Name', 'Type', 'File'],
+              ['Some/Profile', 'Profile', 'Some-Profile.fsh'],
+              ['SomeInstance', 'Instance', 'Some-Profile.fsh']
+            ])
+          )
+      );
+    });
   });
 
   describe('#groupAsFilePerDefinition', () => {
@@ -634,6 +671,90 @@ describe('FSHExporter', () => {
               ['SomeProfile', 'Profile', path.join('profiles', 'SomeProfile.fsh')],
               ['SomeResource', 'Resource', path.join('resources', 'SomeResource.fsh')],
               ['SomeValueSet', 'ValueSet', path.join('valuesets', 'SomeValueSet.fsh')]
+            ])
+          )
+      );
+    });
+
+    it('should remove reserved characters form file names when style is "file-per-definition"', () => {
+      myPackage.add(new ExportableProfile('Some\\Profile'));
+      myPackage.add(new ExportableProfile('Another/Profile'));
+      myPackage.add(new ExportableExtension('Some/Extension'));
+      myPackage.add(new ExportableLogical('Some/Logical'));
+      myPackage.add(new ExportableResource('Some\\Resource'));
+      myPackage.add(new ExportableValueSet('Some/ValueSet'));
+      myPackage.add(new ExportableCodeSystem('Some/CodeSystem'));
+      const instance = new ExportableInstance('Some//Instance');
+      instance.instanceOf = 'Some\\Profile';
+      myPackage.add(instance);
+      myPackage.add(new ExportableInvariant('Some/Invariant'));
+      myPackage.add(new ExportableMapping('Some/Mapping'));
+      myPackage.aliases.push(new ExportableAlias('foo', 'http://example.com/foo'));
+
+      const result = exporter.export('file-per-definition');
+      expect(result).toEqual(
+        new Map()
+          .set('aliases.fsh', ['Alias: foo = http://example.com/foo'].join(''))
+          .set(
+            path.join('invariants', 'Some-Invariant.fsh'),
+            ['Invariant: Some/Invariant'].join('')
+          )
+          .set(
+            path.join('mappings', 'Some-Mapping.fsh'),
+            ['Mapping: Some/Mapping', EOL, 'Id: Some/Mapping'].join('')
+          )
+          .set(
+            path.join('profiles', 'Another-Profile.fsh'),
+            ['Profile: Another/Profile', EOL, 'Id: Another/Profile'].join('')
+          )
+          .set(
+            path.join('profiles', 'Some-Profile.fsh'),
+            ['Profile: Some\\Profile', EOL, 'Id: Some\\Profile'].join('')
+          )
+          .set(
+            path.join('extensions', 'Some-Extension.fsh'),
+            ['Extension: Some/Extension', EOL, 'Id: Some/Extension'].join('')
+          )
+          .set(
+            path.join('logicals', 'Some-Logical.fsh'),
+            ['Logical: Some/Logical', EOL, 'Id: Some/Logical'].join('')
+          )
+          .set(
+            path.join('resources', 'Some-Resource.fsh'),
+            ['Resource: Some\\Resource', EOL, 'Id: Some\\Resource'].join('')
+          )
+          .set(
+            path.join('codesystems', 'Some-CodeSystem.fsh'),
+            ['CodeSystem: Some/CodeSystem', EOL, 'Id: Some/CodeSystem'].join('')
+          )
+          .set(
+            path.join('valuesets', 'Some-ValueSet.fsh'),
+            ['ValueSet: Some/ValueSet', EOL, 'Id: Some/ValueSet'].join('')
+          )
+          .set(
+            path.join('instances', 'Some--Instance.fsh'),
+            [
+              'Instance: Some//Instance',
+              EOL,
+              'InstanceOf: Some\\Profile',
+              EOL,
+              'Usage: #example'
+            ].join('')
+          )
+          .set(
+            'index.txt',
+            table([
+              ['Name', 'Type', 'File'],
+              ['Another/Profile', 'Profile', path.join('profiles', 'Another-Profile.fsh')],
+              ['Some//Instance', 'Instance', path.join('instances', 'Some--Instance.fsh')],
+              ['Some/CodeSystem', 'CodeSystem', path.join('codesystems', 'Some-CodeSystem.fsh')],
+              ['Some/Extension', 'Extension', path.join('extensions', 'Some-Extension.fsh')],
+              ['Some/Invariant', 'Invariant', path.join('invariants', 'Some-Invariant.fsh')],
+              ['Some/Logical', 'Logical', path.join('logicals', 'Some-Logical.fsh')],
+              ['Some/Mapping', 'Mapping', path.join('mappings', 'Some-Mapping.fsh')],
+              ['Some/ValueSet', 'ValueSet', path.join('valuesets', 'Some-ValueSet.fsh')],
+              ['Some\\Profile', 'Profile', path.join('profiles', 'Some-Profile.fsh')],
+              ['Some\\Resource', 'Resource', path.join('resources', 'Some-Resource.fsh')]
             ])
           )
       );


### PR DESCRIPTION
Addresses [CIMPL-870](https://standardhealthrecord.atlassian.net/browse/CIMPL-870), replacing reserved path characters with `-` to prevent unsavory file writing behavior. This PR adds this behavior to `makeNameSushiSafe` which previously just removed whitespace from entity names, and renames the function to `sanitizeName`.