### PR TITLE
Support for extensions on primitives (such as type._targetProfile.extension)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2829,9 +2829,9 @@
       "optional": true
     },
     "fsh-sushi": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-2.8.0.tgz",
-      "integrity": "sha512-LEBsTD3Z2C0+Q9qhuGsXUt/j9phBtv9IkLHcZYY89ocJi4LaAnHQLsbp0SrdD54GmR6aOMvj6zTZHL3fQcKx/g==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-2.10.0.tgz",
+      "integrity": "sha512-k5EDZVGAnEQnKVt/WJquomIwg/RFnDR6sj63Q8kEubpVKMg6/Wd7H3putfUMyKbgHEWjkB72IsduBJ70p+xUEg==",
       "requires": {
         "antlr4": "~4.8.0",
         "axios": "^0.21.4",
@@ -9033,6 +9033,11 @@
           "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
           "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
         },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+        },
         "json5": {
           "version": "2.2.3",
           "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -9330,6 +9335,17 @@
           "requires": {
             "lower-case": "^2.0.2",
             "tslib": "^2.0.3"
+          }
+        },
+        "nock": {
+          "version": "13.3.0",
+          "resolved": "https://registry.npmjs.org/nock/-/nock-13.3.0.tgz",
+          "integrity": "sha512-HHqYQ6mBeiMc+N038w8LkMpDCRquCHWeNmN3v6645P3NhN2+qXOBqvPqo7Rt1VyCMzKhJ733wZqw5B7cQVFNPg==",
+          "requires": {
+            "debug": "^4.1.0",
+            "json-stringify-safe": "^5.0.1",
+            "lodash": "^4.17.21",
+            "propagate": "^2.0.0"
           }
         },
         "node-fetch": {
@@ -9661,6 +9677,11 @@
             "kleur": "^3.0.3",
             "sisteransi": "^1.0.5"
           }
+        },
+        "propagate": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+          "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag=="
         },
         "psl": {
           "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "rm -rf dist && tsc && copyfiles -u 2 \"src/utils/template.html\" dist/utils",
     "check": "npm run test && npm run lint && npm run prettier",
-    "test": "jest --maxWorkers=4 --coverage",
+    "test": "jest --coverage",
     "test:watch": "npm run test -- --watchAll",
     "coverage": "opener coverage/lcov-report/index.html",
     "lint": "tsc && eslint \"**/*.{js,ts}\"",
@@ -71,7 +71,7 @@
     "fhir": "^4.10.0",
     "flat": "^5.0.2",
     "fs-extra": "^9.0.1",
-    "fsh-sushi": "^2.8.0",
+    "fsh-sushi": "^2.10.0",
     "ini": "^1.3.8",
     "lodash": "^4.17.21",
     "readline-sync": "^1.4.10",

--- a/src/exportable/common.ts
+++ b/src/exportable/common.ts
@@ -7,11 +7,3 @@ export function fshifyString(input: string): string {
     .replace(/\r/g, '\\r')
     .replace(/\t/g, '\\t');
 }
-
-// Removes the underscore on paths of children of primitive elements
-export function removeUnderscoreForPrimitiveChildPath(input: string): string {
-  return input
-    .split('.')
-    .map(p => p.replace(/^_/, ''))
-    .join('.');
-}

--- a/src/optimizer/plugins/SimplifyInstanceNameOptimizer.ts
+++ b/src/optimizer/plugins/SimplifyInstanceNameOptimizer.ts
@@ -1,6 +1,6 @@
 import { OptimizerPlugin } from '../OptimizerPlugin';
 import { Package } from '../../processor';
-import { ExportableAssignmentRule } from '../../exportable';
+import { ExportableAssignmentRule, ExportableCaretValueRule } from '../../exportable';
 import ResolveInstanceOfURLsOptimizer from './ResolveInstanceOfURLsOptimizer';
 
 export default {
@@ -10,25 +10,40 @@ export default {
   runAfter: [ResolveInstanceOfURLsOptimizer.name],
 
   optimize(pkg: Package): void {
-    pkg.instances
-      .filter(i => i.usage !== 'Inline')
-      .forEach((instance, index) => {
-        if (!pkg.instances.find((m, i) => m.id === instance.id && i !== index)) {
-          // If the instance does not have the same id as any other instance, it is safe to
-          // use the id as the name and remove the InstanceOf information from the name
-          instance.name = instance.id;
-        } else if (!instance.name.endsWith(instance.instanceOf)) {
-          // If the instance name isn't simplified, the InstanceOf information is present
-          // If it does not end with the current InstanceOf, an alias was used, and we should use that
-          instance.name = `${instance.id}-of-${instance.instanceOf}`;
-        }
+    const oldNameToNewNameMap = new Map<string, string>();
+    pkg.instances.forEach((instance, index) => {
+      if (!pkg.instances.find((m, i) => m.id === instance.id && i !== index)) {
+        // If the instance does not have the same id as any other instance, it is safe to
+        // use the id as the name and remove the InstanceOf information from the name
+        oldNameToNewNameMap.set(instance.name, instance.id);
+        instance.name = instance.id;
+      } else if (!instance.name.endsWith(instance.instanceOf)) {
+        // If the instance name isn't simplified, the InstanceOf information is present
+        // If it does not end with the current InstanceOf, an alias was used, and we should use that
+        oldNameToNewNameMap.set(instance.name, `${instance.id}-of-${instance.instanceOf}`);
+        instance.name = `${instance.id}-of-${instance.instanceOf}`;
+      }
 
-        if (instance.id != null && instance.id !== instance.name) {
-          // add a rule to set the id so it is not lost
-          const idRule = new ExportableAssignmentRule('id');
-          idRule.value = instance.id;
-          instance.rules.unshift(idRule);
+      if (instance.id != null && instance.id !== instance.name) {
+        // add a rule to set the id so it is not lost
+        const idRule = new ExportableAssignmentRule('id');
+        idRule.value = instance.id;
+        instance.rules.unshift(idRule);
+      }
+    });
+
+    // Fix up inline assignments in types that may have them (see: ConstructInlineInstanceOptimizer)
+    [...pkg.instances, ...pkg.profiles, ...pkg.extensions].forEach(resource => {
+      const inlineAssignmentRules = resource.rules.filter(
+        rule =>
+          (rule instanceof ExportableAssignmentRule || rule instanceof ExportableCaretValueRule) &&
+          rule.isInstance
+      );
+      inlineAssignmentRules.forEach((rule: ExportableAssignmentRule | ExportableCaretValueRule) => {
+        if (oldNameToNewNameMap.has(rule.value as string)) {
+          rule.value = oldNameToNewNameMap.get(rule.value as string);
         }
       });
+    });
   }
 } as OptimizerPlugin;

--- a/src/optimizer/plugins/SimplifyInstanceNameOptimizer.ts
+++ b/src/optimizer/plugins/SimplifyInstanceNameOptimizer.ts
@@ -13,7 +13,7 @@ export default {
     const oldNameToNewNameMap = new Map<string, string>();
     const standaloneInstances = pkg.instances.filter(i => i.usage !== 'Inline');
     standaloneInstances.forEach((instance, index) => {
-      // Only match on other standalones because inline instances already depuplicated the name based on id
+      // Only match on other standalones because inline instances already deduplicated the name based on id
       if (!standaloneInstances.find((m, i) => m.id === instance.id && i !== index)) {
         // If the instance does not have the same id as any other instance, it is safe to
         // use the id as the name and remove the InstanceOf information from the name

--- a/src/optimizer/plugins/SimplifyInstanceNameOptimizer.ts
+++ b/src/optimizer/plugins/SimplifyInstanceNameOptimizer.ts
@@ -11,8 +11,10 @@ export default {
 
   optimize(pkg: Package): void {
     const oldNameToNewNameMap = new Map<string, string>();
-    pkg.instances.forEach((instance, index) => {
-      if (!pkg.instances.find((m, i) => m.id === instance.id && i !== index)) {
+    const standaloneInstances = pkg.instances.filter(i => i.usage !== 'Inline');
+    standaloneInstances.forEach((instance, index) => {
+      // Only match on other standalones because inline instances already depuplicated the name based on id
+      if (!standaloneInstances.find((m, i) => m.id === instance.id && i !== index)) {
         // If the instance does not have the same id as any other instance, it is safe to
         // use the id as the name and remove the InstanceOf information from the name
         oldNameToNewNameMap.set(instance.name, instance.id);

--- a/src/processor/InstanceProcessor.ts
+++ b/src/processor/InstanceProcessor.ts
@@ -1,7 +1,6 @@
 import { cloneDeep, compact, isEmpty, toPairs } from 'lodash';
 import { fhirtypes, utils } from 'fsh-sushi';
 import { ExportableAssignmentRule, ExportableInstance } from '../exportable';
-import { removeUnderscoreForPrimitiveChildPath } from '../exportable/common';
 import {
   getFSHValue,
   isFSHValueEmpty,
@@ -109,15 +108,13 @@ export class InstanceProcessor {
     }
 
     const flatInstanceArray = toPairs(getPathValuePairs(inputJSON));
-    flatInstanceArray.forEach(([key], i) => {
-      // Remove any _ at the start of any path part
-      const path = removeUnderscoreForPrimitiveChildPath(key);
+    flatInstanceArray.forEach(([path], i) => {
       const assignmentRule = new ExportableAssignmentRule(path);
       assignmentRule.value = getFSHValue(i, flatInstanceArray, instanceOfJSON.type, fisher);
       // if the value is empty, we can't use that
       if (isFSHValueEmpty(assignmentRule.value)) {
         logger.error(
-          `Value in Instance ${target.name} at path ${key} is empty. No assignment rule will be created.`
+          `Value in Instance ${target.name} at path ${path} is empty. No assignment rule will be created.`
         );
       } else {
         newRules.push(assignmentRule);

--- a/test/extractor/CaretValueRuleExtractor.test.ts
+++ b/test/extractor/CaretValueRuleExtractor.test.ts
@@ -910,11 +910,11 @@ describe('CaretValueRuleExtractor', () => {
       [true, false, false, null, false, true].forEach((value, i) => {
         if (value != null) {
           const extUrlRule = new ExportableCaretValueRule('author');
-          extUrlRule.caretPath = `type[0]._targetProfile[${i}].extension[0].url`;
+          extUrlRule.caretPath = `type[0].targetProfile[${i}].extension[0].url`;
           extUrlRule.value =
             'http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support';
           const extValueRule = new ExportableCaretValueRule('author');
-          extValueRule.caretPath = `type[0]._targetProfile[${i}].extension[0].valueBoolean`;
+          extValueRule.caretPath = `type[0].targetProfile[${i}].extension[0].valueBoolean`;
           extValueRule.value = value;
           expectedRules.push(extUrlRule, extValueRule);
         }

--- a/test/extractor/fixtures/caret-value-targetProfile-extensions.json
+++ b/test/extractor/fixtures/caret-value-targetProfile-extensions.json
@@ -1,0 +1,73 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "caret-value-targetProfile-extensions",
+  "url": "http://hl7.org/fhir/sushi-test/StructureDefinition/caret-value-targetProfile-extensions",
+  "version": "5.0.1",
+  "name": "CaretValueTargetProfileExtensions",
+  "title": "Caret Value Target Profile Extensions",
+  "description": "Inspired by US Core DocumentReference Profile",
+  "status": "active",
+  "experimental": false,
+  "date": "2022-04-20",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "abstract": false,
+  "type": "DocumentReference",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/DocumentReference",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "DocumentReference.author",
+        "path": "DocumentReference.author",
+        "type": [
+          {
+            "_targetProfile": [
+              {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                    "valueBoolean": true
+                  }
+                ]
+              },
+              {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                    "valueBoolean": false
+                  }
+                ]
+              },
+              {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                    "valueBoolean": false
+                  }
+                ]
+              },
+              null,
+              {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                    "valueBoolean": false
+                  }
+                ]
+              },
+              {
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/elementdefinition-type-must-support",
+                    "valueBoolean": true
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test/helpers/asserts.ts
+++ b/test/helpers/asserts.ts
@@ -2,6 +2,25 @@ import { ExportableInstance } from '../../src/exportable';
 
 export function assertExportableInstance(
   instance: ExportableInstance,
+  nameAndId: ExportableInstance['id'],
+  instanceOf: ExportableInstance['instanceOf'],
+  usage: ExportableInstance['usage'],
+  title: ExportableInstance['title'],
+  description: ExportableInstance['description'],
+  rules: ExportableInstance['rules']
+): void {
+  expect(instance.name).toBe(nameAndId);
+  expect(instance.id).toBe(nameAndId);
+  expect(instance.instanceOf).toBe(instanceOf);
+  expect(instance.usage).toBe(usage);
+  expect(instance.title).toBe(title);
+  expect(instance.description).toBe(description);
+  expect(instance.rules).toEqual(rules);
+}
+
+export function assertExportableInstanceWithDifferentName(
+  instance: ExportableInstance,
+  name: ExportableInstance['name'],
   id: ExportableInstance['id'],
   instanceOf: ExportableInstance['instanceOf'],
   usage: ExportableInstance['usage'],
@@ -9,6 +28,7 @@ export function assertExportableInstance(
   description: ExportableInstance['description'],
   rules: ExportableInstance['rules']
 ): void {
+  expect(instance.name).toBe(name);
   expect(instance.id).toBe(id);
   expect(instance.instanceOf).toBe(instanceOf);
   expect(instance.usage).toBe(usage);

--- a/test/optimizer/plugins/ConstructInlineInstanceOptimizer.test.ts
+++ b/test/optimizer/plugins/ConstructInlineInstanceOptimizer.test.ts
@@ -10,10 +10,14 @@ import {
   ExportableProfile
 } from '../../../src/exportable';
 import optimizer from '../../../src/optimizer/plugins/ConstructInlineInstanceOptimizer';
-import { assertExportableInstance } from '../../helpers/asserts';
+import {
+  assertExportableInstance,
+  assertExportableInstanceWithDifferentName
+} from '../../helpers/asserts';
 import RemoveGeneratedTextRulesOptimizer from '../../../src/optimizer/plugins/RemoveGeneratedTextRulesOptimizer';
 import ResolveInstanceOfURLsOptimizer from '../../../src/optimizer/plugins/ResolveInstanceOfURLsOptimizer';
 import AddReferenceKeywordOptimizer from '../../../src/optimizer/plugins/AddReferenceKeywordOptimizer';
+import SimplifyInstanceNameOptimizer from '../../../src/optimizer/plugins/SimplifyInstanceNameOptimizer';
 import { MasterFisher } from '../../../src/utils';
 import { loadTestDefinitions, stockLake } from '../../helpers';
 
@@ -66,7 +70,8 @@ describe('optimizer', () => {
         expect(optimizer.runBefore).toEqual([
           RemoveGeneratedTextRulesOptimizer.name,
           ResolveInstanceOfURLsOptimizer.name,
-          AddReferenceKeywordOptimizer.name
+          AddReferenceKeywordOptimizer.name,
+          SimplifyInstanceNameOptimizer.name
         ]);
         expect(optimizer.runAfter).toBeUndefined();
       });
@@ -222,9 +227,10 @@ describe('optimizer', () => {
         expect(myPackage.instances).toHaveLength(3);
         const expectedRule1 = cloneDeep(containedId1);
         expectedRule1.path = 'id';
-        assertExportableInstance(
+        assertExportableInstanceWithDifferentName(
           myPackage.instances[1],
           'Inline-Instance-for-Foo-1',
+          '123',
           'Observation',
           'Inline',
           undefined,
@@ -234,9 +240,10 @@ describe('optimizer', () => {
 
         const expectedRule2 = cloneDeep(containedId2);
         expectedRule2.path = 'id';
-        assertExportableInstance(
+        assertExportableInstanceWithDifferentName(
           myPackage.instances[2],
           'Inline-Instance-for-Foo-2',
+          '456',
           'ValueSet',
           'Inline',
           undefined,
@@ -265,9 +272,10 @@ describe('optimizer', () => {
         expect(myPackage.instances).toHaveLength(3);
         const expectedRule = cloneDeep(containedId1);
         expectedRule.path = 'id';
-        assertExportableInstance(
+        assertExportableInstanceWithDifferentName(
           myPackage.instances[2],
           'Inline-Instance-for-Foo-1',
+          'repeated-id',
           'Observation',
           'Inline',
           undefined,

--- a/test/optimizer/plugins/ResolveInstanceOfURLsOptimizer.test.ts
+++ b/test/optimizer/plugins/ResolveInstanceOfURLsOptimizer.test.ts
@@ -25,11 +25,11 @@ describe('optimizer', () => {
 
     it('should replace an instanceOf url with the name of the resource', () => {
       const instance = new ExportableInstance('Foo');
-      instance.instanceOf = 'https://demo.org/StructureDefinition/Patient';
+      instance.instanceOf = 'https://demo.org/StructureDefinition/SmallPatient';
       const myPackage = new Package();
       myPackage.add(instance);
       optimizer.optimize(myPackage, fisher);
-      expect(instance.instanceOf).toBe('Patient');
+      expect(instance.instanceOf).toBe('SmallPatient');
     });
 
     it('should alias the instanceOf url if the instanceOf is not found and alias is true', () => {

--- a/test/optimizer/plugins/ResolveOnlyRuleURLsOptimizer.test.ts
+++ b/test/optimizer/plugins/ResolveOnlyRuleURLsOptimizer.test.ts
@@ -12,7 +12,10 @@ describe('optimizer', () => {
 
     beforeAll(() => {
       const defs = loadTestDefinitions();
-      const lake = stockLake(path.join(__dirname, 'fixtures', 'small-profile.json'));
+      const lake = stockLake(
+        path.join(__dirname, 'fixtures', 'small-profile.json'),
+        path.join(__dirname, 'fixtures', 'patient-profile.json')
+      );
       fisher = new MasterFisher(lake, defs);
     });
 
@@ -28,7 +31,7 @@ describe('optimizer', () => {
       const onlySubject = new ExportableOnlyRule('subject');
       onlySubject.types = [
         {
-          type: 'https://demo.org/StructureDefinition/Patient',
+          type: 'https://demo.org/StructureDefinition/SmallPatient',
           isReference: true
         }
       ];
@@ -41,7 +44,7 @@ describe('optimizer', () => {
       const expectedSubject = new ExportableOnlyRule('subject');
       expectedSubject.types = [
         {
-          type: 'Patient',
+          type: 'SmallPatient',
           isReference: true
         }
       ];

--- a/test/optimizer/plugins/ResolveParentURLsOptimizer.test.ts
+++ b/test/optimizer/plugins/ResolveParentURLsOptimizer.test.ts
@@ -21,7 +21,8 @@ describe('optimizer', () => {
         path.join(__dirname, 'fixtures', 'small-profile.json'),
         path.join(__dirname, 'fixtures', 'small-extension.json'),
         path.join(__dirname, 'fixtures', 'small-logical.json'),
-        path.join(__dirname, 'fixtures', 'small-resource.json')
+        path.join(__dirname, 'fixtures', 'small-resource.json'),
+        path.join(__dirname, 'fixtures', 'patient-profile.json')
       );
       fisher = new MasterFisher(lake, defs);
     });
@@ -35,11 +36,11 @@ describe('optimizer', () => {
 
     it('should replace a profile parent url with the name of the parent', () => {
       const profile = new ExportableProfile('ExtraProfile');
-      profile.parent = 'https://demo.org/StructureDefinition/Patient';
+      profile.parent = 'https://demo.org/StructureDefinition/SmallPatient';
       const myPackage = new Package();
       myPackage.add(profile);
       optimizer.optimize(myPackage, fisher);
-      expect(profile.parent).toBe('Patient');
+      expect(profile.parent).toBe('SmallPatient');
     });
 
     it('should replace an extension parent url with the name of the parent', () => {

--- a/test/optimizer/plugins/SimplifyInstanceNameOptimizer.test.ts
+++ b/test/optimizer/plugins/SimplifyInstanceNameOptimizer.test.ts
@@ -1,7 +1,12 @@
 import path from 'path';
 import '../../helpers/loggerSpy'; // side-effect: suppresses logs
 import { Package } from '../../../src/processor/Package';
-import { ExportableAssignmentRule, ExportableInstance } from '../../../src/exportable';
+import {
+  ExportableAssignmentRule,
+  ExportableCaretValueRule,
+  ExportableInstance,
+  ExportableProfile
+} from '../../../src/exportable';
 import { MasterFisher } from '../../../src/utils';
 import { loadTestDefinitions, stockLake } from '../../helpers';
 import optimizer from '../../../src/optimizer/plugins/SimplifyInstanceNameOptimizer';
@@ -26,12 +31,23 @@ describe('optimizer', () => {
       const instance3 = new ExportableInstance('MyObservationExample');
       instance3.instanceOf = 'Observation';
       instance3.name = 'MyObservationExample-of-Observation';
+      const bundle = new ExportableInstance('MyBundleExample');
+      bundle.instanceOf = 'Bundle';
+      const bundleRule1 = new ExportableAssignmentRule('entry[0].resource');
+      bundleRule1.isInstance = true;
+      bundleRule1.value = 'MyExample-of-Condition';
+      const bundleRule2 = new ExportableAssignmentRule('entry[1].resource');
+      bundleRule2.isInstance = true;
+      bundleRule2.value = 'MyObservationExample-of-Observation';
+      bundle.rules = [bundleRule1, bundleRule2];
       const myPackage = new Package();
       myPackage.add(instance1);
       myPackage.add(instance2);
       myPackage.add(instance3);
+      myPackage.add(bundle);
       optimizer.optimize(myPackage);
 
+      // Check that instances were renamed when appropriate
       const myExampleIdRule = new ExportableAssignmentRule('id');
       myExampleIdRule.value = 'MyExample';
       const expectedInstance1 = new ExportableInstance('MyExample');
@@ -46,10 +62,21 @@ describe('optimizer', () => {
       expectedInstance3.instanceOf = 'Observation';
       expectedInstance3.name = 'MyObservationExample'; // Name simplification since it didn't conflict with any other instances
       // NOTE: expectedInstance3 should not have id rule since name matches id
+      // Now check that names have been updated in inline assignments
+      const expectedBundle = new ExportableInstance('MyBundleExample');
+      expectedBundle.instanceOf = 'Bundle';
+      const expectedBundleRule1 = new ExportableAssignmentRule('entry[0].resource');
+      expectedBundleRule1.isInstance = true;
+      expectedBundleRule1.value = 'MyExample-of-Condition'; // This name did not get changed
+      const expectedBundleRule2 = new ExportableAssignmentRule('entry[1].resource');
+      expectedBundleRule2.isInstance = true;
+      expectedBundleRule2.value = 'MyObservationExample'; // This name was changed
+      expectedBundle.rules = [expectedBundleRule1, expectedBundleRule2];
       expect(myPackage.instances).toEqual([
         expectedInstance1,
         expectedInstance2,
-        expectedInstance3
+        expectedInstance3,
+        expectedBundle
       ]);
     });
 
@@ -64,14 +91,25 @@ describe('optimizer', () => {
       const instance2 = new ExportableInstance('MyExample');
       instance2.instanceOf = 'http://hl7.org/fhir/us/foo/StructureDefinition/bar-profile';
       instance2.name = 'MyExample-of-http://hl7.org/fhir/us/foo/StructureDefinition/bar-profile';
+      const bundle = new ExportableInstance('MyBundleExample');
+      bundle.instanceOf = 'Bundle';
+      const bundleRule1 = new ExportableAssignmentRule('entry[0].resource');
+      bundleRule1.isInstance = true;
+      bundleRule1.value = 'MyExample-of-http://hl7.org/fhir/us/foo/StructureDefinition/foo-profile';
+      const bundleRule2 = new ExportableAssignmentRule('entry[1].resource');
+      bundleRule2.isInstance = true;
+      bundleRule2.value = 'MyExample-of-http://hl7.org/fhir/us/foo/StructureDefinition/bar-profile';
+      bundle.rules = [bundleRule1, bundleRule2];
       const myPackage = new Package();
       myPackage.add(instance1);
       myPackage.add(instance2);
+      myPackage.add(bundle);
 
       // Resolve InstanceOf URLs first, then simplify Instance names to check they are updated according to the alias
       ResolveInstanceOfURLsOptimizer.optimize(myPackage, fisher);
       optimizer.optimize(myPackage);
 
+      // Check that instances were renamed when appropriate
       const myExampleIdRule = new ExportableAssignmentRule('id');
       myExampleIdRule.value = 'MyExample';
       const expectedInstance1 = new ExportableInstance('MyExample');
@@ -82,7 +120,88 @@ describe('optimizer', () => {
       expectedInstance2.instanceOf = '$bar-profile';
       expectedInstance2.name = 'MyExample-of-$bar-profile';
       expectedInstance2.rules = [myExampleIdRule];
-      expect(myPackage.instances).toEqual([expectedInstance1, expectedInstance2]);
+      // Now check that names have been updated in inline assignments
+      const expectedBundle = new ExportableInstance('MyBundleExample');
+      expectedBundle.instanceOf = 'Bundle';
+      const expectedBundleRule1 = new ExportableAssignmentRule('entry[0].resource');
+      expectedBundleRule1.isInstance = true;
+      expectedBundleRule1.value = 'MyExample-of-$foo-profile';
+      const expectedBundleRule2 = new ExportableAssignmentRule('entry[1].resource');
+      expectedBundleRule2.isInstance = true;
+      expectedBundleRule2.value = 'MyExample-of-$bar-profile';
+      expectedBundle.rules = [expectedBundleRule1, expectedBundleRule2];
+      expect(myPackage.instances).toEqual([expectedInstance1, expectedInstance2, expectedBundle]);
+    });
+
+    it('should updated inlined contained rules in a profile when the inline instance name changes', () => {
+      const instance1 = new ExportableInstance('AmazingThings');
+      instance1.instanceOf = 'CodeSystem';
+      instance1.name = 'AmazingThings-of-CodeSystem';
+      const instance2 = new ExportableInstance('AmazingThings');
+      instance2.instanceOf = 'ValueSet';
+      instance2.name = 'AmazingThings-of-ValueSet';
+      const instance3 = new ExportableInstance('OtherAmazingThings');
+      instance3.instanceOf = 'ValueSet';
+      instance3.name = 'OtherAmazingThings-of-ValueSet';
+      const profile = new ExportableProfile('MyObservationProfile');
+      profile.parent = 'Observation';
+      const profileContainedRule1 = new ExportableCaretValueRule('.');
+      profileContainedRule1.caretPath = 'contained[0]';
+      profileContainedRule1.isInstance = true;
+      profileContainedRule1.value = 'AmazingThings-of-CodeSystem';
+      const profileContainedRule2 = new ExportableCaretValueRule('.');
+      profileContainedRule2.caretPath = 'contained[1]';
+      profileContainedRule2.isInstance = true;
+      profileContainedRule2.value = 'AmazingThings-of-ValueSet';
+      const profileContainedRule3 = new ExportableCaretValueRule('.');
+      profileContainedRule3.caretPath = 'contained[2]';
+      profileContainedRule3.isInstance = true;
+      profileContainedRule3.value = 'OtherAmazingThings-of-ValueSet';
+      profile.rules = [profileContainedRule1, profileContainedRule2, profileContainedRule3];
+      const myPackage = new Package();
+      myPackage.add(instance1);
+      myPackage.add(instance2);
+      myPackage.add(instance3);
+      myPackage.add(profile);
+      optimizer.optimize(myPackage);
+
+      // Check that instances were renamed when appropriate
+      const amazingThingsIdRule = new ExportableAssignmentRule('id');
+      amazingThingsIdRule.value = 'AmazingThings';
+      const expectedInstance1 = new ExportableInstance('AmazingThings');
+      expectedInstance1.instanceOf = 'CodeSystem';
+      expectedInstance1.name = 'AmazingThings-of-CodeSystem'; // No name simplification since it will conflict with other instances
+      expectedInstance1.rules = [amazingThingsIdRule];
+      const expectedInstance2 = new ExportableInstance('AmazingThings');
+      expectedInstance2.instanceOf = 'ValueSet';
+      expectedInstance2.name = 'AmazingThings-of-ValueSet'; // No name simplification since it will conflict with other instances
+      expectedInstance2.rules = [amazingThingsIdRule];
+      const expectedInstance3 = new ExportableInstance('OtherAmazingThings');
+      expectedInstance3.instanceOf = 'ValueSet';
+      expectedInstance3.name = 'OtherAmazingThings'; // Name simplification since it didn't conflict with any other instances
+      // NOTE: expectedInstance3 should not have id rule since name matches id
+      // Now check that names have been updated in inline assignments
+      const expectedProfile = new ExportableProfile('MyObservationProfile');
+      expectedProfile.parent = 'Observation';
+      const expectedProfileRule1 = new ExportableCaretValueRule('.');
+      expectedProfileRule1.caretPath = 'contained[0]';
+      expectedProfileRule1.isInstance = true;
+      expectedProfileRule1.value = 'AmazingThings-of-CodeSystem'; // This name did not get changed
+      const expectedProfileRule2 = new ExportableCaretValueRule('.');
+      expectedProfileRule2.caretPath = 'contained[1]';
+      expectedProfileRule2.isInstance = true;
+      expectedProfileRule2.value = 'AmazingThings-of-ValueSet'; // This name did not get changed
+      const expectedProfileRule3 = new ExportableCaretValueRule('.');
+      expectedProfileRule3.caretPath = 'contained[2]';
+      expectedProfileRule3.isInstance = true;
+      expectedProfileRule3.value = 'OtherAmazingThings'; // This name was changed
+      expectedProfile.rules = [expectedProfileRule1, expectedProfileRule2, expectedProfileRule3];
+      expect(myPackage.instances).toEqual([
+        expectedInstance1,
+        expectedInstance2,
+        expectedInstance3
+      ]);
+      expect(myPackage.profiles).toEqual([expectedProfile]);
     });
   });
 });

--- a/test/optimizer/plugins/fixtures/patient-profile.json
+++ b/test/optimizer/plugins/fixtures/patient-profile.json
@@ -1,10 +1,10 @@
 {
   "resourceType": "StructureDefinition",
-  "id": "SmallPatient",
+  "id": "Patient",
   "kind": "resource",
   "type": "Patient",
-  "name": "SmallPatient",
-  "url": "https://demo.org/StructureDefinition/SmallPatient",
+  "name": "Patient",
+  "url": "https://demo.org/StructureDefinition/Patient",
   "derivation": "constraint",
   "snapshot": {
     "element": []

--- a/test/optimizer/utils.test.ts
+++ b/test/optimizer/utils.test.ts
@@ -18,12 +18,12 @@ describe('optimizer', () => {
 
     it('should prefer to resolve the URL to a FHIR resource', () => {
       const result = optimizeURL(
-        'https://demo.org/StructureDefinition/Patient',
+        'https://demo.org/StructureDefinition/SmallPatient',
         [],
         [utils.Type.Resource, utils.Type.Profile, utils.Type.Extension],
         fisher
       );
-      expect(result).toBe('Patient');
+      expect(result).toBe('SmallPatient');
     });
 
     it('should resolve the URL to an alias and add that alias if the URL cannot be resolved', () => {
@@ -73,6 +73,7 @@ describe('optimizer', () => {
       const defs = loadTestDefinitions();
       const lake = stockLake(
         path.join(__dirname, 'plugins', 'fixtures', 'small-profile.json'),
+        path.join(__dirname, 'plugins', 'fixtures', 'patient-profile.json'),
         path.join(__dirname, 'plugins', 'fixtures', 'unsupported-codesystem.json'),
         path.join(__dirname, 'plugins', 'fixtures', 'unsupported-valueset.json')
       );
@@ -81,11 +82,11 @@ describe('optimizer', () => {
 
     it('should resolve a URL the name of a local item', () => {
       const result = resolveURL(
-        'https://demo.org/StructureDefinition/Patient',
+        'https://demo.org/StructureDefinition/SmallPatient',
         [utils.Type.Resource, utils.Type.Profile, utils.Type.Extension],
         fisher
       );
-      expect(result).toBe('Patient');
+      expect(result).toBe('SmallPatient');
     });
 
     it('should resolve a URL to the name of a core FHIR resource', () => {


### PR DESCRIPTION
Adds support for properly generating rules for ids and extensions on primitive values. Prior to this PR, they were dropped. This required a change in SUSHI, so the version of SUSHI was updated. This in turn caused additional regressions related to a fix in SUSHI 2.9.0 that made it so an instance's `id` getter would consult assignment rules for `id` overrides (see: https://github.com/FHIR/sushi/pull/1198). Most of the changes in this PR are to update GoFSH to work properly with this new way of handling Instance ids. Changes included:
* setting inline instances via name rather than id
* updating the name optimizer to fix up changed names in inline instance assignments

There was also some ambiguity / confusion related to a test profile having the name Patient (which conflicts with a resource name), so I updated the fixture and tests to reflect a unique name, and added a new fixture for a profile named Patient to test that name clash condition specifically.

Fixes #211 and [CIMPL-1076](https://standardhealthrecord.atlassian.net/browse/CIMPL-1076).