### PR TITLE
Don't combine rules on inline ValueSet

### DIFF
--- a/src/optimizer/plugins/ConstructInlineInstanceOptimizer.ts
+++ b/src/optimizer/plugins/ConstructInlineInstanceOptimizer.ts
@@ -15,6 +15,7 @@ import AddReferenceKeywordOptimizer from './AddReferenceKeywordOptimizer';
 import SimplifyInstanceNameOptimizer from './SimplifyInstanceNameOptimizer';
 import { MasterFisher, logger, ProcessingOptions } from '../../utils';
 import { utils } from 'fsh-sushi';
+import CombineCodingAndQuantityValuesOptimizer from './CombineCodingAndQuantityValuesOptimizer';
 
 export default {
   name: 'construct_inline_instance',
@@ -24,7 +25,8 @@ export default {
     RemoveGeneratedTextRulesOptimizer.name,
     ResolveInstanceOfURLsOptimizer.name,
     AddReferenceKeywordOptimizer.name,
-    SimplifyInstanceNameOptimizer.name
+    SimplifyInstanceNameOptimizer.name,
+    CombineCodingAndQuantityValuesOptimizer.name
   ],
 
   optimize(pkg: Package, fisher: MasterFisher, options: ProcessingOptions = {}): void {

--- a/test/optimizer/plugins/ConstructInlineInstanceOptimizer.test.ts
+++ b/test/optimizer/plugins/ConstructInlineInstanceOptimizer.test.ts
@@ -20,6 +20,7 @@ import AddReferenceKeywordOptimizer from '../../../src/optimizer/plugins/AddRefe
 import SimplifyInstanceNameOptimizer from '../../../src/optimizer/plugins/SimplifyInstanceNameOptimizer';
 import { MasterFisher } from '../../../src/utils';
 import { loadTestDefinitions, stockLake } from '../../helpers';
+import { CombineCodingAndQuantityValuesOptimizer } from '../../../src/optimizer/plugins';
 
 describe('optimizer', () => {
   describe('#construct_inline_instance', () => {
@@ -71,7 +72,8 @@ describe('optimizer', () => {
           RemoveGeneratedTextRulesOptimizer.name,
           ResolveInstanceOfURLsOptimizer.name,
           AddReferenceKeywordOptimizer.name,
-          SimplifyInstanceNameOptimizer.name
+          SimplifyInstanceNameOptimizer.name,
+          CombineCodingAndQuantityValuesOptimizer.name
         ]);
         expect(optimizer.runAfter).toBeUndefined();
       });

--- a/test/utils/fixtures/contained-valueset/Observation-MyObs.json
+++ b/test/utils/fixtures/contained-valueset/Observation-MyObs.json
@@ -1,0 +1,36 @@
+{
+  "resourceType": "Observation",
+  "id": "MyObs",
+  "status": "final",
+  "code": {
+    "coding": [
+      {
+        "code": "something"
+      }
+    ]
+  },
+  "contained": [
+    {
+      "resourceType": "ValueSet",
+      "id": "MyInlineVS",
+      "status": "active",
+      "compose": {
+        "include": [
+          {
+            "system": "http://example.org",
+            "concept": [
+              {
+                "code": "123",
+                "display": "one two three"
+              },
+              {
+                "code": "456",
+                "display": "four five six"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #218 and completes task [CIMPL-1095](https://standardhealthrecord.atlassian.net/browse/CIMPL-1095).

Construct inline instances before combining coding and Quantity values. This way, rules that assign to elements in a ValueSet instance that shouldn't be combined will be correctly detected as having a type that does not use combined rules.