### PR TITLE
Resolve contentReference when getting types

### DIFF
--- a/src/optimizer/utils.ts
+++ b/src/optimizer/utils.ts
@@ -165,7 +165,9 @@ function getTypesForPath(
     // NOTE: Normalize the path to remove indices and/or slice references
     const element = instanceOfSD.findElementByPath(path.replace(/\[[^\]]+\]/g, ''), fisher);
     if (element?.contentReference) {
-      return instanceOfSD.findElement(element.contentReference.slice(1))?.type;
+      return instanceOfSD.findElement(
+        element.contentReference.slice(element.contentReference.indexOf('#') + 1)
+      )?.type;
     } else {
       return element?.type;
     }

--- a/src/optimizer/utils.ts
+++ b/src/optimizer/utils.ts
@@ -164,6 +164,10 @@ function getTypesForPath(
     const instanceOfSD = fhirtypes.StructureDefinition.fromJSON(instanceOfDef);
     // NOTE: Normalize the path to remove indices and/or slice references
     const element = instanceOfSD.findElementByPath(path.replace(/\[[^\]]+\]/g, ''), fisher);
-    return element?.type;
+    if (element?.contentReference) {
+      return instanceOfSD.findElement(element.contentReference.slice(1))?.type;
+    } else {
+      return element?.type;
+    }
   }
 }

--- a/test/optimizer/plugins/CombineCodingAndQuantityValuesOptimizer.test.ts
+++ b/test/optimizer/plugins/CombineCodingAndQuantityValuesOptimizer.test.ts
@@ -233,6 +233,26 @@ describe('optimizer', () => {
         expect(valueSet.rules[1]).toEqual(expectedDisplayRule);
       });
 
+      it('should not combine rules on code and system for ValueSet.expansion.contains.contains', () => {
+        const valueSet = new ExportableValueSet('ValueSet');
+        const codeRule = new ExportableCaretValueRule('');
+        codeRule.caretPath = 'expansion.contains[0].contains[0].code';
+        codeRule.value = new FshCode('gooseberry');
+        const systemRule = new ExportableCaretValueRule('');
+        systemRule.caretPath = 'expansion.contains[0].contains[0].system';
+        systemRule.value = 'https://fruit.net/CodeSystems/FruitCS';
+        valueSet.rules.push(codeRule, systemRule);
+        const myPackage = new Package();
+        myPackage.add(valueSet);
+
+        const expectedCodeRule = cloneDeep(codeRule);
+        const expectedSystemRule = cloneDeep(systemRule);
+        optimizer.optimize(myPackage, fisher);
+        expect(valueSet.rules.length).toBe(2);
+        expect(valueSet.rules[0]).toEqual(expectedCodeRule);
+        expect(valueSet.rules[1]).toEqual(expectedSystemRule);
+      });
+
       it('should combine rules on code and unit into a single rule', () => {
         const extension = new ExportableExtension('MyExtension');
         const codeRule = new ExportableCaretValueRule('');


### PR DESCRIPTION
Fixes #204 and completes task [CIMPL-1048](https://standardhealthrecord.atlassian.net/browse/CIMPL-1048).

CombineCodingAndQuantityValuesOptimizer has a set list of types for which it will optimize rules. Resolve contentReference on elements to more accurately determine the type of the element at the rule's path.

Previously, since contentReference wasn't resolved, any element with a contentReference (and therefore no type) on a non-Instance would get optimized. This is why, on a ValueSet, `expansion.contains` would not get optimized (since it has a type), but the deeper versions like `expansion.contains.contains` would get optimized (since they have a contentReference to `expansion.contains`).