### PR TITLE
update SUSHI to v3.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "fhir-package-loader": "^0.5.0",
         "flat": "^5.0.2",
         "fs-extra": "^9.0.1",
-        "fsh-sushi": "^3.1.0",
+        "fsh-sushi": "^3.3.1",
         "ini": "^1.3.8",
         "lodash": "^4.17.21",
         "readline-sync": "^1.4.10",
@@ -3223,17 +3223,18 @@
       }
     },
     "node_modules/fsh-sushi": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.1.0.tgz",
-      "integrity": "sha512-vM0QgjXUU0atWMsQR90yVdQJmPf0MC46tNweWsMpLIrnJ7SAf/hXISkcVXmTNcEEyyw6F5sIgh2exo5TfOzpkw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.3.1.tgz",
+      "integrity": "sha512-k53bid9yAKUXlc46QD2387zXRMtJvrtt8M39GzLrHS1V9C89s7ZVRzdHHJzfOoWKJfrQEDD74DqjgaNwvzeUbA==",
+      "hasInstallScript": true,
       "dependencies": {
         "ajv": "^8.12.0",
-        "antlr4": "~4.9.3",
+        "antlr4": "~4.13.0",
         "axios": "^0.21.4",
         "chalk": "^3.0.0",
         "commander": "^8.2.0",
         "fhir": "^4.9.0",
-        "fhir-package-loader": "^0.3.0",
+        "fhir-package-loader": "^0.6.0",
         "fs-extra": "^8.1.0",
         "html-minifier-terser": "5.1.1",
         "https-proxy-agent": "^5.0.0",
@@ -3245,7 +3246,6 @@
         "sax": "^1.2.4",
         "temp": "^0.9.1",
         "title-case": "^3.0.2",
-        "tsconfig-paths": "^3.14.1",
         "valid-url": "^1.0.9",
         "winston": "^3.3.3",
         "yaml": "^1.9.2"
@@ -3253,11 +3253,6 @@
       "bin": {
         "sushi": "dist/app.js"
       }
-    },
-    "node_modules/fsh-sushi/node_modules/@types/json5": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
     },
     "node_modules/fsh-sushi/node_modules/ajv": {
       "version": "8.12.0",
@@ -3289,11 +3284,11 @@
       }
     },
     "node_modules/fsh-sushi/node_modules/antlr4": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.9.3.tgz",
-      "integrity": "sha512-qNy2odgsa0skmNMCuxzXhM4M8J1YDaPv3TI+vCdnOAanu0N982wBrSqziDKRDctEZLZy9VffqIZXc0UGjjSP/g==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.13.0.tgz",
+      "integrity": "sha512-zooUbt+UscjnWyOrsuY/tVFL4rwrAGwOivpQmvmUDE22hy/lUA467Rc1rcixyRwcRUIXFYBwv7+dClDSHdmmew==",
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/fsh-sushi/node_modules/chalk": {
@@ -3372,9 +3367,9 @@
       }
     },
     "node_modules/fsh-sushi/node_modules/fhir-package-loader": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.3.0.tgz",
-      "integrity": "sha512-+S1jC8OxFWTeD6Ro+76/29Tk9ffIYIxpOvfEFu1qlnWLNzvTuTI7uM0RjOW79sD1TWv9XWaZRKTIPZooioMUbQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.6.0.tgz",
+      "integrity": "sha512-rqO2Iiz7rCopNbPbEF59j4jOMScb5fCnf/gdgLFpsWvkGsnalbV/Q+T3E4bRPjdvwhuyZAoUJezwnvEfrQfnZg==",
       "dependencies": {
         "axios": "^0.21.1",
         "chalk": "^4.1.2",
@@ -3382,6 +3377,7 @@
         "fs-extra": "^10.0.0",
         "https-proxy-agent": "^5.0.0",
         "lodash": "^4.17.21",
+        "semver": "^7.5.4",
         "tar": "^5.0.11",
         "temp": "^0.9.1",
         "winston": "^3.3.3"
@@ -3585,11 +3581,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/fsh-sushi/node_modules/minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
-    },
     "node_modules/fsh-sushi/node_modules/pascal-case": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
@@ -3667,36 +3658,6 @@
       "integrity": "sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==",
       "dependencies": {
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/fsh-sushi/node_modules/tsconfig-paths": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-      "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
-      "dependencies": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      }
-    },
-    "node_modules/fsh-sushi/node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "node_modules/fsh-sushi/node_modules/tsconfig-paths/node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/fsh-sushi/node_modules/tslib": {
@@ -9468,17 +9429,17 @@
       "optional": true
     },
     "fsh-sushi": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.1.0.tgz",
-      "integrity": "sha512-vM0QgjXUU0atWMsQR90yVdQJmPf0MC46tNweWsMpLIrnJ7SAf/hXISkcVXmTNcEEyyw6F5sIgh2exo5TfOzpkw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.3.1.tgz",
+      "integrity": "sha512-k53bid9yAKUXlc46QD2387zXRMtJvrtt8M39GzLrHS1V9C89s7ZVRzdHHJzfOoWKJfrQEDD74DqjgaNwvzeUbA==",
       "requires": {
         "ajv": "^8.12.0",
-        "antlr4": "~4.9.3",
+        "antlr4": "~4.13.0",
         "axios": "^0.21.4",
         "chalk": "^3.0.0",
         "commander": "^8.2.0",
         "fhir": "^4.9.0",
-        "fhir-package-loader": "^0.3.0",
+        "fhir-package-loader": "^0.6.0",
         "fs-extra": "^8.1.0",
         "html-minifier-terser": "5.1.1",
         "https-proxy-agent": "^5.0.0",
@@ -9490,17 +9451,11 @@
         "sax": "^1.2.4",
         "temp": "^0.9.1",
         "title-case": "^3.0.2",
-        "tsconfig-paths": "^3.14.1",
         "valid-url": "^1.0.9",
         "winston": "^3.3.3",
         "yaml": "^1.9.2"
       },
       "dependencies": {
-        "@types/json5": {
-          "version": "0.0.29",
-          "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-          "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="
-        },
         "ajv": {
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
@@ -9521,9 +9476,9 @@
           }
         },
         "antlr4": {
-          "version": "4.9.3",
-          "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.9.3.tgz",
-          "integrity": "sha512-qNy2odgsa0skmNMCuxzXhM4M8J1YDaPv3TI+vCdnOAanu0N982wBrSqziDKRDctEZLZy9VffqIZXc0UGjjSP/g=="
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.13.0.tgz",
+          "integrity": "sha512-zooUbt+UscjnWyOrsuY/tVFL4rwrAGwOivpQmvmUDE22hy/lUA467Rc1rcixyRwcRUIXFYBwv7+dClDSHdmmew=="
         },
         "chalk": {
           "version": "3.0.0",
@@ -9632,9 +9587,9 @@
           }
         },
         "fhir-package-loader": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.3.0.tgz",
-          "integrity": "sha512-+S1jC8OxFWTeD6Ro+76/29Tk9ffIYIxpOvfEFu1qlnWLNzvTuTI7uM0RjOW79sD1TWv9XWaZRKTIPZooioMUbQ==",
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/fhir-package-loader/-/fhir-package-loader-0.6.0.tgz",
+          "integrity": "sha512-rqO2Iiz7rCopNbPbEF59j4jOMScb5fCnf/gdgLFpsWvkGsnalbV/Q+T3E4bRPjdvwhuyZAoUJezwnvEfrQfnZg==",
           "requires": {
             "axios": "^0.21.1",
             "chalk": "^4.1.2",
@@ -9642,6 +9597,7 @@
             "fs-extra": "^10.0.0",
             "https-proxy-agent": "^5.0.0",
             "lodash": "^4.17.21",
+            "semver": "^7.5.4",
             "tar": "^5.0.11",
             "temp": "^0.9.1",
             "winston": "^3.3.3"
@@ -9754,11 +9710,6 @@
           "resolved": "https://registry.npmjs.org/junk/-/junk-3.1.0.tgz",
           "integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ=="
         },
-        "minimist": {
-          "version": "1.2.6",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
-        },
         "pascal-case": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
@@ -9828,32 +9779,6 @@
           "integrity": "sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==",
           "requires": {
             "tslib": "^2.0.3"
-          }
-        },
-        "tsconfig-paths": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz",
-          "integrity": "sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==",
-          "requires": {
-            "@types/json5": "^0.0.29",
-            "json5": "^1.0.1",
-            "minimist": "^1.2.6",
-            "strip-bom": "^3.0.0"
-          },
-          "dependencies": {
-            "json5": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-              "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-              "requires": {
-                "minimist": "^1.2.0"
-              }
-            },
-            "strip-bom": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-              "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="
-            }
           }
         },
         "tslib": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "fhir-package-loader": "^0.5.0",
     "flat": "^5.0.2",
     "fs-extra": "^9.0.1",
-    "fsh-sushi": "^3.1.0",
+    "fsh-sushi": "^3.3.1",
     "ini": "^1.3.8",
     "lodash": "^4.17.21",
     "readline-sync": "^1.4.10",


### PR DESCRIPTION
Completes task [CIMPL-1151](https://standardhealthrecord.atlassian.net/browse/CIMPL-1151)

This gets GoFSH up-to-date with SUSHI in preparation for updating both in FSH Online. Note that this does _not_ update the `antlr4` dependency which was updated in SUSHI. GoFSH's usage of `antlr4` is sufficiently limited that it makes sense to wait until the performance improvement in `antlr4` is available, at which point the dependency will be updated in both SUSHI and GoFSH.