### PR TITLE
v1.6.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gofsh",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1894,10 +1894,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001291",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001291.tgz",
-      "integrity": "sha512-roMV5V0HNGgJ88s42eE70sstqGW/gwFndosYrikHthw98N5tLnOTxFqMLQjZVRxTWFlJ4rn+MsgXrR7MDPY4jA==",
-      "dev": true
+      "version": "1.0.30001425",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001425.tgz",
+      "integrity": "sha512-/pzFv0OmNG6W0ym80P3NtapU0QEiDS3VuYAZMGoLLqiC7f6FJFe1MjpQDREGApeenD9wloeytmVDj+JLXPC6qw=="
     },
     "chalk": {
       "version": "4.1.0",
@@ -5189,11 +5188,6 @@
             "map-obj": "^4.0.0",
             "quick-lru": "^4.0.1"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001291",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001291.tgz",
-          "integrity": "sha512-roMV5V0HNGgJ88s42eE70sstqGW/gwFndosYrikHthw98N5tLnOTxFqMLQjZVRxTWFlJ4rn+MsgXrR7MDPY4jA=="
         },
         "chalk": {
           "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1816,9 +1816,9 @@
       }
     },
     "balanced-match": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -2026,7 +2026,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "convert-source-map": {
       "version": "1.8.0",
@@ -9253,8 +9253,7 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "resolved": "",
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -11945,9 +11944,9 @@
       "dev": true
     },
     "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2829,9 +2829,9 @@
       "optional": true
     },
     "fsh-sushi": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-2.6.1.tgz",
-      "integrity": "sha512-YCyoBaOjmeJ6y7XCjbz+8Dpf14ZzxS/hTtyIFO+uhunIIiV9ynnqmXG75FtcAS8GEof3kL9zTUD/QKVAZWYcjA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-2.7.0.tgz",
+      "integrity": "sha512-HdPwPbuECUm+4zk3GgN4SnXfl1X8gXD8HMi6ZGa+ClumkZUR5FELM/e5vVXIgP/9sb3v06Xtp+KfMJw3L9Ru0g==",
       "requires": {
         "antlr4": "~4.8.0",
         "axios": "^0.21.4",
@@ -9253,7 +9253,8 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
             "brace-expansion": "^1.1.7"
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gofsh",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "GoFSH is a FHIR Shorthand (FSH) decompiler, able to convert formal FHIR definitions from JSON to FSH.",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "fhir": "^4.10.0",
     "flat": "^5.0.2",
     "fs-extra": "^9.0.1",
-    "fsh-sushi": "^2.6.1",
+    "fsh-sushi": "^2.7.0",
     "ini": "^1.3.8",
     "lodash": "^4.17.21",
     "readline-sync": "^1.4.10",


### PR DESCRIPTION
* Fix most reported vulnerabilities from npm audit (one was not able to be resolved)
* Upgrade the caniuselite browser list (as prompted when running tests)
* Upgrade SUSHI to 2.7.0
* Bump version number to 1.6.3