### PR TITLE
Update SUSHI to 2.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3473,9 +3473,9 @@
       "optional": true
     },
     "fsh-sushi": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-2.2.4.tgz",
-      "integrity": "sha512-rk/YAcvNMf6il3apiZeWxkjFQoJdOYx+/34oy4/cJu/V8UKbIc/4k9mU9HHZahABoDKukSHIBgFEYH8tZ0KJxA==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-2.2.6.tgz",
+      "integrity": "sha512-FPsOZaWVGrX+Ai+Y49ravrpDkXYoRhxiGjZ1xiV3++VVwP7ZM+CUQP2zP2G5Ieag5C7hWy7vzT6ul8SyEQUT9w==",
       "requires": {
         "antlr4": "~4.8.0",
         "axios": "^0.21.4",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "fhir": "^4.10.0",
     "flat": "^5.0.2",
     "fs-extra": "^9.0.1",
-    "fsh-sushi": "^2.2.4",
+    "fsh-sushi": "^2.2.6",
     "ini": "^1.3.8",
     "lodash": "^4.17.21",
     "readline-sync": "^1.4.10",


### PR DESCRIPTION
This mainly adds support for FHIR 5.0.0-snapshot1.  You can test this using the attached simple project:
[TestR5JSON.zip](https://github.com/FHIR/GoFSH/files/7818742/TestR5JSON.zip)

