### PR TITLE
Improve support for additional FHIR versions

### DIFF
--- a/src/api/FhirToFsh.ts
+++ b/src/api/FhirToFsh.ts
@@ -1,5 +1,6 @@
 import { fhirdefs, fhirtypes, fshtypes, utils } from 'fsh-sushi';
 import {
+  determineCorePackageId,
   getResources,
   isProcessableContent,
   loadExternalDependencies,
@@ -79,13 +80,12 @@ export async function fhirToFsh(
   );
 
   // Load dependencies, including those inferred from an IG file, and those given as input
-  const dependencies = configuration.config.dependencies?.map(
-    (dep: fhirtypes.ImplementationGuideDependsOn) => `${dep.packageId}@${dep.version}`
-  );
-  if (dependencies) {
-    const fhirPackageId = configuration.config.fhirVersion[0].startsWith('4.0')
-      ? 'hl7.fhir.r4.core'
-      : 'hl7.fhir.r5.core';
+  const dependencies =
+    configuration.config.dependencies?.map(
+      (dep: fhirtypes.ImplementationGuideDependsOn) => `${dep.packageId}@${dep.version}`
+    ) ?? [];
+  const fhirPackageId = determineCorePackageId(configuration.config.fhirVersion[0]);
+  if (!dependencies.includes(`${fhirPackageId}@${configuration.config.fhirVersion[0]}`)) {
     dependencies.push(`${fhirPackageId}@${configuration.config.fhirVersion[0]}`);
   }
   await Promise.all(loadExternalDependencies(defs, dependencies));

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ import chalk from 'chalk';
 import { pad, padStart, padEnd } from 'lodash';
 import { fhirdefs, fhirtypes, utils } from 'fsh-sushi';
 import {
+  determineCorePackageId,
   ensureOutputDir,
   getInputDir,
   getAliasFile,
@@ -153,9 +154,7 @@ async function app() {
     config.config.dependencies?.map(
       (dep: fhirtypes.ImplementationGuideDependsOn) => `${dep.packageId}@${dep.version}`
     ) ?? [];
-  const fhirPackageId = config.config.fhirVersion[0].startsWith('4.0')
-    ? 'hl7.fhir.r4.core'
-    : 'hl7.fhir.r5.core';
+  const fhirPackageId = determineCorePackageId(config.config.fhirVersion[0]);
   allDependencies.push(`${fhirPackageId}@${config.config.fhirVersion[0]}`);
   const dependencyDefs = loadExternalDependencies(defs, allDependencies);
 

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -117,7 +117,7 @@ export function loadExternalDependencies(
   dependencies: string[] = []
 ): Promise<fhirdefs.FHIRDefinitions | void>[] {
   // Automatically include FHIR R4 if no other versions of FHIR are already included
-  if (!dependencies.some(dep => /hl7\.fhir\.r[45]\.core/.test(dep))) {
+  if (!dependencies.some(dep => /hl7\.fhir\.r(4|5|4b)\.core/.test(dep))) {
     dependencies.push('hl7.fhir.r4.core@4.0.1');
   }
 
@@ -300,6 +300,20 @@ export function getFilesRecursive(dir: string): string[] {
       return [];
     }
     return [dir];
+  }
+}
+
+export function determineCorePackageId(fhirVersion: string): string {
+  if (/^4\.0\./.test(fhirVersion)) {
+    return 'hl7.fhir.r4.core';
+  } else if (/^(4\.1\.|4\.3.\d+-)/.test(fhirVersion)) {
+    return 'hl7.fhir.r4b.core';
+  } else if (/^4\.3.\d+$/.test(fhirVersion)) {
+    return 'hl7.fhir.r4b.core';
+  } else if (/^5\.0.\d+$/.test(fhirVersion)) {
+    return 'hl7.fhir.r5.core';
+  } else {
+    return 'hl7.fhir.r5.core';
   }
 }
 

--- a/test/api/FhirToFsh.test.ts
+++ b/test/api/FhirToFsh.test.ts
@@ -132,6 +132,27 @@ describe('fhirToFsh', () => {
     ]);
   });
 
+  it('should load FHIR R4B when specified in config fhirVersion', async () => {
+    // Loads R4B from fhirVersion
+    const results = await fhirToFsh([
+      JSON.stringify({
+        resourceType: 'StructureDefinition',
+        name: 'Foo',
+        baseDefinition: 'http://hl7.org/fhir/StructureDefinition/Patient',
+        derivation: 'constraint',
+        fhirVersion: '4.3.0' // FHIR R4B
+      })
+    ]);
+    expect(results.errors).toHaveLength(0);
+    expect(results.warnings).toHaveLength(0);
+    expect(results.configuration).toEqual({
+      ...defaultConfig,
+      fhirVersion: ['4.3.0']
+    });
+    expect(loadSpy.mock.calls).toHaveLength(1);
+    expect(loadSpy.mock.calls[0][1]).toEqual(['hl7.fhir.r4b.core@4.3.0']);
+  });
+
   it('should parse a string input into JSON', async () => {
     const results = await fhirToFsh([
       JSON.stringify({


### PR DESCRIPTION
This PR improves support for other FHIR versions besides R4 in GoFSH. There main changes are:

- When running the GoFSH CLI, use `determineCorePackageId` to determine the FHIR package name based on the `fhirVersion` specified.
- When using the GoFSH API, use `determineCorePackageId` to determine the FHIR package name based on the `fhirVersion`.
- When using the GoFSH API, no longer assume that we should let R4 be loaded by default in `loadExternalDependencies` if no `dependencies` are specified in `options`. Instead, add the FHIR version if it is not already listed in `options`. I think that previous logic (let R4 be loaded by default if no `dependencies` are found) was actually wrong, so this updates it to what I think is correct.
- Expand the regex used to determine if no core FHIR versions are going to be loaded to include R4B. If R4, R4B, or R5 are not loaded based on the dependencies GoFSH finds, it will default to load R4.

Fixes #176 