### PR TITLE
Re-introducing support for running GoFSH without arguments

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -136,7 +136,7 @@ async function app() {
   if (programOptions.out) {
     logger.info(`  --out ${path.resolve(programOptions.out)}`);
   }
-  logger.info(`  ${path.resolve(inDir)}`);
+  logger.info(`  ${path.resolve(inDir || '.')}`);
 
   inDir = getInputDir(inDir);
 


### PR DESCRIPTION
Fixes #192, allowing GoFSH to be run without any arguments with the current working directory assumed. 

To test, remove your globally install `gofsh` package, run `npm pack` on this branch, globally install the generated `.tgz` file, and then run `gofsh` from a FHIR package with no arguments. GoFSH should assume an input directory of `.` and run successfully.

