### PR TITLE
Extract more specific types in OnlyRules with target profiles

### DIFF
--- a/src/extractor/OnlyRuleExtractor.ts
+++ b/src/extractor/OnlyRuleExtractor.ts
@@ -1,3 +1,4 @@
+import { fshrules } from 'fsh-sushi';
 import { ProcessableElementDefinition } from '../processor';
 import { ExportableOnlyRule } from '../exportable';
 import { getPath } from '../utils';
@@ -9,9 +10,17 @@ export class OnlyRuleExtractor {
     }
     const onlyRule = new ExportableOnlyRule(getPath(input));
     input.type.forEach((t, i) => {
-      if (['Reference', 'CodeableReference'].includes(t.code) && t.targetProfile) {
+      if (['Reference', 'CodeableReference', 'canonical'].includes(t.code) && t.targetProfile) {
+        const targeting: Partial<fshrules.OnlyRuleType> = {};
+        if (t.code === 'Reference') {
+          targeting.isReference = true;
+        } else if (t.code === 'CodeableReference') {
+          targeting.isCodeableReference = true;
+        } else {
+          targeting.isCanonical = true;
+        }
         t.targetProfile.forEach((tp, tpi) => {
-          onlyRule.types.push({ type: tp, isReference: true });
+          onlyRule.types.push(Object.assign({ type: tp }, targeting));
           input.processedPaths.push(`type[${i}].targetProfile[${tpi}]`);
         });
       } else if (t.profile) {

--- a/test/extractor/fixtures/only-profile-with-codeablereference.json
+++ b/test/extractor/fixtures/only-profile-with-codeablereference.json
@@ -34,6 +34,71 @@
             "versioning": "either"
           }
         ]
+      },
+      {
+        "id": "CarePlan.extension:bar.value[x]",
+        "path": "CarePlan.extension:bar.value[x]",
+        "type": [
+          {
+            "code": "Reference",
+            "targetProfile": [
+              "http://hl7.org/fhir/StructureDefinition/Practitioner",
+              "http://hl7.org/fhir/StructureDefinition/Patient"
+            ]
+          },
+          {
+            "code": "CodeableReference",
+            "targetProfile": [
+              "http://hl7.org/fhir/StructureDefinition/Observation",
+              "http://hl7.org/fhir/StructureDefinition/DiagnosticReport"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "CarePlan.extension:cookie.value[x]",
+        "path": "CarePlan.extension:cookie.value[x]",
+        "type": [
+          {
+            "code": "string"
+          },
+          {
+            "code": "CodeableReference",
+            "targetProfile": [
+              "http://hl7.org/fhir/StructureDefinition/Observation",
+              "http://hl7.org/fhir/StructureDefinition/DiagnosticReport"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "CarePlan.extension:toast.value[x]",
+        "path": "CarePlan.extension:toast.value[x]",
+        "type": [
+          {
+            "code": "canonical",
+            "targetProfile": [
+              "http://hl7.org/fhir/StructureDefinition/Observation",
+              "http://hl7.org/fhir/StructureDefinition/Patient"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "CarePlan.extension:blank.value[x]",
+        "path": "CarePlan.extension:blank.value[x]",
+        "type": [
+          {
+            "code": "canonical",
+            "targetProfile": [
+              "http://hl7.org/fhir/StructureDefinition/Patient",
+              "http://hl7.org/fhir/StructureDefinition/Observation"
+            ]
+          },
+          {
+            "code": "Annotation"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
Fixes #220 and completes task [CIMPL-1100](https://standardhealthrecord.atlassian.net/browse/CIMPL-1100).

Reference, CodeableReference, and canonical types can all be specified with target profiles. When extracting an OnlyRule, set the corresponding boolean value on the extracted type along with the target profiles. This takes advantage of the newly available isCodeableReference flag on SUSHI's OnlyRuleType.

The changes in this PR ended up going a bit beyond the original task description, as I noticed that GoFSH was handling canonical types with target profiles by creating caret rules. But, everything appears to round-trip cleanly, so I thought it would be best to clean up all these types together.