### PR TITLE
Add element rule may have contentReference

### DIFF
--- a/src/extractor/AddElementRuleExtractor.ts
+++ b/src/extractor/AddElementRuleExtractor.ts
@@ -18,12 +18,22 @@ export class AddElementRuleExtractor {
     addElementRule.max = input.max;
     input.processedPaths.push('min', 'max');
     // get types using OnlyRuleExtractor
-    addElementRule.types = OnlyRuleExtractor.process(input)?.types;
-    // if types were missing, default to BackboneElement
-    if (isEmpty(addElementRule.types)) {
+    addElementRule.types = OnlyRuleExtractor.process(input)?.types ?? [];
+    if (input.contentReference) {
+      if (isEmpty(addElementRule.types)) {
+        addElementRule.contentReference = input.contentReference;
+      } else {
+        logger.warn(
+          `Found types and contentReference for element ${input.id} in ${structDef.name}. The contentReference will be ignored.`
+        );
+      }
+      input.processedPaths.push('contentReference');
+    }
+    // if types and contentReference were missing, default to BackboneElement
+    if (isEmpty(addElementRule.types) && isEmpty(addElementRule.contentReference)) {
       addElementRule.types = [{ type: 'BackboneElement' }];
       logger.warn(
-        `No types found for element ${input.id} in ${structDef.name}. Defaulting to BackboneElement.`
+        `No types or contentReference found for element ${input.id} in ${structDef.name}. Defaulting to BackboneElement.`
       );
     }
     // we might have flags, so use FlagRuleExtractor

--- a/test/extractor/fixtures/add-element-resource.json
+++ b/test/extractor/fixtures/add-element-resource.json
@@ -229,6 +229,15 @@
           }
         ],
         "isSummary": true
+      },
+      {
+        "id": "MyResource.moreCookies",
+        "path": "MyResource.moreCookies",
+        "short": "Additional cookie information",
+        "definition": "Sometimes you need many more cookies",
+        "min": 0,
+        "max": "*",
+        "contentReference": "cookies"
       }
     ]
   }


### PR DESCRIPTION
Completes task [CIMPL-1018](https://standardhealthrecord.atlassian.net/browse/CIMPL-1018).

An ElementDefinition may have no types and have a contentReference instead. In this case, set the rule's contentReference and do not emit a warning. If the ElementDefinition has at least one type and also has a contentReference, however, that is not a valid ElementDefinition. In this case, emit a warning and ignore the contentReference.