### PR TITLE
v1.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gofsh",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gofsh",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "GoFSH is a FHIR Shorthand (FSH) decompiler, able to convert formal FHIR definitions from JSON to FSH.",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Updates the version to `1.6.4`. `npm audit` shows no new updates are needed and SUSHI was updated when we tried to release last time.