### PR TITLE
Load the same automatic dependencies as SUSHI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "diff": "^5.0.0",
         "diff2html": "^3.1.18",
         "fhir": "^4.10.0",
-        "fhir-package-loader": "^0.3.0",
+        "fhir-package-loader": "^0.4.0",
         "flat": "^5.0.2",
         "fs-extra": "^9.0.1",
         "fsh-sushi": "^3.1.0",
@@ -2952,9 +2952,9 @@
       }
     },
     "node_modules/fhir-package-loader": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.3.0.tgz",
-      "integrity": "sha512-+S1jC8OxFWTeD6Ro+76/29Tk9ffIYIxpOvfEFu1qlnWLNzvTuTI7uM0RjOW79sD1TWv9XWaZRKTIPZooioMUbQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.4.0.tgz",
+      "integrity": "sha512-l7spvyZhSykRtcQkbmuZmsvqh+z31eyY1jVTW1dpE4gd6Ydk/0+rEt9imr2mvFPvRgneB0/GN2gOWfh0pxOoSQ==",
       "dependencies": {
         "axios": "^0.21.1",
         "chalk": "^4.1.2",
@@ -3368,6 +3368,72 @@
         "q": "^1.4.1",
         "randomatic": "^3.1.0",
         "xml-js": "^1.6.8"
+      }
+    },
+    "node_modules/fsh-sushi/node_modules/fhir-package-loader": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.3.0.tgz",
+      "integrity": "sha512-+S1jC8OxFWTeD6Ro+76/29Tk9ffIYIxpOvfEFu1qlnWLNzvTuTI7uM0RjOW79sD1TWv9XWaZRKTIPZooioMUbQ==",
+      "dependencies": {
+        "axios": "^0.21.1",
+        "chalk": "^4.1.2",
+        "commander": "^8.3.0",
+        "fs-extra": "^10.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "lodash": "^4.17.21",
+        "tar": "^5.0.11",
+        "temp": "^0.9.1",
+        "winston": "^3.3.3"
+      },
+      "bin": {
+        "fpl": "dist/app.js"
+      }
+    },
+    "node_modules/fsh-sushi/node_modules/fhir-package-loader/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/fsh-sushi/node_modules/fhir-package-loader/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/fsh-sushi/node_modules/fhir-package-loader/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/fsh-sushi/node_modules/fhir-package-loader/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/fsh-sushi/node_modules/fhir/node_modules/inherits": {
@@ -9252,9 +9318,9 @@
       }
     },
     "fhir-package-loader": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.3.0.tgz",
-      "integrity": "sha512-+S1jC8OxFWTeD6Ro+76/29Tk9ffIYIxpOvfEFu1qlnWLNzvTuTI7uM0RjOW79sD1TWv9XWaZRKTIPZooioMUbQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.4.0.tgz",
+      "integrity": "sha512-l7spvyZhSykRtcQkbmuZmsvqh+z31eyY1jVTW1dpE4gd6Ydk/0+rEt9imr2mvFPvRgneB0/GN2gOWfh0pxOoSQ==",
       "requires": {
         "axios": "^0.21.1",
         "chalk": "^4.1.2",
@@ -9560,6 +9626,57 @@
               "requires": {
                 "sax": "^1.2.4"
               }
+            }
+          }
+        },
+        "fhir-package-loader": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.3.0.tgz",
+          "integrity": "sha512-+S1jC8OxFWTeD6Ro+76/29Tk9ffIYIxpOvfEFu1qlnWLNzvTuTI7uM0RjOW79sD1TWv9XWaZRKTIPZooioMUbQ==",
+          "requires": {
+            "axios": "^0.21.1",
+            "chalk": "^4.1.2",
+            "commander": "^8.3.0",
+            "fs-extra": "^10.0.0",
+            "https-proxy-agent": "^5.0.0",
+            "lodash": "^4.17.21",
+            "tar": "^5.0.11",
+            "temp": "^0.9.1",
+            "winston": "^3.3.3"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+              "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+              }
+            },
+            "fs-extra": {
+              "version": "10.1.0",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+              "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+              "requires": {
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+              }
+            },
+            "jsonfile": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+              "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+              "requires": {
+                "graceful-fs": "^4.1.6",
+                "universalify": "^2.0.0"
+              }
+            },
+            "universalify": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
             }
           }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "diff": "^5.0.0",
         "diff2html": "^3.1.18",
         "fhir": "^4.10.0",
-        "fhir-package-loader": "^0.4.0",
+        "fhir-package-loader": "^0.5.0",
         "flat": "^5.0.2",
         "fs-extra": "^9.0.1",
         "fsh-sushi": "^3.1.0",
@@ -2952,9 +2952,9 @@
       }
     },
     "node_modules/fhir-package-loader": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.4.0.tgz",
-      "integrity": "sha512-l7spvyZhSykRtcQkbmuZmsvqh+z31eyY1jVTW1dpE4gd6Ydk/0+rEt9imr2mvFPvRgneB0/GN2gOWfh0pxOoSQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.5.0.tgz",
+      "integrity": "sha512-Q+W+l0jNLkpC2lUCIbtJ76P7xUvU3Bady/dcHo6f45q/CpFtvE9DyfeSNIGJZwpI72IIVZe5lvZ+lA58CGoVuA==",
       "dependencies": {
         "axios": "^0.21.1",
         "chalk": "^4.1.2",
@@ -2962,6 +2962,7 @@
         "fs-extra": "^10.0.0",
         "https-proxy-agent": "^5.0.0",
         "lodash": "^4.17.21",
+        "semver": "^7.5.4",
         "tar": "^5.0.11",
         "temp": "^0.9.1",
         "winston": "^3.3.3"
@@ -9318,9 +9319,9 @@
       }
     },
     "fhir-package-loader": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.4.0.tgz",
-      "integrity": "sha512-l7spvyZhSykRtcQkbmuZmsvqh+z31eyY1jVTW1dpE4gd6Ydk/0+rEt9imr2mvFPvRgneB0/GN2gOWfh0pxOoSQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.5.0.tgz",
+      "integrity": "sha512-Q+W+l0jNLkpC2lUCIbtJ76P7xUvU3Bady/dcHo6f45q/CpFtvE9DyfeSNIGJZwpI72IIVZe5lvZ+lA58CGoVuA==",
       "requires": {
         "axios": "^0.21.1",
         "chalk": "^4.1.2",
@@ -9328,6 +9329,7 @@
         "fs-extra": "^10.0.0",
         "https-proxy-agent": "^5.0.0",
         "lodash": "^4.17.21",
+        "semver": "^7.5.4",
         "tar": "^5.0.11",
         "temp": "^0.9.1",
         "winston": "^3.3.3"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "diff": "^5.0.0",
     "diff2html": "^3.1.18",
     "fhir": "^4.10.0",
-    "fhir-package-loader": "^0.3.0",
+    "fhir-package-loader": "^0.4.0",
     "flat": "^5.0.2",
     "fs-extra": "^9.0.1",
     "fsh-sushi": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "diff": "^5.0.0",
     "diff2html": "^3.1.18",
     "fhir": "^4.10.0",
-    "fhir-package-loader": "^0.4.0",
+    "fhir-package-loader": "^0.5.0",
     "flat": "^5.0.2",
     "fs-extra": "^9.0.1",
     "fsh-sushi": "^3.1.0",

--- a/src/api/FhirToFsh.ts
+++ b/src/api/FhirToFsh.ts
@@ -1,14 +1,13 @@
-import { fhirtypes, fshtypes, utils } from 'fsh-sushi';
+import { fshtypes, utils } from 'fsh-sushi';
 import {
-  determineCorePackageId,
   FHIRDefinitions,
   getResources,
   isProcessableContent,
-  loadExternalDependencies,
   MasterFisher,
   logger,
   errorsAndWarnings,
-  ErrorsAndWarnings
+  ErrorsAndWarnings,
+  loadExternalDependencies
 } from '../utils';
 import { FHIRProcessor, LakeOfFHIR, WildFHIR } from '../processor';
 import { FSHExporter } from '../export';
@@ -81,15 +80,7 @@ export async function fhirToFsh(
   );
 
   // Load dependencies, including those inferred from an IG file, and those given as input
-  const dependencies =
-    configuration.config.dependencies?.map(
-      (dep: fhirtypes.ImplementationGuideDependsOn) => `${dep.packageId}@${dep.version}`
-    ) ?? [];
-  const fhirPackageId = determineCorePackageId(configuration.config.fhirVersion[0]);
-  if (!dependencies.includes(`${fhirPackageId}@${configuration.config.fhirVersion[0]}`)) {
-    dependencies.push(`${fhirPackageId}@${configuration.config.fhirVersion[0]}`);
-  }
-  await Promise.all(loadExternalDependencies(defs, dependencies));
+  await loadExternalDependencies(defs, configuration);
 
   // Process the FHIR to rules, and then export to FSH
   const pkg = await getResources(processor, configuration, processingOptions);

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,22 +5,21 @@ import fs from 'fs-extra';
 import program from 'commander';
 import chalk from 'chalk';
 import { pad, padStart, padEnd } from 'lodash';
-import { fhirtypes, utils } from 'fsh-sushi';
+import { utils } from 'fsh-sushi';
 import {
-  determineCorePackageId,
   ensureOutputDir,
   FHIRDefinitions,
   getInputDir,
   getAliasFile,
   getFhirProcessor,
   getResources,
-  loadExternalDependencies,
   writeFSH,
   logger,
   stats,
   fshingTrip,
   getRandomPun,
-  ProcessingOptions
+  ProcessingOptions,
+  loadExternalDependencies
 } from './utils';
 import { Package, AliasProcessor } from './processor';
 import { ExportableAlias } from './exportable';
@@ -202,21 +201,7 @@ async function app() {
   const config = processor.processConfig(dependencies, specifiedFHIRVersion);
 
   // Load dependencies from config for GoFSH processing
-  const allDependencies =
-    config.config.dependencies?.map(
-      (dep: fhirtypes.ImplementationGuideDependsOn) => `${dep.packageId}@${dep.version}`
-    ) ?? [];
-  const fhirPackageId = determineCorePackageId(config.config.fhirVersion[0]);
-  allDependencies.push(`${fhirPackageId}@${config.config.fhirVersion[0]}`);
-  await utils.loadAutomaticDependencies(
-    config.config.fhirVersion[0],
-    config.config.dependencies ?? [],
-    // @ts-ignore TODO: this can be removed once SUSHI changes the type signature for this function to use FPL's FHIRDefinitions type
-    defs
-  );
-  const dependencyDefs = loadExternalDependencies(defs, allDependencies);
-
-  await Promise.all(dependencyDefs);
+  await loadExternalDependencies(defs, config);
 
   let pkg: Package;
   try {

--- a/src/app.ts
+++ b/src/app.ts
@@ -208,6 +208,12 @@ async function app() {
     ) ?? [];
   const fhirPackageId = determineCorePackageId(config.config.fhirVersion[0]);
   allDependencies.push(`${fhirPackageId}@${config.config.fhirVersion[0]}`);
+  await utils.loadAutomaticDependencies(
+    config.config.fhirVersion[0],
+    config.config.dependencies ?? [],
+    // @ts-ignore TODO: this can be removed once SUSHI changes the type signature for this function to use FPL's FHIRDefinitions type
+    defs
+  );
   const dependencyDefs = loadExternalDependencies(defs, allDependencies);
 
   await Promise.all(dependencyDefs);

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -122,7 +122,9 @@ export async function loadExternalDependencies(
       (dep: fhirtypes.ImplementationGuideDependsOn) => `${dep.packageId}@${dep.version}`
     ) ?? [];
   const fhirPackageId = determineCorePackageId(config.config.fhirVersion[0]);
-  allDependencies.push(`${fhirPackageId}@${config.config.fhirVersion[0]}`);
+  if (!allDependencies.includes(`${fhirPackageId}@${config.config.fhirVersion[0]}`)) {
+    allDependencies.push(`${fhirPackageId}@${config.config.fhirVersion[0]}`);
+  }
   await utils.loadAutomaticDependencies(
     config.config.fhirVersion[0],
     config.config.dependencies ?? [],

--- a/test/api/FhirToFsh.test.ts
+++ b/test/api/FhirToFsh.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import * as processing from '../../src/utils/Processing';
 import { fshtypes } from 'fsh-sushi';
-import { logger } from '../../src/utils';
+import { FHIRDefinitions, logger } from '../../src/utils';
 import { fhirToFsh, ResourceMap } from '../../src/api';
 import { loggerSpy } from '../helpers/loggerSpy';
 import { EOL } from 'os';
@@ -109,6 +109,30 @@ describe('fhirToFsh', () => {
     expect(results.warnings[0].message).toMatch('Could not determine FHIR version. Using 4.0.1.');
     expect(results.fsh).toEqual('');
     expect(results.configuration).toEqual(defaultConfig);
+  });
+
+  it('should try to load external dependencies', async () => {
+    await fhirToFsh([], {
+      dependencies: ['hl7.fhir.us.core#3.1.0', 'hl7.fhir.us.mcode@1.0.0']
+    });
+    expect(loadSpy).toHaveBeenCalledTimes(1);
+    expect(loadSpy).toHaveBeenCalledWith(
+      expect.any(FHIRDefinitions),
+      expect.objectContaining({
+        config: expect.objectContaining({
+          dependencies: [
+            {
+              packageId: 'hl7.fhir.us.core',
+              version: '3.1.0'
+            },
+            {
+              packageId: 'hl7.fhir.us.mcode',
+              version: '1.0.0'
+            }
+          ]
+        })
+      })
+    );
   });
 
   it('should parse a string input into JSON', async () => {

--- a/test/utils/Processing.test.ts
+++ b/test/utils/Processing.test.ts
@@ -580,6 +580,29 @@ describe('Processing', () => {
       expect(loadedPackages).toContain('hl7.terminology.r4#1.0.0');
       expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
     });
+
+    it('should not add the identified FHIR core package to the list of dependencies when it is already there', async () => {
+      const config = new ExportableConfiguration({
+        FSHOnly: true,
+        canonical: 'http://example.org',
+        fhirVersion: ['4.0.1'],
+        id: 'example',
+        name: 'Example',
+        applyExtensionMetadataToRoot: false,
+        dependencies: [
+          { packageId: 'hl7.fhir.us.core', version: '3.1.0' },
+          { packageId: 'hl7.fhir.r4.core', version: '4.0.1' }
+        ]
+      });
+      const defs = new FHIRDefinitions();
+      await loadExternalDependencies(defs, config);
+      // the core FHIR package is only present once in the list
+      expect(loadedPackages).toHaveLength(3);
+      expect(loadedPackages).toContain('hl7.fhir.r4.core#4.0.1');
+      expect(loadedPackages).toContain('hl7.fhir.us.core#3.1.0');
+      expect(loadedPackages).toContain('hl7.terminology.r4#1.0.0');
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(0);
+    });
   });
 
   describe('loadConfiguredDependencies', () => {


### PR DESCRIPTION
Completes task [CIMPL-1113](https://standardhealthrecord.atlassian.net/browse/CIMPL-1113).

Use SUSHI's function for loading automatic dependencies. There is a minor discrepancy in the expected type, but the FHIR definitions are only passed in so they can be passed to fhir-package-loader's mergeDependency function. So, the ts-ignore here should be safe. Add a note indicating the reason for the ts-ignore and the conditions under which it can be removed.