### PR TITLE
Integrate FPL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1723,6 +1723,14 @@
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
+    "axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "requires": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
     "babel-jest": {
       "version": "27.4.5",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.4.5.tgz",
@@ -1913,6 +1921,11 @@
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
+    },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "ci-info": {
       "version": "3.3.0",
@@ -2729,6 +2742,52 @@
         }
       }
     },
+    "fhir-package-loader": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.1.0.tgz",
+      "integrity": "sha512-NZwWgiHO8MpJyrXUYy5xJsaAiYFQofwz5LbwhTjN87BTxPV4IcrO2rBt+idUOzVPQ70aJmTc/LSP0ih13KhDhQ==",
+      "requires": {
+        "axios": "^0.21.1",
+        "chalk": "^4.1.2",
+        "commander": "^8.3.0",
+        "fs-extra": "^10.0.0",
+        "lodash": "^4.17.21",
+        "tar": "^5.0.11",
+        "temp": "^0.9.1",
+        "winston": "^3.3.3"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "commander": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+          "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
+        },
+        "fs-extra": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+          "integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+        }
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -2794,6 +2853,11 @@
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
+    "follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
+    },
     "form-data": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
@@ -2814,6 +2878,14 @@
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^1.0.0"
+      }
+    },
+    "fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "requires": {
+        "minipass": "^3.0.0"
       }
     },
     "fs.realpath": {
@@ -6298,15 +6370,18 @@
           "dependencies": {
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
             },
             "lodash": {
               "version": "4.17.21",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
             },
             "path": {
               "version": "0.12.7",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
               "requires": {
                 "process": "^0.11.1",
                 "util": "^0.10.3"
@@ -6314,26 +6389,31 @@
             },
             "process": {
               "version": "0.11.10",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
             },
             "q": {
               "version": "1.5.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
             },
             "sax": {
               "version": "1.2.4",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
             },
             "util": {
               "version": "0.10.4",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
               "requires": {
                 "inherits": "2.0.3"
               }
             },
             "xml-js": {
               "version": "1.6.8",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-kUv/geyN80d+s1T68uBfjoz+PjNUjwwf5AWWRwKRqqQaGozpMVsFsKYnenPsxlbN/VL7f0ia8NfLLPCDwX+95Q==",
               "requires": {
                 "sax": "^1.2.4"
               }
@@ -11782,6 +11862,23 @@
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
+    "minipass": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "requires": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      }
+    },
     "mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -12401,6 +12498,34 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "tar": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-5.0.11.tgz",
+      "integrity": "sha512-E6q48d5y4XSCD+Xmwc0yc8lXuyDK38E0FB8N4S/drQRtXOMUhfhDxbB0xr2KKDhNfO51CFmoa6Oz00nAkWsjnA==",
+      "requires": {
+        "chownr": "^1.1.4",
+        "fs-minipass": "^2.1.0",
+        "minipass": "^3.1.3",
+        "minizlib": "^2.1.2",
+        "mkdirp": "^0.5.5",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+        },
+        "mkdirp": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+          "requires": {
+            "minimist": "^1.2.6"
+          }
+        }
+      }
+    },
     "temp": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/temp/-/temp-0.9.1.tgz",
@@ -12890,8 +13015,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
     "Mint Thompson <mathompson@mitre.org>",
     "Guhan B. Thuran <gthuran@mitre.org>"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/FHIR/GoFSH.git"
+  },
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/antlr4": "^4.7.2",
@@ -69,6 +73,7 @@
     "diff": "^5.0.0",
     "diff2html": "^3.1.18",
     "fhir": "^4.10.0",
+    "fhir-package-loader": "^0.1.0",
     "flat": "^5.0.2",
     "fs-extra": "^9.0.1",
     "fsh-sushi": "^2.5.0",

--- a/src/api/FhirToFsh.ts
+++ b/src/api/FhirToFsh.ts
@@ -1,6 +1,7 @@
-import { fhirdefs, fhirtypes, fshtypes, utils } from 'fsh-sushi';
+import { fhirtypes, fshtypes, utils } from 'fsh-sushi';
 import {
   determineCorePackageId,
+  FHIRDefinitions,
   getResources,
   isProcessableContent,
   loadExternalDependencies,
@@ -70,7 +71,7 @@ export async function fhirToFsh(
 
   // Set up the FHIRProcessor
   const lake = new LakeOfFHIR(docs);
-  const defs = new fhirdefs.FHIRDefinitions();
+  const defs = new FHIRDefinitions();
   const fisher = new MasterFisher(lake, defs);
   const processor = new FHIRProcessor(lake, fisher);
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,10 +5,11 @@ import fs from 'fs-extra';
 import program from 'commander';
 import chalk from 'chalk';
 import { pad, padStart, padEnd } from 'lodash';
-import { fhirdefs, fhirtypes, utils } from 'fsh-sushi';
+import { fhirtypes, utils } from 'fsh-sushi';
 import {
   determineCorePackageId,
   ensureOutputDir,
+  FHIRDefinitions,
   getInputDir,
   getAliasFile,
   getFhirProcessor,
@@ -115,7 +116,7 @@ async function app() {
   }
 
   // Load dependencies
-  const defs = new fhirdefs.FHIRDefinitions();
+  const defs = new FHIRDefinitions();
 
   // Trim empty spaces from command line dependencies
   const dependencies = programOptions.dependency?.map((dep: string) => dep.trim());

--- a/src/processor/AliasProcessor.ts
+++ b/src/processor/AliasProcessor.ts
@@ -5,8 +5,8 @@ import { logger } from '../utils/GoFSHLogger';
 import { InputStream, CommonTokenStream } from 'antlr4';
 // digging up the lexer/parser so that we can implement with less code duplication
 // it's a little risky, but such is the nature of the sea
-import { FSHLexer } from 'fsh-sushi/dist/import/generated/FSHLexer';
-import { FSHParser } from 'fsh-sushi/dist/import/generated/FSHParser';
+import FSHLexer from 'fsh-sushi/dist/import/generated/FSHLexer';
+import FSHParser from 'fsh-sushi/dist/import/generated/FSHParser';
 
 export class AliasProcessor {
   static process(aliasFile: string): ExportableAlias[] {

--- a/src/processor/LakeOfFHIR.ts
+++ b/src/processor/LakeOfFHIR.ts
@@ -1,11 +1,11 @@
-import { fhirdefs, utils } from 'fsh-sushi';
+import { utils } from 'fsh-sushi';
 import { uniqWith } from 'lodash';
 import { CodeSystemProcessor } from './CodeSystemProcessor';
 import { CONFORMANCE_AND_TERMINOLOGY_RESOURCES } from './InstanceProcessor';
 import { StructureDefinitionProcessor } from './StructureDefinitionProcessor';
 import { ValueSetProcessor } from './ValueSetProcessor';
 import { WildFHIR } from './WildFHIR';
-import { logger } from '../utils';
+import { FHIRDefinitions, logger } from '../utils';
 
 // Like FSHTank in SUSHI, but it doesn't contain FSH, it contains FHIR.  And who ever heard of a tank of FHIR?  But a lake of FHIR...
 export class LakeOfFHIR implements utils.Fishable {
@@ -116,7 +116,7 @@ export class LakeOfFHIR implements utils.Fishable {
     // the only safe way to do this is by rebuilding a FHIRDefinitions object each time we need it.  If this becomes a performance
     // concern, we can optimize it later -- but performance isn't a huge concern in GoFSH. Note also that this approach may need to be
     // updated if we ever need to support fishing for Instances.
-    const defs = new fhirdefs.FHIRDefinitions();
+    const defs = new FHIRDefinitions();
     this.docs.forEach(d => defs.add(d.content));
     return defs.fishForFHIR(item, ...types);
   }
@@ -126,7 +126,7 @@ export class LakeOfFHIR implements utils.Fishable {
     // the only safe way to do this is by rebuilding a FHIRDefinitions object each time we need it.  If this becomes a performance
     // concern, we can optimize it later -- but performance isn't a huge concern in GoFSH. Note also that this approach may need to be
     // updated if we ever need to support fishing for Instances.
-    const defs = new fhirdefs.FHIRDefinitions();
+    const defs = new FHIRDefinitions();
     this.docs.forEach(d => defs.add(d.content));
     return defs.fishForMetadata(item, ...types);
   }

--- a/src/utils/FHIRDefinitions.ts
+++ b/src/utils/FHIRDefinitions.ts
@@ -1,0 +1,15 @@
+import { FHIRDefinitions as BaseFHIRDefinitions, Type } from 'fhir-package-loader';
+import { utils } from 'fsh-sushi';
+
+export class FHIRDefinitions extends BaseFHIRDefinitions implements utils.Fishable {
+  fishForMetadata(item: string, ...types: Type[]): utils.Metadata | undefined {
+    const result = this.fishForFHIR(item, ...types);
+    if (result) {
+      return {
+        id: result.id as string,
+        name: result.name as string,
+        url: result.url as string
+      };
+    }
+  }
+}

--- a/src/utils/GoFSHLogger.ts
+++ b/src/utils/GoFSHLogger.ts
@@ -99,3 +99,7 @@ export class ErrorsAndWarnings {
 
 export const stats = new LoggerStats();
 export const errorsAndWarnings = new ErrorsAndWarnings();
+
+export const logMessage = (level: string, message: string): void => {
+  logger.log(level, message);
+};

--- a/src/utils/MasterFisher.ts
+++ b/src/utils/MasterFisher.ts
@@ -1,5 +1,6 @@
-import { utils, fhirdefs, fhirtypes } from 'fsh-sushi';
+import { utils, fhirtypes } from 'fsh-sushi';
 import { LakeOfFHIR } from '../processor';
+import { FHIRDefinitions } from '../utils';
 
 /**
  * The MasterFisher can fish from the LakeOfFHIR and external definitions. When the MasterFisher fishes,
@@ -7,10 +8,7 @@ import { LakeOfFHIR } from '../processor';
  * definitions first (when there are naming clashes) - matching the SUSHI MasterFisher behavior.
  */
 export class MasterFisher implements utils.Fishable {
-  constructor(
-    public lakeOfFHIR = new LakeOfFHIR([]),
-    public external = new fhirdefs.FHIRDefinitions()
-  ) {}
+  constructor(public lakeOfFHIR = new LakeOfFHIR([]), public external = new FHIRDefinitions()) {}
 
   fishForStructureDefinition(item: string) {
     const json = this.fishForFHIR(

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import ini from 'ini';
 import readlineSync from 'readline-sync';
 import { mergeDependency } from 'fhir-package-loader';
-import { logger } from './GoFSHLogger';
+import { logger, logMessage } from './GoFSHLogger';
 import {
   Package,
   FHIRProcessor,
@@ -133,7 +133,7 @@ export function loadExternalDependencies(
       continue;
     }
     dependencyDefs.push(
-      mergeDependency(packageId, version, defs)
+      mergeDependency(packageId, version, defs, undefined, logMessage)
         .then((def: FHIRDefinitions) => {
           return def;
         })

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import ini from 'ini';
 import readlineSync from 'readline-sync';
 import { fhirdefs } from 'fsh-sushi';
-import { loadDependency } from 'fhir-package-loader';
+import { mergeDependency } from 'fhir-package-loader';
 import { logger } from './GoFSHLogger';
 import {
   Package,
@@ -134,7 +134,7 @@ export function loadExternalDependencies(
       continue;
     }
     dependencyDefs.push(
-      loadDependency(packageId, version, defs)
+      mergeDependency(packageId, version, defs)
         .then((def: fhirdefs.FHIRDefinitions) => {
           return def;
         })

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -2,7 +2,6 @@ import fs from 'fs-extra';
 import path from 'path';
 import ini from 'ini';
 import readlineSync from 'readline-sync';
-import { fhirdefs } from 'fsh-sushi';
 import { mergeDependency } from 'fhir-package-loader';
 import { logger } from './GoFSHLogger';
 import {
@@ -15,7 +14,7 @@ import {
 } from '../processor';
 import { FSHExporter } from '../export/FSHExporter';
 import { loadOptimizers } from '../optimizer';
-import { MasterFisher } from '../utils';
+import { FHIRDefinitions, MasterFisher } from '../utils';
 import { ExportableAlias } from '../exportable';
 import { ExportableConfiguration } from '../exportable';
 import { Fhir as FHIR } from 'fhir/fhir';
@@ -58,7 +57,7 @@ export function ensureOutputDir(output = path.join('.', 'gofsh')): string {
   return output;
 }
 
-export function getFhirProcessor(inDir: string, defs: fhirdefs.FHIRDefinitions, fileType: string) {
+export function getFhirProcessor(inDir: string, defs: FHIRDefinitions, fileType: string) {
   const lake = getLakeOfFHIR(inDir, fileType);
 
   // Assign any missing ids where we can before filtering out duplicates so that all
@@ -114,16 +113,16 @@ export function writeFSH(resources: Package, outDir: string, style: string): voi
 }
 
 export function loadExternalDependencies(
-  defs: fhirdefs.FHIRDefinitions,
+  defs: FHIRDefinitions,
   dependencies: string[] = []
-): Promise<fhirdefs.FHIRDefinitions | void>[] {
+): Promise<FHIRDefinitions | void>[] {
   // Automatically include FHIR R4 if no other versions of FHIR are already included
   if (!dependencies.some(dep => /hl7\.fhir\.r(4|5|4b)\.core/.test(dep))) {
     dependencies.push('hl7.fhir.r4.core@4.0.1');
   }
 
   // Load dependencies
-  const dependencyDefs: Promise<fhirdefs.FHIRDefinitions | void>[] = [];
+  const dependencyDefs: Promise<FHIRDefinitions | void>[] = [];
   for (const dep of dependencies) {
     const [packageId, version] = dep.split('@');
     if (version == null) {
@@ -135,7 +134,7 @@ export function loadExternalDependencies(
     }
     dependencyDefs.push(
       mergeDependency(packageId, version, defs)
-        .then((def: fhirdefs.FHIRDefinitions) => {
+        .then((def: FHIRDefinitions) => {
           return def;
         })
         .catch(e => {

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import ini from 'ini';
 import readlineSync from 'readline-sync';
 import { fhirdefs } from 'fsh-sushi';
+import { loadDependency } from 'fhir-package-loader';
 import { logger } from './GoFSHLogger';
 import {
   Package,
@@ -133,9 +134,8 @@ export function loadExternalDependencies(
       continue;
     }
     dependencyDefs.push(
-      fhirdefs
-        .loadDependency(packageId, version, defs)
-        .then(def => {
+      loadDependency(packageId, version, defs)
+        .then((def: fhirdefs.FHIRDefinitions) => {
           return def;
         })
         .catch(e => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './element';
+export * from './FHIRDefinitions';
 export * from './GoFSHLogger';
 export * from './Processing';
 export * from './MasterFisher';

--- a/test/extractor/CardRuleExtractor.test.ts
+++ b/test/extractor/CardRuleExtractor.test.ts
@@ -1,17 +1,17 @@
 import path from 'path';
 import fs from 'fs-extra';
-import { fhirdefs } from 'fsh-sushi';
 import { cloneDeep } from 'lodash';
 import { CardRuleExtractor } from '../../src/extractor';
 import { ExportableCardRule } from '../../src/exportable';
 import { ProcessableElementDefinition } from '../../src/processor';
 import { loadTestDefinitions } from '../helpers/loadTestDefinitions';
+import { FHIRDefinitions } from '../../src/utils';
 
 describe('CardRuleExtractor', () => {
   let looseSD: any;
   let looseSDWithSlices: any;
   let looseSDWithInheritedSlices: any;
-  let defs: fhirdefs.FHIRDefinitions;
+  let defs: FHIRDefinitions;
 
   beforeAll(() => {
     looseSD = JSON.parse(

--- a/test/extractor/CaretValueRuleExtractor.test.ts
+++ b/test/extractor/CaretValueRuleExtractor.test.ts
@@ -1,12 +1,13 @@
 import path from 'path';
 import fs from 'fs-extra';
 import { cloneDeep } from 'lodash';
-import { fhirdefs, fhirtypes, fshtypes } from 'fsh-sushi';
+import { fhirtypes, fshtypes } from 'fsh-sushi';
 import { CaretValueRuleExtractor } from '../../src/extractor';
 import { ExportableCaretValueRule } from '../../src/exportable';
 import { ProcessableElementDefinition } from '../../src/processor';
 import { loggerSpy } from '../helpers/loggerSpy';
 import { loadTestDefinitions } from '../helpers/loadTestDefinitions';
+import { FHIRDefinitions } from '../../src/utils';
 
 describe('CaretValueRuleExtractor', () => {
   let looseSD: any;
@@ -14,7 +15,7 @@ describe('CaretValueRuleExtractor', () => {
   let looseCS: any;
   let looseBSSD: any;
   let config: fshtypes.Configuration;
-  let defs: fhirdefs.FHIRDefinitions;
+  let defs: FHIRDefinitions;
 
   beforeAll(() => {
     defs = loadTestDefinitions();

--- a/test/extractor/ContainsRuleExtractor.test.ts
+++ b/test/extractor/ContainsRuleExtractor.test.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 import fs from 'fs-extra';
-import { fhirdefs } from 'fsh-sushi';
 import { ContainsRuleExtractor } from '../../src/extractor';
 import { ProcessableElementDefinition } from '../../src/processor';
 import {
@@ -8,12 +7,13 @@ import {
   ExportableCardRule,
   ExportableFlagRule
 } from '../../src/exportable';
+import { FHIRDefinitions } from '../../src/utils';
 import { loadTestDefinitions } from '../helpers/loadTestDefinitions';
 import { loggerSpy } from '../helpers/loggerSpy';
 
 describe('ContainsRuleExtractor', () => {
   let looseSD: any;
-  let defs: fhirdefs.FHIRDefinitions;
+  let defs: FHIRDefinitions;
 
   beforeAll(() => {
     looseSD = JSON.parse(

--- a/test/extractor/MappingExtractor.test.ts
+++ b/test/extractor/MappingExtractor.test.ts
@@ -1,16 +1,17 @@
 import path from 'path';
 import fs from 'fs-extra';
 import { cloneDeep } from 'lodash';
-import { fhirdefs, fshtypes } from 'fsh-sushi';
+import { fshtypes } from 'fsh-sushi';
 import { loggerSpy } from '../helpers/loggerSpy';
 import { ProcessableElementDefinition, ProcessableStructureDefinition } from '../../src/processor';
 import { MappingExtractor } from '../../src/extractor';
 import { ExportableMapping, ExportableMappingRule } from '../../src/exportable';
+import { FHIRDefinitions } from '../../src/utils';
 import { loadTestDefinitions } from '../helpers/loadTestDefinitions';
 
 describe('MappingExtractor', () => {
   let looseSD: ProcessableStructureDefinition;
-  let defs: fhirdefs.FHIRDefinitions;
+  let defs: FHIRDefinitions;
   let elements: ProcessableElementDefinition[];
 
   beforeAll(() => {

--- a/test/helpers/loadTestDefinitions.ts
+++ b/test/helpers/loadTestDefinitions.ts
@@ -1,8 +1,9 @@
 import path from 'path';
 import { fhirdefs } from 'fsh-sushi';
+import { loadFromPath } from 'fhir-package-loader';
 
 export function loadTestDefinitions(): fhirdefs.FHIRDefinitions {
   const defs = new fhirdefs.FHIRDefinitions();
-  fhirdefs.loadFromPath(path.join(__dirname), 'testdefs', defs);
+  loadFromPath(path.join(__dirname), 'testdefs', defs);
   return defs;
 }

--- a/test/helpers/loadTestDefinitions.ts
+++ b/test/helpers/loadTestDefinitions.ts
@@ -1,9 +1,9 @@
 import path from 'path';
-import { fhirdefs } from 'fsh-sushi';
 import { loadFromPath } from 'fhir-package-loader';
+import { FHIRDefinitions } from '../../src/utils';
 
-export function loadTestDefinitions(): fhirdefs.FHIRDefinitions {
-  const defs = new fhirdefs.FHIRDefinitions();
+export function loadTestDefinitions(): FHIRDefinitions {
+  const defs = new FHIRDefinitions();
   loadFromPath(path.join(__dirname), 'testdefs', defs);
   return defs;
 }

--- a/test/optimizer/plugins/ResolveValueSetComponentRuleURLsOptimizer.test.ts
+++ b/test/optimizer/plugins/ResolveValueSetComponentRuleURLsOptimizer.test.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-import { fhirdefs } from 'fsh-sushi';
 import '../../helpers/loggerSpy'; // side-effect: suppresses logs
 import { LakeOfFHIR, Package } from '../../../src/processor';
 import {
@@ -7,7 +6,7 @@ import {
   ExportableValueSetConceptComponentRule,
   ExportableValueSetFilterComponentRule
 } from '../../../src/exportable';
-import { MasterFisher } from '../../../src/utils';
+import { FHIRDefinitions, MasterFisher } from '../../../src/utils';
 import { loadTestDefinitions, stockLake } from '../../helpers';
 import optimizer from '../../../src/optimizer/plugins/ResolveValueSetComponentRuleURLsOptimizer';
 import { cloneDeep } from 'lodash';
@@ -15,7 +14,7 @@ import { FshCode } from 'fsh-sushi/dist/fshtypes';
 
 describe('optimizer', () => {
   describe('#resolve_value_set_component_rule_urls', () => {
-    let defs: fhirdefs.FHIRDefinitions;
+    let defs: FHIRDefinitions;
     let lake: LakeOfFHIR;
     let fisher: MasterFisher;
 

--- a/test/processor/CodeSystemProcessor.test.ts
+++ b/test/processor/CodeSystemProcessor.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs-extra';
-import { fhirdefs, fshtypes } from 'fsh-sushi';
+import { fshtypes } from 'fsh-sushi';
 import { CodeSystemProcessor } from '../../src/processor';
 import {
   ExportableCodeSystem,
@@ -8,11 +8,12 @@ import {
   ExportableCaretValueRule
 } from '../../src/exportable';
 import { loadTestDefinitions } from '../helpers/loadTestDefinitions';
+import { FHIRDefinitions } from '../../src/utils';
 import { loggerSpy } from '../helpers/loggerSpy';
 import { FshCode } from 'fsh-sushi/dist/fshtypes';
 
 describe('CodeSystemProcessor', () => {
-  let defs: fhirdefs.FHIRDefinitions;
+  let defs: FHIRDefinitions;
   let config: fshtypes.Configuration;
 
   beforeAll(() => {

--- a/test/processor/InstanceProcessor.test.ts
+++ b/test/processor/InstanceProcessor.test.ts
@@ -1,14 +1,15 @@
 import path from 'path';
 import fs from 'fs-extra';
-import { fhirdefs, fshtypes } from 'fsh-sushi';
+import { fshtypes } from 'fsh-sushi';
 import { InstanceProcessor } from '../../src/processor';
 import { ExportableAssignmentRule, ExportableInstance } from '../../src/exportable';
+import { FHIRDefinitions } from '../../src/utils';
 import { loadTestDefinitions } from '../helpers/loadTestDefinitions';
 import { loggerSpy } from '../helpers/loggerSpy';
 
 describe('InstanceProcessor', () => {
   let simpleIg: any;
-  let defs: fhirdefs.FHIRDefinitions;
+  let defs: FHIRDefinitions;
 
   beforeEach(() => {
     simpleIg = JSON.parse(

--- a/test/processor/StructureDefinitionProcessor.test.ts
+++ b/test/processor/StructureDefinitionProcessor.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs-extra';
-import { fhirdefs, fshtypes } from 'fsh-sushi';
+import { fshtypes } from 'fsh-sushi';
 import {
   StructureDefinitionProcessor,
   ProcessableElementDefinition,
@@ -20,12 +20,13 @@ import {
   ExportableInvariant,
   ExportableBindingRule
 } from '../../src/exportable';
+import { FHIRDefinitions } from '../../src/utils';
 import { loggerSpy } from '../helpers/loggerSpy';
 import { loadTestDefinitions } from '../helpers/loadTestDefinitions';
 import { ContainsRuleExtractor } from '../../src/extractor';
 
 describe('StructureDefinitionProcessor', () => {
-  let defs: fhirdefs.FHIRDefinitions;
+  let defs: FHIRDefinitions;
   let config: fshtypes.Configuration;
 
   beforeAll(() => {

--- a/test/processor/ValueSetProcessor.test.ts
+++ b/test/processor/ValueSetProcessor.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import fs from 'fs-extra';
-import { fshtypes, fhirdefs } from 'fsh-sushi';
+import { fshtypes } from 'fsh-sushi';
 import { ValueSetProcessor } from '../../src/processor';
 import {
   ExportableCaretValueRule,
@@ -8,12 +8,13 @@ import {
   ExportableValueSet,
   ExportableValueSetConceptComponentRule
 } from '../../src/exportable';
+import { FHIRDefinitions } from '../../src/utils';
 import { loadTestDefinitions } from '../helpers/loadTestDefinitions';
 import { loggerSpy } from '../helpers/loggerSpy';
 const { FshCode } = fshtypes;
 
 describe('ValueSetProcessor', () => {
-  let defs: fhirdefs.FHIRDefinitions;
+  let defs: FHIRDefinitions;
   let config: fshtypes.Configuration;
 
   beforeAll(() => {

--- a/test/utils/MasterFisher.test.ts
+++ b/test/utils/MasterFisher.test.ts
@@ -1,7 +1,6 @@
-import { utils, fhirdefs } from 'fsh-sushi';
-import { FHIRDefinitions } from 'fsh-sushi/dist/fhirdefs';
+import { utils } from 'fsh-sushi';
 import { LakeOfFHIR } from '../../src/processor';
-import { MasterFisher } from '../../src/utils';
+import { FHIRDefinitions, MasterFisher } from '../../src/utils';
 
 const RESOURCE_A_FHIR = { resourceType: 'TypeA', id: 'resource-a', name: 'ResourceA' };
 const RESOURCE_A_METADATA = { id: 'resource-a', name: 'ResourceA' };
@@ -10,7 +9,7 @@ const RESOURCE_B_METADATA = { id: 'resource-b', name: 'ResourceB' };
 
 describe('MasterFisher', () => {
   let lake: LakeOfFHIR;
-  let fhir: fhirdefs.FHIRDefinitions;
+  let fhir: FHIRDefinitions;
   let fisher: MasterFisher;
 
   beforeAll(() => {

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -28,18 +28,20 @@ import {
 } from '../../src/exportable';
 import * as loadOptimizers from '../../src/optimizer/loadOptimizers';
 
+let loadedPackages: string[] = [];
+
 jest.mock('fhir-package-loader', () => {
   const original = jest.requireActual('fhir-package-loader');
   const newStyle = {
     ...original,
-    loadDependency: jest.fn(async (packageName: string, version: string, FHIRDefs: any) => {
+    mergeDependency: jest.fn(async (packageName: string, version: string, FHIRDefs: any) => {
       // the mock loader can find hl7.fhir.r4.core, hl7.fhir.r4b.core, and hl7.fhir.us.core
       if (
         packageName === 'hl7.fhir.r4.core' ||
         packageName === 'hl7.fhir.us.core' ||
         packageName === 'hl7.fhir.r4b.core'
       ) {
-        FHIRDefs.packages.push(`${packageName}#${version}`);
+        loadedPackages.push(`${packageName}#${version}`);
         return Promise.resolve(FHIRDefs);
       } else {
         throw new Error();
@@ -522,6 +524,7 @@ describe('Processing', () => {
   describe('loadExternalDependencies', () => {
     beforeEach(() => {
       loggerSpy.reset();
+      loadedPackages = [];
     });
 
     it('should load specified dependencies', () => {
@@ -529,9 +532,9 @@ describe('Processing', () => {
       const dependencies = ['hl7.fhir.us.core@3.1.0'];
       const dependencyDefs = loadExternalDependencies(defs, dependencies);
       return Promise.all(dependencyDefs).then(() => {
-        expect(defs.packages).toHaveLength(2);
-        expect(defs.packages).toContain('hl7.fhir.r4.core#4.0.1');
-        expect(defs.packages).toContain('hl7.fhir.us.core#3.1.0');
+        expect(loadedPackages).toHaveLength(2);
+        expect(loadedPackages).toContain('hl7.fhir.r4.core#4.0.1');
+        expect(loadedPackages).toContain('hl7.fhir.us.core#3.1.0');
         expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
       });
     });
@@ -541,8 +544,8 @@ describe('Processing', () => {
       const badDependencies = ['hl7.does.not.exist@current'];
       const dependencyDefs = loadExternalDependencies(defs, badDependencies);
       return Promise.all(dependencyDefs).then(() => {
-        expect(defs.packages).toHaveLength(1);
-        expect(defs.packages).toContain('hl7.fhir.r4.core#4.0.1');
+        expect(loadedPackages).toHaveLength(1);
+        expect(loadedPackages).toContain('hl7.fhir.r4.core#4.0.1');
         expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
         expect(loggerSpy.getLastMessage('error')).toMatch(
           /Failed to load hl7\.does\.not\.exist@current/s
@@ -555,8 +558,8 @@ describe('Processing', () => {
       const badDependencies = ['hl7.fhir.us.core']; // No version
       const dependencyDefs = loadExternalDependencies(defs, badDependencies);
       return Promise.all(dependencyDefs).then(() => {
-        expect(defs.packages).toHaveLength(1);
-        expect(defs.packages).toContain('hl7.fhir.r4.core#4.0.1');
+        expect(loadedPackages).toHaveLength(1);
+        expect(loadedPackages).toContain('hl7.fhir.r4.core#4.0.1');
         expect(loggerSpy.getAllMessages('error')).toHaveLength(1);
         expect(loggerSpy.getLastMessage('error')).toMatch(
           /Failed to load hl7\.fhir\.us\.core: No version specified\./s
@@ -569,8 +572,8 @@ describe('Processing', () => {
       // No dependencies specified on CLI will pass in undefined
       const dependencyDefs = loadExternalDependencies(defs, undefined);
       return Promise.all(dependencyDefs).then(() => {
-        expect(defs.packages).toHaveLength(1);
-        expect(defs.packages).toContain('hl7.fhir.r4.core#4.0.1');
+        expect(loadedPackages).toHaveLength(1);
+        expect(loadedPackages).toContain('hl7.fhir.r4.core#4.0.1');
         expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
       });
     });

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -579,12 +579,12 @@ describe('Processing', () => {
     });
 
     it('should load FHIR R4B if specified', () => {
-      const defs = new fhirdefs.FHIRDefinitions();
+      const defs = new FHIRDefinitions();
       const dependencies = ['hl7.fhir.r4b.core@4.3.0-snapshot1'];
       const dependencyDefs = loadExternalDependencies(defs, dependencies);
       return Promise.all(dependencyDefs).then(() => {
-        expect(defs.packages).toHaveLength(1);
-        expect(defs.packages).toContain('hl7.fhir.r4b.core#4.3.0-snapshot1'); // Only contains r4b, doesn't load r4
+        expect(loadedPackages).toHaveLength(1);
+        expect(loadedPackages).toContain('hl7.fhir.r4b.core#4.3.0-snapshot1'); // Only contains r4b, doesn't load r4
         expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
       });
     });

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -28,30 +28,23 @@ import {
 } from '../../src/exportable';
 import * as loadOptimizers from '../../src/optimizer/loadOptimizers';
 
-jest.mock('fsh-sushi', () => {
-  const original = jest.requireActual('fsh-sushi');
+jest.mock('fhir-package-loader', () => {
+  const original = jest.requireActual('fhir-package-loader');
   const newStyle = {
     ...original,
-    fhirdefs: {
-      ...original.fhirdefs
-    }
-  };
-  newStyle.fhirdefs.loadDependency = async (
-    packageName: string,
-    version: string,
-    FHIRDefs: any
-  ) => {
-    // the mock loader can find hl7.fhir.r4.core, hl7.fhir.r4b.core, and hl7.fhir.us.core
-    if (
-      packageName === 'hl7.fhir.r4.core' ||
-      packageName === 'hl7.fhir.us.core' ||
-      packageName === 'hl7.fhir.r4b.core'
-    ) {
-      FHIRDefs.packages.push(`${packageName}#${version}`);
-      return Promise.resolve(FHIRDefs);
-    } else {
-      throw new Error();
-    }
+    loadDependency: jest.fn(async (packageName: string, version: string, FHIRDefs: any) => {
+      // the mock loader can find hl7.fhir.r4.core, hl7.fhir.r4b.core, and hl7.fhir.us.core
+      if (
+        packageName === 'hl7.fhir.r4.core' ||
+        packageName === 'hl7.fhir.us.core' ||
+        packageName === 'hl7.fhir.r4b.core'
+      ) {
+        FHIRDefs.packages.push(`${packageName}#${version}`);
+        return Promise.resolve(FHIRDefs);
+      } else {
+        throw new Error();
+      }
+    })
   };
   return newStyle;
 });

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -3,7 +3,6 @@ import path from 'path';
 import temp from 'temp';
 import { Fhir } from 'fhir/fhir';
 import readlineSync from 'readline-sync';
-import { fhirdefs } from 'fsh-sushi';
 import { loggerSpy } from '../helpers/loggerSpy';
 import {
   determineCorePackageId,
@@ -26,6 +25,7 @@ import {
   ExportableProfile,
   ExportableAssignmentRule
 } from '../../src/exportable';
+import { FHIRDefinitions } from '../../src/utils';
 import * as loadOptimizers from '../../src/optimizer/loadOptimizers';
 
 let loadedPackages: string[] = [];
@@ -528,7 +528,7 @@ describe('Processing', () => {
     });
 
     it('should load specified dependencies', () => {
-      const defs = new fhirdefs.FHIRDefinitions();
+      const defs = new FHIRDefinitions();
       const dependencies = ['hl7.fhir.us.core@3.1.0'];
       const dependencyDefs = loadExternalDependencies(defs, dependencies);
       return Promise.all(dependencyDefs).then(() => {
@@ -540,7 +540,7 @@ describe('Processing', () => {
     });
 
     it('should log an error when it fails to load a dependency', () => {
-      const defs = new fhirdefs.FHIRDefinitions();
+      const defs = new FHIRDefinitions();
       const badDependencies = ['hl7.does.not.exist@current'];
       const dependencyDefs = loadExternalDependencies(defs, badDependencies);
       return Promise.all(dependencyDefs).then(() => {
@@ -554,7 +554,7 @@ describe('Processing', () => {
     });
 
     it('should log an error when a dependency has no specified version', () => {
-      const defs = new fhirdefs.FHIRDefinitions();
+      const defs = new FHIRDefinitions();
       const badDependencies = ['hl7.fhir.us.core']; // No version
       const dependencyDefs = loadExternalDependencies(defs, badDependencies);
       return Promise.all(dependencyDefs).then(() => {
@@ -568,7 +568,7 @@ describe('Processing', () => {
     });
 
     it('should load only FHIR if no dependencies specified', () => {
-      const defs = new fhirdefs.FHIRDefinitions();
+      const defs = new FHIRDefinitions();
       // No dependencies specified on CLI will pass in undefined
       const dependencyDefs = loadExternalDependencies(defs, undefined);
       return Promise.all(dependencyDefs).then(() => {

--- a/test/utils/element.test.ts
+++ b/test/utils/element.test.ts
@@ -1,8 +1,9 @@
 import path from 'path';
 import fs from 'fs-extra';
-import { fhirtypes, fhirdefs, fshtypes } from 'fsh-sushi';
+import { fhirtypes, fshtypes } from 'fsh-sushi';
 import { cloneDeep } from 'lodash';
 import {
+  FHIRDefinitions,
   getFSHValue,
   getPath,
   getPathValuePairs,
@@ -15,7 +16,7 @@ import { ProcessableElementDefinition, ProcessableStructureDefinition } from '..
 import { loadTestDefinitions } from '../helpers/loadTestDefinitions';
 
 describe('element', () => {
-  let defs: fhirdefs.FHIRDefinitions;
+  let defs: FHIRDefinitions;
 
   beforeAll(() => {
     defs = loadTestDefinitions();
@@ -244,7 +245,7 @@ describe('element', () => {
   });
 
   describe('#getAncestorSliceDefinition', () => {
-    let defs: fhirdefs.FHIRDefinitions;
+    let defs: FHIRDefinitions;
     let parentJson: any;
     let childJson: any;
 


### PR DESCRIPTION
This PR integrates FPL with GoFSH. The only changes here are to use FPL's `mergeDependency` function instead of the old one from SUSHI and update how the tests load packages and track which packages are loaded similar to how SUSHI's test work now.

This PR requires the updated version of SUSHI ~because it contains the updated `FHIRDefinitions` class~. You can test this PR by locally linking the `separate-package-loading` SUSHI branch on this branch. Until the next SUSHI version is released, I don't think this can be fully updated for the checks to pass here, so I've left this as a draft PR for now, but it can/should still be reviewed now.

Edit: This PR still requires the updated version of SUSHI (3.x), but it is because of how the `Type` enum changed. [846ef42](https://github.com/FHIR/GoFSH/pull/181/commits/846ef42976acd4078213f6839a5047ba6b22078e) updates to use FPL's `FHIRDefinitions` class and implements its own `fishForMetadata` method, but there are still places in SUSHI where functions are called using SUSHI's version of `Type` but GoFSH (and FPL) are expecting the updated `Type` values. Therefore, this PR needs to have a SUSHI version who has the same version of the `Type` enum as GoFSH and FPL. This can still be tested locally by linking an updated version of SUSHI here, but it shouldn't be merged until we can update the branch's version of SUSHI.