### PR TITLE
Use name of local CodeSystem when optimizing assigned code

### DIFF
--- a/src/optimizer/plugins/ResolveValueRuleURLsOptimizer.ts
+++ b/src/optimizer/plugins/ResolveValueRuleURLsOptimizer.ts
@@ -11,9 +11,9 @@ import CombineCodingAndQuantityValuesOptimizer from './CombineCodingAndQuantityV
 import { ProcessingOptions, MasterFisher } from '../../utils';
 
 export default {
-  name: 'resolve_value_rule_system_system_urls_for_codes',
+  name: 'resolve_value_rule_system_urls_for_codes',
   description:
-    'Replace URLs in code values in caret and assignment rules with their names or aliases',
+    'Replace system URLs in code values in caret and assignment rules with their names or aliases',
   runAfter: [CombineCodingAndQuantityValuesOptimizer.name],
 
   optimize(pkg: Package, fisher: MasterFisher, options: ProcessingOptions = {}): void {

--- a/src/optimizer/plugins/ResolveValueRuleURLsOptimizer.ts
+++ b/src/optimizer/plugins/ResolveValueRuleURLsOptimizer.ts
@@ -36,7 +36,8 @@ export default {
           if (localSystem?.name) {
             rule.value.system = localSystem.name;
           } else if (options.alias ?? true) {
-            rule.value.system = resolveAliasFromURL(rule.value.system, pkg.aliases);
+            rule.value.system =
+              resolveAliasFromURL(rule.value.system, pkg.aliases) ?? rule.value.system;
           }
         }
       });

--- a/test/optimizer/plugins/ResolveValueRuleURLsOptimizer.test.ts
+++ b/test/optimizer/plugins/ResolveValueRuleURLsOptimizer.test.ts
@@ -78,6 +78,19 @@ describe('optimizer', () => {
       expect(instance.rules[0]).toEqual(expectedRule);
     });
 
+    it('should not change the system URI if it is not a web URL when alias is true', () => {
+      const instance = new ExportableInstance('Foo');
+      instance.instanceOf = 'Observation';
+      const codeRule = new ExportableAssignmentRule('code');
+      codeRule.value = new fshtypes.FshCode('US', 'urn:iso:std:iso:3166');
+      instance.rules = [codeRule];
+      const myPackage = new Package();
+      myPackage.add(instance);
+      optimizer.optimize(myPackage, fisher, { alias: true });
+
+      expect(instance.rules[0]).toEqual(codeRule);
+    });
+
     it('should alias a system in an AssignmentRule when alias is undefined', () => {
       const instance = new ExportableInstance('Foo');
       instance.instanceOf = 'Observation';
@@ -126,6 +139,19 @@ describe('optimizer', () => {
       expect(instance.rules[0]).toEqual(expectedRule);
     });
 
+    it('should not change the system URI if it is not a web URL when alias is undefined', () => {
+      const instance = new ExportableInstance('Foo');
+      instance.instanceOf = 'Observation';
+      const codeRule = new ExportableAssignmentRule('code');
+      codeRule.value = new fshtypes.FshCode('US', 'urn:iso:std:iso:3166');
+      instance.rules = [codeRule];
+      const myPackage = new Package();
+      myPackage.add(instance);
+      optimizer.optimize(myPackage, fisher);
+
+      expect(instance.rules[0]).toEqual(codeRule);
+    });
+
     it('should not alias a system in an AssignmentRule when alias is false', () => {
       const instance = new ExportableInstance('Foo');
       instance.instanceOf = 'Observation';
@@ -168,6 +194,19 @@ describe('optimizer', () => {
       const expectedRule = cloneDeep(codeRule);
       (expectedRule.value as fshtypes.FshCode).system = 'SimpleCodeSystem';
       expect(instance.rules[0]).toEqual(expectedRule);
+    });
+
+    it('should not change the system URI if it is not a web URL when alias is false', () => {
+      const instance = new ExportableInstance('Foo');
+      instance.instanceOf = 'Observation';
+      const codeRule = new ExportableAssignmentRule('code');
+      codeRule.value = new fshtypes.FshCode('US', 'urn:iso:std:iso:3166');
+      instance.rules = [codeRule];
+      const myPackage = new Package();
+      myPackage.add(instance);
+      optimizer.optimize(myPackage, fisher, { alias: false });
+
+      expect(instance.rules[0]).toEqual(codeRule);
     });
 
     it('should alias a system in an CaretValueRule when alias is true', () => {

--- a/test/optimizer/plugins/ResolveValueRuleURLsOptimizer.test.ts
+++ b/test/optimizer/plugins/ResolveValueRuleURLsOptimizer.test.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { cloneDeep } from 'lodash';
 import { fshtypes } from 'fsh-sushi';
 import '../../helpers/loggerSpy'; // side-effect: suppresses logs
@@ -10,9 +11,18 @@ import {
 } from '../../../src/exportable';
 import CombineCodingAndQuantityValuesOptimizer from '../../../src/optimizer/plugins/CombineCodingAndQuantityValuesOptimizer';
 import optimizer from '../../../src/optimizer/plugins/ResolveValueRuleURLsOptimizer';
+import { MasterFisher } from '../../../src/utils';
+import { loadTestDefinitions, stockLake } from '../../helpers';
 
 describe('optimizer', () => {
   describe('#resolve_value_rule_urls', () => {
+    let fisher: MasterFisher;
+    beforeAll(() => {
+      const defs = loadTestDefinitions();
+      const lake = stockLake(path.join(__dirname, 'fixtures', 'simple-codesystem.json'));
+      fisher = new MasterFisher(lake, defs);
+    });
+
     it('should have appropriate metadata', () => {
       expect(optimizer.name).toBe('resolve_value_rule_urls');
       expect(optimizer.description).toBeDefined();
@@ -28,10 +38,28 @@ describe('optimizer', () => {
       instance.rules = [codeRule];
       const myPackage = new Package();
       myPackage.add(instance);
-      optimizer.optimize(myPackage, undefined, { alias: true });
+      optimizer.optimize(myPackage, fisher, { alias: true });
 
       const expectedRule = cloneDeep(codeRule);
       (expectedRule.value as fshtypes.FshCode).system = '$loinc';
+      expect(instance.rules[0]).toEqual(expectedRule);
+    });
+
+    it('should use the name of a locally defined system in an AssignmentRule when alias is true', () => {
+      const instance = new ExportableInstance('Foo');
+      instance.instanceOf = 'Observation';
+      const codeRule = new ExportableAssignmentRule('code');
+      codeRule.value = new fshtypes.FshCode(
+        '10-9',
+        'http://example.org/tests/CodeSystem/simple.codesystem'
+      );
+      instance.rules = [codeRule];
+      const myPackage = new Package();
+      myPackage.add(instance);
+      optimizer.optimize(myPackage, fisher, { alias: true });
+
+      const expectedRule = cloneDeep(codeRule);
+      (expectedRule.value as fshtypes.FshCode).system = 'SimpleCodeSystem';
       expect(instance.rules[0]).toEqual(expectedRule);
     });
 
@@ -43,10 +71,28 @@ describe('optimizer', () => {
       instance.rules = [codeRule];
       const myPackage = new Package();
       myPackage.add(instance);
-      optimizer.optimize(myPackage);
+      optimizer.optimize(myPackage, fisher);
 
       const expectedRule = cloneDeep(codeRule);
       (expectedRule.value as fshtypes.FshCode).system = '$loinc';
+      expect(instance.rules[0]).toEqual(expectedRule);
+    });
+
+    it('should use the name of a locally defined system in an AssignmentRule when alias is undefined', () => {
+      const instance = new ExportableInstance('Foo');
+      instance.instanceOf = 'Observation';
+      const codeRule = new ExportableAssignmentRule('code');
+      codeRule.value = new fshtypes.FshCode(
+        '10-9',
+        'http://example.org/tests/CodeSystem/simple.codesystem'
+      );
+      instance.rules = [codeRule];
+      const myPackage = new Package();
+      myPackage.add(instance);
+      optimizer.optimize(myPackage, fisher);
+
+      const expectedRule = cloneDeep(codeRule);
+      (expectedRule.value as fshtypes.FshCode).system = 'SimpleCodeSystem';
       expect(instance.rules[0]).toEqual(expectedRule);
     });
 
@@ -58,9 +104,27 @@ describe('optimizer', () => {
       instance.rules = [codeRule];
       const myPackage = new Package();
       myPackage.add(instance);
-      optimizer.optimize(myPackage, undefined, { alias: false });
+      optimizer.optimize(myPackage, fisher, { alias: false });
 
       expect(instance.rules[0]).toEqual(codeRule);
+    });
+
+    it('should use the name of a locally defined system in an AssignmentRule when alias is false', () => {
+      const instance = new ExportableInstance('Foo');
+      instance.instanceOf = 'Observation';
+      const codeRule = new ExportableAssignmentRule('code');
+      codeRule.value = new fshtypes.FshCode(
+        '10-9',
+        'http://example.org/tests/CodeSystem/simple.codesystem'
+      );
+      instance.rules = [codeRule];
+      const myPackage = new Package();
+      myPackage.add(instance);
+      optimizer.optimize(myPackage, fisher, { alias: false });
+
+      const expectedRule = cloneDeep(codeRule);
+      (expectedRule.value as fshtypes.FshCode).system = 'SimpleCodeSystem';
+      expect(instance.rules[0]).toEqual(expectedRule);
     });
 
     it('should alias a system in an CaretValueRule when alias is true', () => {
@@ -72,10 +136,29 @@ describe('optimizer', () => {
       profile.rules = [jurisdictionRule];
       const myPackage = new Package();
       myPackage.add(profile);
-      optimizer.optimize(myPackage, undefined, { alias: true });
+      optimizer.optimize(myPackage, fisher, { alias: true });
 
       const expectedRule = cloneDeep(jurisdictionRule);
       (expectedRule.value as fshtypes.FshCode).system = '$bar';
+      expect(profile.rules[0]).toEqual(expectedRule);
+    });
+
+    it('should use the name of a locally defined system in a CaretValueRule when alias is true', () => {
+      const profile = new ExportableProfile('Foo');
+      profile.parent = 'Observation';
+      const jurisdictionRule = new ExportableCaretValueRule('');
+      jurisdictionRule.caretPath = 'jurisdiction';
+      jurisdictionRule.value = new fshtypes.FshCode(
+        'MA',
+        'http://example.org/tests/CodeSystem/simple.codesystem'
+      );
+      profile.rules = [jurisdictionRule];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      optimizer.optimize(myPackage, fisher, { alias: true });
+
+      const expectedRule = cloneDeep(jurisdictionRule);
+      (expectedRule.value as fshtypes.FshCode).system = 'SimpleCodeSystem';
       expect(profile.rules[0]).toEqual(expectedRule);
     });
 
@@ -88,10 +171,29 @@ describe('optimizer', () => {
       profile.rules = [jurisdictionRule];
       const myPackage = new Package();
       myPackage.add(profile);
-      optimizer.optimize(myPackage);
+      optimizer.optimize(myPackage, fisher);
 
       const expectedRule = cloneDeep(jurisdictionRule);
       (expectedRule.value as fshtypes.FshCode).system = '$bar';
+      expect(profile.rules[0]).toEqual(expectedRule);
+    });
+
+    it('should use the name of a locally defined system in a CaretValueRule when alias is undefined', () => {
+      const profile = new ExportableProfile('Foo');
+      profile.parent = 'Observation';
+      const jurisdictionRule = new ExportableCaretValueRule('');
+      jurisdictionRule.caretPath = 'jurisdiction';
+      jurisdictionRule.value = new fshtypes.FshCode(
+        'MA',
+        'http://example.org/tests/CodeSystem/simple.codesystem'
+      );
+      profile.rules = [jurisdictionRule];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      optimizer.optimize(myPackage, fisher);
+
+      const expectedRule = cloneDeep(jurisdictionRule);
+      (expectedRule.value as fshtypes.FshCode).system = 'SimpleCodeSystem';
       expect(profile.rules[0]).toEqual(expectedRule);
     });
 
@@ -104,12 +206,31 @@ describe('optimizer', () => {
       profile.rules = [jurisdictionRule];
       const myPackage = new Package();
       myPackage.add(profile);
-      optimizer.optimize(myPackage, undefined, { alias: false });
+      optimizer.optimize(myPackage, fisher, { alias: false });
 
       expect(profile.rules[0]).toEqual(jurisdictionRule);
     });
 
-    it('should maintain the original value when it cannot be aliased', () => {
+    it('should use the name of a locally defined system in a CaretValueRule when alias is false', () => {
+      const profile = new ExportableProfile('Foo');
+      profile.parent = 'Observation';
+      const jurisdictionRule = new ExportableCaretValueRule('');
+      jurisdictionRule.caretPath = 'jurisdiction';
+      jurisdictionRule.value = new fshtypes.FshCode(
+        'MA',
+        'http://example.org/tests/CodeSystem/simple.codesystem'
+      );
+      profile.rules = [jurisdictionRule];
+      const myPackage = new Package();
+      myPackage.add(profile);
+      optimizer.optimize(myPackage, fisher, { alias: false });
+
+      const expectedRule = cloneDeep(jurisdictionRule);
+      (expectedRule.value as fshtypes.FshCode).system = 'SimpleCodeSystem';
+      expect(profile.rules[0]).toEqual(expectedRule);
+    });
+
+    it('should maintain the original value when it is not locally defined and cannot be aliased', () => {
       const profile = new ExportableProfile('Foo');
       profile.parent = 'Observation';
       const jurisdictionRule = new ExportableCaretValueRule('');
@@ -118,7 +239,7 @@ describe('optimizer', () => {
       profile.rules = [jurisdictionRule];
       const myPackage = new Package();
       myPackage.add(profile);
-      optimizer.optimize(myPackage);
+      optimizer.optimize(myPackage, fisher);
 
       expect(profile.rules[0]).toEqual(jurisdictionRule);
     });

--- a/test/optimizer/plugins/ResolveValueRuleURLsOptimizer.test.ts
+++ b/test/optimizer/plugins/ResolveValueRuleURLsOptimizer.test.ts
@@ -15,7 +15,7 @@ import { MasterFisher } from '../../../src/utils';
 import { loadTestDefinitions, stockLake } from '../../helpers';
 
 describe('optimizer', () => {
-  describe('#resolve_value_rule_system_system_urls_for_codes', () => {
+  describe('#resolve_value_rule_system_urls_for_codes', () => {
     let fisher: MasterFisher;
     beforeAll(() => {
       const defs = loadTestDefinitions();
@@ -24,7 +24,7 @@ describe('optimizer', () => {
     });
 
     it('should have appropriate metadata', () => {
-      expect(optimizer.name).toBe('resolve_value_rule_system_system_urls_for_codes');
+      expect(optimizer.name).toBe('resolve_value_rule_system_urls_for_codes');
       expect(optimizer.description).toBeDefined();
       expect(optimizer.runBefore).toBeUndefined();
       expect(optimizer.runAfter).toEqual([CombineCodingAndQuantityValuesOptimizer.name]);


### PR DESCRIPTION
Fixes #190 and completes task [CIMPL-989](https://standardhealthrecord.atlassian.net/browse/CIMPL-989).

A url for the system of an assigned code used in an AssignmentRule or CaretValueRule will be turned into the name of a locally defined CodeSystem when possible. A local name can be used regardless of the option to create aliases.

The existing `optimizeURL` function is used here, since it does exactly what we need.