### PR TITLE
Update PathRule optimization

### DIFF
--- a/src/optimizer/plugins/AddPathRulesOptimizer.ts
+++ b/src/optimizer/plugins/AddPathRulesOptimizer.ts
@@ -21,7 +21,7 @@ type AllowedRule =
 
 type PathNode = {
   path: string;
-  rule: AllowedRule[];
+  rules: AllowedRule[];
   children: PathNode[];
 };
 
@@ -38,7 +38,7 @@ function buildPathTree(parent: PathNode, rule: AllowedRule) {
     currentPathNode = parent.children.find(child => child.path === currentPath);
     if (currentPathNode == null) {
       // If this path hasn't been seen, create a node for it in the tree
-      const newNode: PathNode = { path: currentPath, children: [], rule: [] };
+      const newNode: PathNode = { path: currentPath, children: [], rules: [] };
       parent.children.push(newNode);
       currentPathNode = newNode;
     }
@@ -47,7 +47,7 @@ function buildPathTree(parent: PathNode, rule: AllowedRule) {
   });
   // After building the tree, add the rule in at the current node
   // since the last node will be the full rule path
-  currentPathNode.rule = currentPathNode.rule.concat(rule);
+  currentPathNode.rules = currentPathNode.rules.concat(rule);
 }
 
 // Build the list of rules that will create optimal context.
@@ -56,18 +56,18 @@ function createAndOrganizeRules(pathNodes: PathNode[], rules: AllowedRule[]) {
     if (node.children.length > 1) {
       // There are at least 2 children. Create a path rule if necessary,
       // otherwise just include the rule at that path.
-      if (node.rule.length === 0) {
+      if (node.rules.length === 0) {
         rules.push(new ExportablePathRule(node.path));
       } else {
-        rules.push(...node.rule);
+        rules.push(...node.rules);
       }
       // Continue processing all child nodes
       createAndOrganizeRules(node.children, rules);
     } else {
       // If there are 0 or 1 rules at the path, we don't need to create a path rule,
       // but we do need to include the rule if there is one at that path.
-      if (node.rule != null) {
-        rules.push(...node.rule);
+      if (node.rules.length > 0) {
+        rules.push(...node.rules);
       }
       // If this path has a child, continue processing the child node.
       if (node.children.length > 0) {
@@ -93,7 +93,7 @@ export default {
     ].forEach(entity => {
       const root: PathNode = {
         path: '',
-        rule: [],
+        rules: [],
         children: []
       };
 

--- a/src/optimizer/plugins/AddPathRulesOptimizer.ts
+++ b/src/optimizer/plugins/AddPathRulesOptimizer.ts
@@ -53,27 +53,12 @@ function buildPathTree(parent: PathNode, rule: AllowedRule) {
 // Build the list of rules that will create optimal context.
 function createAndOrganizeRules(pathNodes: PathNode[], rules: AllowedRule[]) {
   pathNodes?.forEach(node => {
-    if (node.children.length > 1) {
-      // There are at least 2 children. Create a path rule if necessary,
-      // otherwise just include the rule at that path.
-      if (node.rules.length === 0) {
-        rules.push(new ExportablePathRule(node.path));
-      } else {
-        rules.push(...node.rules);
-      }
-      // Continue processing all child nodes
-      createAndOrganizeRules(node.children, rules);
-    } else {
-      // If there are 0 or 1 rules at the path, we don't need to create a path rule,
-      // but we do need to include the rule if there is one at that path.
-      if (node.rules.length > 0) {
-        rules.push(...node.rules);
-      }
-      // If this path has a child, continue processing the child node.
-      if (node.children.length > 0) {
-        createAndOrganizeRules(node.children, rules);
-      }
+    rules.push(...node.rules);
+    if (node.children.length > 1 && node.rules.length === 0) {
+      // There are at least 2 children and no parent rule. Push a path rule.
+      rules.push(new ExportablePathRule(node.path));
     }
+    createAndOrganizeRules(node.children, rules);
   });
 }
 

--- a/src/optimizer/plugins/AddPathRulesOptimizer.ts
+++ b/src/optimizer/plugins/AddPathRulesOptimizer.ts
@@ -51,6 +51,11 @@ export default {
             // Increment i so it still references the right item (since we spliced something in)
             i++;
             break; // We only want to pull out one ancestor
+          } else if (seenPathList.some(l => ancestorPath.includes(l))) {
+            // Otherwise, if a path rule that has already been added is a more specific path than
+            // the current ancestor path, then stop. This prevents us from adding a path for
+            // meta.extension and later a path for meta.
+            break;
           }
         }
       }

--- a/src/optimizer/plugins/SimplifyRulePathContextsOptimizer.ts
+++ b/src/optimizer/plugins/SimplifyRulePathContextsOptimizer.ts
@@ -101,8 +101,8 @@ export default {
               .join('.');
             // if the rule has any path left after that, push its full path onto the pathContext list
             if (newPath.length) {
-              // change soft-index marker because a matching path should use [=]
-              pathContext.push(rule.path.replace(/\[\+\]/g, '[=]'));
+              // change soft-index or zero-index (because we keep [0] indexes as is) marker because a matching path should use [=]
+              pathContext.push(rule.path.replace(/\[(\+|0)\]/g, '[=]'));
             }
             // assign the new path to the rule
             rule.path = newPath;
@@ -113,7 +113,8 @@ export default {
             pathContext.splice(0);
             // change soft-index marker because a matching path should use [=]
             if (rule.path.length > 0) {
-              pathContext.push(rule.path.replace(/\[\+\]/g, '[=]'));
+              // change soft-index or zero-index (because we keep [0] indexes as is) marker because a matching path should use [=]
+              pathContext.push(rule.path.replace(/\[(\+|0)\]/g, '[=]'));
             }
           }
         });

--- a/test/optimizer/plugins/AddPathRulesOptimizer.test.ts
+++ b/test/optimizer/plugins/AddPathRulesOptimizer.test.ts
@@ -532,11 +532,11 @@ describe('optimizer', () => {
       // Profile: MultipleRulesPerPathObs
       // Parent: Observation
       // * category 1..1 MS
-      // * category only CodeableConcept
       // * category.coding 1..* MS
-      // * category.coding only Coding
       // * category.coding.system 1..1 MS
       // * category.coding.system only uri
+      // * category.coding only Coding
+      // * category only CodeableConcept
       const profile = new ExportableProfile('MultipleRulesPerPathObs');
       profile.parent = 'Observation';
       const categoryCard = new ExportableCardRule('category');

--- a/test/optimizer/plugins/SimplifyArrayIndexingOptimizer.test.ts
+++ b/test/optimizer/plugins/SimplifyArrayIndexingOptimizer.test.ts
@@ -69,10 +69,10 @@ describe('optimizer', () => {
       nameRule1.value = 'John';
 
       const nameRule2 = new ExportableAssignmentRule('name[0].family');
-      nameRule1.value = 'Doe';
+      nameRule2.value = 'Doe';
 
       const nameRule3 = new ExportableAssignmentRule('name[5].given[0]');
-      nameRule2.value = 'James';
+      nameRule3.value = 'James';
 
       instance.rules.push(nameRule1, nameRule2, nameRule3);
       const myPackage = new Package();


### PR DESCRIPTION
Fixes #208.

This PR updates how path rules are calculated in order to better determine when they are needed. This fixes the issue reported in #208. The problem in the reported issue was due to a path with multiple parts that didn't exactly match the previous rule, but did partially match the rule, so a path rule for the first part of the path was added incorrectly.

The `AddPathRuleOptimizer` does a bit more than just add path rules now due to the new implementation. It adds path rules as necessary, but it also reorders rules so that if an Assignment Rule or other type of rule can be used to set context (when we simplify the paths later), that rule is used first and no path rule is needed. It might be worth updating the name of the optimizer, but I wasn't sure so I haven't done that yet.

The refactor not only fixes the problem in the #208, but it also fixes some other issues that seem to have been introduced recently. I tested this branch by running a round trip on US Core. The comparison generated has some differences, so I also compared the `fsh-generated` folder from a round trip on this branch with a round trip on `master` and GoFSH `v1.6.3` (the latest published version). There are a few issues in the round trip on `master` that are resolved in this branch. If anyone reviewing this would like more details on what I compared, let me know.