### PR TITLE
Update logging statements to include more information

### DIFF
--- a/src/extractor/AddElementRuleExtractor.ts
+++ b/src/extractor/AddElementRuleExtractor.ts
@@ -1,12 +1,15 @@
 import { isEmpty } from 'lodash';
-import { ProcessableElementDefinition } from '../processor';
+import { ProcessableElementDefinition, ProcessableStructureDefinition } from '../processor';
 import { ExportableAddElementRule } from '../exportable';
 import { getPath, logger } from '../utils';
 import { FlagRuleExtractor } from '.';
 import { OnlyRuleExtractor } from './OnlyRuleExtractor';
 
 export class AddElementRuleExtractor {
-  static process(input: ProcessableElementDefinition): ExportableAddElementRule {
+  static process(
+    input: ProcessableElementDefinition,
+    structDef: ProcessableStructureDefinition
+  ): ExportableAddElementRule {
     const addElementRule = new ExportableAddElementRule(getPath(input));
     // we always have cardinality
     // don't use CardRuleExtractor here, since that has extra logic
@@ -19,7 +22,9 @@ export class AddElementRuleExtractor {
     // if types were missing, default to BackboneElement
     if (isEmpty(addElementRule.types)) {
       addElementRule.types = [{ type: 'BackboneElement' }];
-      logger.warn(`No types found for element ${input.id}. Defaulting to BackboneElement.`);
+      logger.warn(
+        `No types found for element ${input.id} in ${structDef.name}. Defaulting to BackboneElement.`
+      );
     }
     // we might have flags, so use FlagRuleExtractor
     const flagRule = FlagRuleExtractor.process(input);

--- a/src/extractor/ContainsRuleExtractor.ts
+++ b/src/extractor/ContainsRuleExtractor.ts
@@ -18,9 +18,10 @@ export class ContainsRuleExtractor {
     const sliceNameFromId = input.id.match(/[:/]([^:/]+)$/)?.[1];
     if (sliceNameFromId !== input.sliceName) {
       logger.error(
-        `Element sliceName "${input.sliceName}" is not correctly used to populate id "${input.id}" according to ` +
-          'the algorithm specified here: https://www.hl7.org/fhir/elementdefinition.html#id. ' +
-          'The value implied by the id will be used.'
+        `The StructureDefinition ${structDef.name} has an element where the id (${input.id}) does not contain ` +
+          `the sliceName (${input.sliceName}). The id should contain the sliceName, as specified here: ` +
+          `https://www.hl7.org/fhir/elementdefinition.html#id. The sliceName "${sliceNameFromId}" (as implied ` +
+          'by the id) will be used.'
       );
     }
     const rulePath = elementPath.replace(RegExp(`\\[${sliceNameFromId}\\]$`), '');

--- a/src/extractor/ValueSetFilterComponentRuleExtractor.ts
+++ b/src/extractor/ValueSetFilterComponentRuleExtractor.ts
@@ -56,7 +56,9 @@ export class ValueSetFilterComponentRuleExtractor {
           default:
             // unknown operator type; default to a string value
             value = f.value;
-            logger.error(`Unsupported filter operator in ValueSet ${valueSet.id}: ${f.op}`);
+            logger.error(
+              `Unsupported filter operator in ValueSet ${valueSet.name ?? valueSet.id}: ${f.op}`
+            );
         }
         return {
           property: f.property,

--- a/src/optimizer/plugins/RemoveExtensionURLAssignmentRules.ts
+++ b/src/optimizer/plugins/RemoveExtensionURLAssignmentRules.ts
@@ -43,8 +43,9 @@ export default {
                 }
               } else if (urlRule.value !== item.name) {
                 logger.error(
-                  `${sd.name}: Inline extension at "${rule.path}[${item.name}]" has sliceName "${item.name}" but "${urlRule.value}" is assigned to url. ` +
-                    'SUSHI requires that these values match exactly, so the value assigned to the url will be used as the sliceName.'
+                  `${sd.name}: Inline extension at "${rule.path}[${item.name}]" has sliceName "${item.name}" but ` +
+                    `"${urlRule.value}" is assigned to url. SUSHI requires that these values match exactly, so the value assigned to the url ` +
+                    'will be used as the sliceName.'
                 );
                 // If the value set by the url rule and the sliceName do not match, prefer the value set by the url rule
                 // and replace all occurrences of the old sliceName in other rules

--- a/src/processor/Package.ts
+++ b/src/processor/Package.ts
@@ -103,9 +103,12 @@ function checkDuplicateDefinition(
   resource: NamedExportable,
   type: string
 ): boolean {
-  if (array.find(e => e.name === resource.name)) {
+  const existing = array.find(e => e.name === resource.name);
+  if (existing) {
     logger.error(
-      `Encountered ${type} with a duplicate name, ${resource.name}, which GoFSH cannot make unique. Fix the source file to resolve this error or update the resulting FSH definition.`
+      `Encountered ${type}s (id: ${existing.id} and id: ${resource.id}) with duplicate name: ` +
+        `${resource.name}. SUSHI requires named to be unique. Fix the source file for one of ` +
+        `these ${type}s to resolve this error or update the resulting FSH definition.`
     );
     return true;
   }

--- a/src/processor/StructureDefinitionProcessor.ts
+++ b/src/processor/StructureDefinitionProcessor.ts
@@ -149,7 +149,7 @@ export class StructureDefinitionProcessor {
             element.processedPaths.push('min', 'max');
           } else {
             // For all other elements, make a rule to add them.
-            const addElementRule = AddElementRuleExtractor.process(element);
+            const addElementRule = AddElementRuleExtractor.process(element, input);
             newRules.push(addElementRule);
           }
         }

--- a/src/processor/common.ts
+++ b/src/processor/common.ts
@@ -50,6 +50,7 @@ export function makeNameSushiSafe(
     | ExportableCodeSystem
 ) {
   if (/\s/.test(entity.name)) {
+    const fixedEntityName = entity.name.replace(/\s/g, '_');
     let entityType: string;
     if (entity instanceof ExportableValueSet) {
       entityType = 'ValueSet';
@@ -59,12 +60,12 @@ export function makeNameSushiSafe(
       entityType = 'StructureDefinition';
     }
     logger.warn(
-      `${entityType} with id ${entity.id} has name with whitespace. Converting whitespace to underscores.`
+      `${entityType} with id ${entity.id} has name with whitespace (${entity.name}). Converting whitespace to underscores (${fixedEntityName}).`
     );
     const nameRule = new ExportableCaretValueRule('');
     nameRule.caretPath = 'name';
     nameRule.value = entity.name;
-    entity.name = entity.name.replace(/\s/g, '_');
+    entity.name = fixedEntityName;
     entity.rules.unshift(nameRule);
   }
 }

--- a/test/extractor/AddElementRuleExtractor.test.ts
+++ b/test/extractor/AddElementRuleExtractor.test.ts
@@ -22,7 +22,7 @@ describe('AddElementRuleExtractor', () => {
   describe('#process', () => {
     it('should extract an add element rule with a cardinality and one type', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[1]);
-      const elementRule = AddElementRuleExtractor.process(element);
+      const elementRule = AddElementRuleExtractor.process(element, looseSD);
       const expectedRule = new ExportableAddElementRule('bread');
       expectedRule.min = 1;
       expectedRule.max = '1';
@@ -36,7 +36,7 @@ describe('AddElementRuleExtractor', () => {
 
     it('should extract an add element rule with multiple types', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[2]);
-      const elementRule = AddElementRuleExtractor.process(element);
+      const elementRule = AddElementRuleExtractor.process(element, looseSD);
       const expectedRule = new ExportableAddElementRule('apple[x]');
       expectedRule.min = 0;
       expectedRule.max = '3';
@@ -50,7 +50,7 @@ describe('AddElementRuleExtractor', () => {
 
     it('should extract an add element rule with a reference type', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[3]);
-      const elementRule = AddElementRuleExtractor.process(element);
+      const elementRule = AddElementRuleExtractor.process(element, looseSD);
       const expectedRule = new ExportableAddElementRule('orange');
       expectedRule.min = 0;
       expectedRule.max = '1';
@@ -67,7 +67,7 @@ describe('AddElementRuleExtractor', () => {
 
     it('should extract an add element rule with a profiled type', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[4]);
-      const elementRule = AddElementRuleExtractor.process(element);
+      const elementRule = AddElementRuleExtractor.process(element, looseSD);
       const expectedRule = new ExportableAddElementRule('banana');
       expectedRule.min = 1;
       expectedRule.max = '*';
@@ -84,7 +84,7 @@ describe('AddElementRuleExtractor', () => {
     it('should extract an add element rule with the must support flag', () => {
       // SUSHI does not allow this flag on AddElementRule, but that's something for SUSHI to complain about.
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[5]);
-      const elementRule = AddElementRuleExtractor.process(element);
+      const elementRule = AddElementRuleExtractor.process(element, looseSD);
       const expectedRule = new ExportableAddElementRule('potato');
       expectedRule.min = 1;
       expectedRule.max = '3';
@@ -101,7 +101,7 @@ describe('AddElementRuleExtractor', () => {
 
     it('should extract an add element rule with the summary flag', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[6]);
-      const elementRule = AddElementRuleExtractor.process(element);
+      const elementRule = AddElementRuleExtractor.process(element, looseSD);
       const expectedRule = new ExportableAddElementRule('peppers');
       expectedRule.min = 0;
       expectedRule.max = '*';
@@ -118,7 +118,7 @@ describe('AddElementRuleExtractor', () => {
 
     it('should extract an add element rule with the modifier flag', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[7]);
-      const elementRule = AddElementRuleExtractor.process(element);
+      const elementRule = AddElementRuleExtractor.process(element, looseSD);
       const expectedRule = new ExportableAddElementRule('onions');
       expectedRule.min = 0;
       expectedRule.max = '3';
@@ -135,7 +135,7 @@ describe('AddElementRuleExtractor', () => {
 
     it('should extract an add element rule with the draft flag', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[8]);
-      const elementRule = AddElementRuleExtractor.process(element);
+      const elementRule = AddElementRuleExtractor.process(element, looseSD);
       const expectedRule = new ExportableAddElementRule('cabbage');
       expectedRule.min = 0;
       expectedRule.max = '1';
@@ -159,7 +159,7 @@ describe('AddElementRuleExtractor', () => {
 
     it('should extract an add element rule with the trial use flag', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[9]);
-      const elementRule = AddElementRuleExtractor.process(element);
+      const elementRule = AddElementRuleExtractor.process(element, looseSD);
       const expectedRule = new ExportableAddElementRule('milk');
       expectedRule.min = 0;
       expectedRule.max = '1';
@@ -183,7 +183,7 @@ describe('AddElementRuleExtractor', () => {
 
     it('should extract an add element rule with the normative flag', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[10]);
-      const elementRule = AddElementRuleExtractor.process(element);
+      const elementRule = AddElementRuleExtractor.process(element, looseSD);
       const expectedRule = new ExportableAddElementRule('coffee');
       expectedRule.min = 0;
       expectedRule.max = '2';
@@ -207,7 +207,7 @@ describe('AddElementRuleExtractor', () => {
 
     it('should extract an add element rule with multiple flags', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[11]);
-      const elementRule = AddElementRuleExtractor.process(element);
+      const elementRule = AddElementRuleExtractor.process(element, looseSD);
       const expectedRule = new ExportableAddElementRule('peanuts');
       expectedRule.min = 0;
       expectedRule.max = '*';
@@ -233,7 +233,7 @@ describe('AddElementRuleExtractor', () => {
 
     it('should extract an add element rule with definition text', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[12]);
-      const elementRule = AddElementRuleExtractor.process(element);
+      const elementRule = AddElementRuleExtractor.process(element, looseSD);
       const expectedRule = new ExportableAddElementRule('spice');
       expectedRule.min = 0;
       expectedRule.max = '*';
@@ -248,7 +248,7 @@ describe('AddElementRuleExtractor', () => {
 
     it('should extract an add element rule with multiple types, flags, and definition text', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[13]);
-      const elementRule = AddElementRuleExtractor.process(element);
+      const elementRule = AddElementRuleExtractor.process(element, looseSD);
       const expectedRule = new ExportableAddElementRule('cookies');
       expectedRule.min = 0;
       expectedRule.max = '2';
@@ -277,10 +277,10 @@ describe('AddElementRuleExtractor', () => {
         ProcessableElementDefinition.fromJSON(looseSD.differential.element[12])
       );
       delete element.type;
-      const elementRule = AddElementRuleExtractor.process(element);
+      const elementRule = AddElementRuleExtractor.process(element, looseSD);
       expect(elementRule.types).toEqual([{ type: 'BackboneElement' }]);
       expect(loggerSpy.getLastMessage('warn')).toBe(
-        'No types found for element MyResource.spice. Defaulting to BackboneElement.'
+        'No types found for element MyResource.spice in MyResource. Defaulting to BackboneElement.'
       );
     });
   });

--- a/test/extractor/ContainsRuleExtractor.test.ts
+++ b/test/extractor/ContainsRuleExtractor.test.ts
@@ -81,7 +81,7 @@ describe('ContainsRuleExtractor', () => {
     expect(containsRule).toEqual<ExportableContainsRule>(expectedRule);
     expect(element.processedPaths).toEqual(['min', 'max', 'sliceName']);
     expect(loggerSpy.getLastMessage('error')).toMatch(
-      /Element sliceName \"Plums\".*Observation.extension:Nectarines/
+      /StructureDefinition ObservationWithContains.*id \(Observation.extension:Nectarines\).*sliceName \(Plums\).*sliceName "Nectarines"/
     );
   });
 

--- a/test/extractor/ValueSetFilterComponentRuleExtractor.test.ts
+++ b/test/extractor/ValueSetFilterComponentRuleExtractor.test.ts
@@ -5,7 +5,7 @@ import { ProcessableValueSet } from '../../src/processor';
 import { loggerSpy } from '../helpers';
 
 // We need to pass this in to ever call, but it's only used when logging an error message
-const VALUESET: ProcessableValueSet = { id: 'test-vs' };
+const VALUESET: ProcessableValueSet = { name: 'TestVS', id: 'test-vs' };
 
 describe('ValueSetFilterComponentRuleExtractor', () => {
   it('should extract a filter rule that includes all codes from a system', () => {
@@ -179,7 +179,7 @@ describe('ValueSetFilterComponentRuleExtractor', () => {
     loggerSpy.reset();
     const filter = ValueSetFilterComponentRuleExtractor.process(input, VALUESET, false);
     expect(loggerSpy.getLastMessage('error')).toBe(
-      'Unsupported filter operator in ValueSet test-vs: begets'
+      'Unsupported filter operator in ValueSet TestVS: begets'
     );
     const expectedFilter = new ExportableValueSetFilterComponentRule(false);
     expectedFilter.from = { system: 'http://mycodesystem.org' };

--- a/test/processor/CodeSystemProcessor.test.ts
+++ b/test/processor/CodeSystemProcessor.test.ts
@@ -73,7 +73,7 @@ describe('CodeSystemProcessor', () => {
       expect(result.name).toBe('Simple_CodeSystem');
       expect(result.rules).toContainEqual(expectedNameRule);
       expect(loggerSpy.getLastMessage('warn')).toMatch(
-        'CodeSystem with id simple.codesystem has name with whitespace. Converting whitespace to underscores.'
+        'CodeSystem with id simple.codesystem has name with whitespace (Simple\nCodeSystem). Converting whitespace to underscores (Simple_CodeSystem).'
       );
     });
 

--- a/test/processor/Package.test.ts
+++ b/test/processor/Package.test.ts
@@ -97,7 +97,9 @@ describe('Package', () => {
 
     it('should log an error and add duplicate named exports to the corresponding arrays', () => {
       const myProfile = new ExportableProfile('MyProfile');
+      myProfile.id = 'my-profile';
       const myDupProfile = new ExportableProfile('MyProfile');
+      myDupProfile.id = 'my-other-profile';
       myPackage.add(myProfile);
       myPackage.add(myDupProfile);
       expect(myPackage.profiles).toHaveLength(2);
@@ -105,7 +107,9 @@ describe('Package', () => {
       expect(myPackage.profiles[1]).toBe(myDupProfile);
 
       const myExtension = new ExportableExtension('MyExtension');
+      myExtension.id = 'my-extension';
       const myDupExtension = new ExportableExtension('MyExtension');
+      myDupExtension.id = 'my-other-extension';
       myPackage.add(myExtension);
       myPackage.add(myDupExtension);
       expect(myPackage.extensions).toHaveLength(2);
@@ -113,7 +117,9 @@ describe('Package', () => {
       expect(myPackage.extensions[1]).toBe(myDupExtension);
 
       const myInstance = new ExportableInstance('MyInstance');
+      // (no separate id to set)
       const myDupInstance = new ExportableInstance('MyInstance');
+      // (no separate id to set)
       myPackage.add(myInstance);
       myPackage.add(myDupInstance);
       expect(myPackage.instances).toHaveLength(2);
@@ -121,7 +127,9 @@ describe('Package', () => {
       expect(myPackage.instances[1]).toBe(myDupInstance);
 
       const myValueSet = new ExportableValueSet('MyValueSet');
+      myValueSet.id = 'my-value-set';
       const myDupValueSet = new ExportableValueSet('MyValueSet');
+      myDupValueSet.id = 'my-other-value-set';
       myPackage.add(myValueSet);
       myPackage.add(myDupValueSet);
       expect(myPackage.valueSets).toHaveLength(2);
@@ -129,7 +137,9 @@ describe('Package', () => {
       expect(myPackage.valueSets[1]).toBe(myDupValueSet);
 
       const myCodeSystem = new ExportableCodeSystem('MyCodeSystem');
+      myCodeSystem.id = 'my-code-system';
       const myDupCodeSystem = new ExportableCodeSystem('MyCodeSystem');
+      myDupCodeSystem.id = 'my-other-code-system';
       myPackage.add(myCodeSystem);
       myPackage.add(myDupCodeSystem);
       expect(myPackage.codeSystems).toHaveLength(2);
@@ -137,7 +147,9 @@ describe('Package', () => {
       expect(myPackage.codeSystems[1]).toBe(myDupCodeSystem);
 
       const myInvariant = new ExportableInvariant('inv-1');
+      // (no separate id to set)
       const myDupInvariant = new ExportableInvariant('inv-1');
+      // (no separate id to set)
       myPackage.add(myInvariant);
       myPackage.add(myDupInvariant);
       expect(myPackage.invariants).toHaveLength(2);
@@ -145,7 +157,9 @@ describe('Package', () => {
       expect(myPackage.invariants[1]).toBe(myDupInvariant);
 
       const myMapping = new ExportableMapping('MyMapping');
+      // (no separate id to set)
       const myDupMapping = new ExportableMapping('MyMapping');
+      // (no separate id to set)
       myPackage.add(myMapping);
       myPackage.add(myDupMapping);
       expect(myPackage.mappings).toHaveLength(2);
@@ -154,25 +168,25 @@ describe('Package', () => {
 
       expect(loggerSpy.getAllMessages('error')).toHaveLength(7);
       expect(loggerSpy.getMessageAtIndex(0, 'error')).toMatch(
-        /Encountered profile with a duplicate name, MyProfile/
+        /Encountered profiles \(id: my-profile and id: my-other-profile\) with duplicate name: MyProfile\./
       );
       expect(loggerSpy.getMessageAtIndex(1, 'error')).toMatch(
-        /Encountered extension with a duplicate name, MyExtension/
+        /Encountered extensions \(id: my-extension and id: my-other-extension\) with duplicate name: MyExtension\./
       );
       expect(loggerSpy.getMessageAtIndex(2, 'error')).toMatch(
-        /Encountered instance with a duplicate name, MyInstance/
+        /Encountered instances \(id: MyInstance and id: MyInstance\) with duplicate name: MyInstance\./
       );
       expect(loggerSpy.getMessageAtIndex(3, 'error')).toMatch(
-        /Encountered value set with a duplicate name, MyValueSet/
+        /Encountered value sets \(id: my-value-set and id: my-other-value-set\) with duplicate name: MyValueSet\./
       );
       expect(loggerSpy.getMessageAtIndex(4, 'error')).toMatch(
-        /Encountered code system with a duplicate name, MyCodeSystem/
+        /Encountered code systems \(id: my-code-system and id: my-other-code-system\) with duplicate name: MyCodeSystem\./
       );
       expect(loggerSpy.getMessageAtIndex(5, 'error')).toMatch(
-        /Encountered invariant with a duplicate name, inv-1/
+        /Encountered invariants \(id: inv-1 and id: inv-1\) with duplicate name: inv-1\./
       );
       expect(loggerSpy.getMessageAtIndex(6, 'error')).toMatch(
-        /Encountered mapping with a duplicate name, MyMapping/
+        /Encountered mappings \(id: MyMapping and id: MyMapping\) with duplicate name: MyMapping\./
       );
     });
 

--- a/test/processor/StructureDefinitionProcessor.test.ts
+++ b/test/processor/StructureDefinitionProcessor.test.ts
@@ -229,7 +229,7 @@ describe('StructureDefinitionProcessor', () => {
       expect(result[0].name).toBe('Simple_Profile');
       expect(result[0].rules).toContainEqual(expectedNameRule);
       expect(loggerSpy.getLastMessage('warn')).toMatch(
-        'StructureDefinition with id simple.profile has name with whitespace. Converting whitespace to underscores.'
+        'StructureDefinition with id simple.profile has name with whitespace (Simple Profile). Converting whitespace to underscores (Simple_Profile).'
       );
     });
 

--- a/test/processor/ValueSetProcessor.test.ts
+++ b/test/processor/ValueSetProcessor.test.ts
@@ -61,7 +61,7 @@ describe('ValueSetProcessor', () => {
       expect(result.name).toBe('Simple_Value__Set');
       expect(result.rules).toContainEqual(expectedNameRule);
       expect(loggerSpy.getLastMessage('warn')).toMatch(
-        'ValueSet with id simple.valueset has name with whitespace. Converting whitespace to underscores.'
+        'ValueSet with id simple.valueset has name with whitespace (Simple\tValue\t\tSet). Converting whitespace to underscores (Simple_Value__Set).'
       );
     });
 


### PR DESCRIPTION
Some logging statements did not provide enough information to help the user debug the issue. Several statements have now been updated to include useful details for identifying the source of the problem being reported.

I would have liked to include filenames where possible, but the current structure of the code does not allow for that, as file names are lost pretty early in the process. Perhaps we can rework it some day, but for now, this PR should be enough of an improvement to satisfy the original request.

Fixes #197 