### PR TITLE
Extract extension contexts to keyword

### DIFF
--- a/src/extractor/CaretValueRuleExtractor.ts
+++ b/src/extractor/CaretValueRuleExtractor.ts
@@ -119,6 +119,12 @@ export class CaretValueRuleExtractor {
       parent = cloneDeep(sd);
     }
 
+    // if this is an Extension, ignore context, since it was covered by a keyword
+    if (sd.derivation === 'constraint' && sd.type === 'Extension') {
+      delete sd.context;
+      delete parent.context;
+    }
+
     // Remove properties that are covered by other extractors or keywords
     RESOURCE_IGNORED_PROPERTIES['StructureDefinition'].forEach(prop => {
       delete sd[prop];

--- a/src/optimizer/plugins/RemoveDefaultExtensionContextRulesOptimizer.ts
+++ b/src/optimizer/plugins/RemoveDefaultExtensionContextRulesOptimizer.ts
@@ -1,37 +1,22 @@
 import { OptimizerPlugin } from '../OptimizerPlugin';
 import { Package } from '../../processor';
-import { ExportableCaretValueRule } from '../../exportable';
-import { isEqual, pullAt } from 'lodash';
-import { fshtypes } from 'fsh-sushi';
-const { FshCode } = fshtypes;
+import { isEqual } from 'lodash';
 
 export default {
   name: 'remove_default_extension_context_rules',
   description: 'Remove extension contexts matching the default context that SUSHI generates',
 
   optimize(pkg: Package): void {
-    // * ^context[0].type = #element
-    const DEFAULT_TYPE = new ExportableCaretValueRule('');
-    DEFAULT_TYPE.caretPath = 'context[0].type';
-    DEFAULT_TYPE.value = new FshCode('element');
-    // * ^context[0].expression = "Element"
-    const DEFAULT_EXPRESSION = new ExportableCaretValueRule('');
-    DEFAULT_EXPRESSION.caretPath = 'context[0].expression';
-    DEFAULT_EXPRESSION.value = 'Element';
     // Loop through extensions looking for the default context type (and removing it)
     pkg.extensions.forEach(sd => {
-      const numContexts = sd.rules.filter(
-        r =>
-          r instanceof ExportableCaretValueRule &&
-          r.path === '' &&
-          /^context\[\d+]\.type$/.test(r.caretPath)
-      ).length;
-      if (numContexts === 1) {
-        const typeRuleIdx = sd.rules.findIndex(r => isEqual(r, DEFAULT_TYPE));
-        const expressionRuleIdx = sd.rules.findIndex(r => isEqual(r, DEFAULT_EXPRESSION));
-        if (typeRuleIdx !== -1 && expressionRuleIdx !== -1) {
-          pullAt(sd.rules, [typeRuleIdx, expressionRuleIdx]);
-        }
+      if (
+        sd.contexts?.length === 1 &&
+        isEqual(sd.contexts[0], {
+          value: 'Element',
+          isQuoted: false
+        })
+      ) {
+        sd.contexts = [];
       }
     });
   }

--- a/src/optimizer/plugins/ResolveContextURLsOptimizer.ts
+++ b/src/optimizer/plugins/ResolveContextURLsOptimizer.ts
@@ -1,0 +1,59 @@
+import { utils } from 'fsh-sushi';
+import { OptimizerPlugin } from '../OptimizerPlugin';
+import { optimizeURL } from '../utils';
+import { Package } from '../../processor';
+import { MasterFisher, ProcessingOptions } from '../../utils';
+import { isUri } from 'valid-url';
+
+const FISHER_TYPES = [
+  utils.Type.Resource,
+  utils.Type.Type,
+  utils.Type.Profile,
+  utils.Type.Extension,
+  utils.Type.Logical
+];
+
+export default {
+  name: 'resolve_context_urls',
+  description: 'Replace declared extension context URLs with their names or aliases',
+
+  optimize(pkg: Package, fisher: MasterFisher, options: ProcessingOptions = {}): void {
+    for (const extension of pkg.extensions) {
+      if (extension.contexts) {
+        extension.contexts.forEach(context => {
+          if (!context.isQuoted) {
+            // if the context is an extension, value is just a url without a #
+            // if the context is an element of a non-core resource, value is a url, #, and a path
+            if (context.value.indexOf('#') > -1) {
+              const [url, path] = context.value.split('#');
+              const newUrl = optimizeURL(
+                url,
+                pkg.aliases,
+                FISHER_TYPES,
+                fisher,
+                options.alias ?? true
+              );
+              if (newUrl !== url) {
+                let separator: string;
+                if (newUrl.startsWith('$')) {
+                  separator = '#';
+                } else {
+                  separator = '.';
+                }
+                context.value = `${newUrl}${separator}${path}`;
+              }
+            } else if (isUri(context.value)) {
+              context.value = optimizeURL(
+                context.value,
+                pkg.aliases,
+                FISHER_TYPES,
+                fisher,
+                options.alias ?? true
+              );
+            }
+          }
+        });
+      }
+    }
+  }
+} as OptimizerPlugin;

--- a/src/optimizer/plugins/index.ts
+++ b/src/optimizer/plugins/index.ts
@@ -15,6 +15,7 @@ import RemoveGeneratedTextRulesOptimizer from './RemoveGeneratedTextRulesOptimiz
 import RemoveImpliedZeroZeroCardRulesOptimize from './RemoveImpliedZeroZeroCardRulesOptimizer';
 import RemovePublisherDerivedDateRulesOptimizer from './RemovePublisherDerivedDateRulesOptimizer';
 import ResolveBindingRuleURLsOptimizer from './ResolveBindingRuleURLsOptimizer';
+import ResolveContextURLsOptimizer from './ResolveContextURLsOptimizer';
 import ResolveInstanceOfURLsOptimizer from './ResolveInstanceOfURLsOptimizer';
 import ResolveOnlyRuleURLsOptimizer from './ResolveOnlyRuleURLsOptimizer';
 import ResolveParentURLsOptimizer from './ResolveParentURLsOptimizer';
@@ -45,6 +46,7 @@ export {
   RemoveImpliedZeroZeroCardRulesOptimize,
   RemovePublisherDerivedDateRulesOptimizer,
   ResolveBindingRuleURLsOptimizer,
+  ResolveContextURLsOptimizer,
   ResolveInstanceOfURLsOptimizer,
   ResolveOnlyRuleURLsOptimizer,
   ResolveParentURLsOptimizer,

--- a/src/optimizer/utils.ts
+++ b/src/optimizer/utils.ts
@@ -26,7 +26,7 @@ export function optimizeURL(
 
 /**
  * Resolves a URL to a name, if possible; otherwise returns undefined. If the URL resolves to a name,
- * but the name does not resolve back to the same URL, then return udnefined since the name clashes with
+ * but the name does not resolve back to the same URL, then return undefined since the name clashes with
  * a more preferred name. This can happen if a project defines something with the same name as a FHIR
  * definition.
  * @param url - the url to resolve

--- a/test/extractor/CaretValueRuleExtractor.test.ts
+++ b/test/extractor/CaretValueRuleExtractor.test.ts
@@ -15,6 +15,7 @@ describe('CaretValueRuleExtractor', () => {
   let looseCS: any;
   let looseBSSD: any;
   let looseTPESD: any;
+  let looseExtSD: any;
   let config: fshtypes.Configuration;
   let defs: FHIRDefinitions;
 
@@ -48,6 +49,11 @@ describe('CaretValueRuleExtractor', () => {
         )
         .trim()
     );
+    looseExtSD = JSON.parse(
+      fs
+        .readFileSync(path.join(__dirname, 'fixtures', 'extension-with-context.json'), 'utf-8')
+        .trim()
+    );
   });
 
   beforeEach(() => {
@@ -57,6 +63,15 @@ describe('CaretValueRuleExtractor', () => {
   describe('StructureDefinition', () => {
     it('should not extract any SD caret rules when only keyword-based properties have changed', () => {
       const caretRules = CaretValueRuleExtractor.processStructureDefinition(looseSD, defs, config);
+      expect(caretRules).toEqual<ExportableCaretValueRule[]>([]);
+    });
+
+    it('should not extract any SD caret rules for context on an Extension', () => {
+      const caretRules = CaretValueRuleExtractor.processStructureDefinition(
+        looseExtSD,
+        defs,
+        config
+      );
       expect(caretRules).toEqual<ExportableCaretValueRule[]>([]);
     });
 

--- a/test/extractor/fixtures/extension-with-context.json
+++ b/test/extractor/fixtures/extension-with-context.json
@@ -1,0 +1,34 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "ExtensionWithContext",
+  "url": "http://hl7.org/fhir/sushi-test/StructureDefinition/ExtensionWithContext",
+  "name": "ExtensionWithContext",
+  "fhirVersion": "4.0.1",
+  "mapping": [
+    {
+      "identity": "rim",
+      "uri": "http://hl7.org/v3",
+      "name": "RIM Mapping"
+    }
+  ],
+  "kind": "complex-type",
+  "abstract": false,
+  "context": [
+    {
+      "expression": "some.fhirpath",
+      "type": "fhirpath"
+    }
+  ],
+  "type": "Extension",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Extension.url",
+        "path": "Extension.url",
+        "fixedUri": "http://hl7.org/fhir/sushi-test/StructureDefinition/ExtensionWithContext"
+      }
+    ]
+  }
+}

--- a/test/optimizer/plugins/RemoveDefaultExtensionContextRulesOptimizer.test.ts
+++ b/test/optimizer/plugins/RemoveDefaultExtensionContextRulesOptimizer.test.ts
@@ -1,13 +1,7 @@
 import '../../helpers/loggerSpy'; // side-effect: suppresses logs
 import { Package } from '../../../src/processor/Package';
-import {
-  ExportableCaretValueRule,
-  ExportableExtension,
-  ExportableProfile
-} from '../../../src/exportable';
+import { ExportableExtension } from '../../../src/exportable';
 import optimizer from '../../../src/optimizer/plugins/RemoveDefaultExtensionContextRulesOptimizer';
-import { fshtypes } from 'fsh-sushi';
-const { FshCode } = fshtypes;
 
 describe('optimizer', () => {
   describe('#remove_default_extension_context_rules', () => {
@@ -20,84 +14,32 @@ describe('optimizer', () => {
 
     it('should remove default context from extensions', () => {
       const extension = new ExportableExtension('ExtraExtension');
-      const typeRule = new ExportableCaretValueRule('');
-      typeRule.caretPath = 'context[0].type';
-      typeRule.value = new FshCode('element');
-      const expressionRule = new ExportableCaretValueRule('');
-      expressionRule.caretPath = 'context[0].expression';
-      expressionRule.value = 'Element';
-      extension.rules = [typeRule, expressionRule];
+      extension.contexts = [{ value: 'Element', isQuoted: false }];
       const myPackage = new Package();
       myPackage.add(extension);
       optimizer.optimize(myPackage);
-      expect(extension.rules).toHaveLength(0);
+      expect(extension.contexts).toHaveLength(0);
     });
 
-    it('should not remove non-default context from extensions (different type)', () => {
+    it('should not remove non-default context from extensions', () => {
       const extension = new ExportableExtension('ExtraExtension');
-      const typeRule = new ExportableCaretValueRule('');
-      typeRule.caretPath = 'context[0].type';
-      typeRule.value = new FshCode('fhirpath');
-      const expressionRule = new ExportableCaretValueRule('');
-      expressionRule.caretPath = 'context[0].expression';
-      expressionRule.value = 'Element';
-      extension.rules = [typeRule, expressionRule];
+      extension.contexts = [{ value: 'Observation', isQuoted: false }];
       const myPackage = new Package();
       myPackage.add(extension);
       optimizer.optimize(myPackage);
-      expect(extension.rules).toHaveLength(2);
-    });
-
-    it('should not remove non-default context from extensions (different expression)', () => {
-      const extension = new ExportableExtension('ExtraExtension');
-      const typeRule = new ExportableCaretValueRule('');
-      typeRule.caretPath = 'context[0].type';
-      typeRule.value = new FshCode('element');
-      const expressionRule = new ExportableCaretValueRule('');
-      expressionRule.caretPath = 'context[0].expression';
-      expressionRule.value = 'BackboneElement';
-      extension.rules = [typeRule, expressionRule];
-      const myPackage = new Package();
-      myPackage.add(extension);
-      optimizer.optimize(myPackage);
-      expect(extension.rules).toHaveLength(2);
+      expect(extension.contexts).toHaveLength(1);
     });
 
     it('should not remove default context from extensions when there is more than one context', () => {
       const extension = new ExportableExtension('ExtraExtension');
-      const typeRule = new ExportableCaretValueRule('');
-      typeRule.caretPath = 'context[0].type';
-      typeRule.value = new FshCode('element');
-      const expressionRule = new ExportableCaretValueRule('');
-      expressionRule.caretPath = 'context[0].expression';
-      expressionRule.value = 'Element';
-      const typeRule2 = new ExportableCaretValueRule('');
-      typeRule2.caretPath = 'context[1].type';
-      typeRule2.value = new FshCode('element');
-      const expressionRule2 = new ExportableCaretValueRule('');
-      expressionRule2.caretPath = 'context[1].expression';
-      expressionRule2.value = 'CodeSystem';
-      extension.rules = [typeRule, expressionRule, typeRule2, expressionRule2];
+      extension.contexts = [
+        { value: 'Element', isQuoted: false },
+        { value: 'Observation', isQuoted: false }
+      ];
       const myPackage = new Package();
       myPackage.add(extension);
       optimizer.optimize(myPackage);
-      expect(extension.rules).toHaveLength(4);
-    });
-
-    it('should not remove default context from profiles', () => {
-      // Technically, I don't think having context on a profile is allowed, but check just in case
-      const profile = new ExportableProfile('ExtraProfile');
-      const typeRule = new ExportableCaretValueRule('');
-      typeRule.caretPath = 'context[0].type';
-      typeRule.value = new FshCode('element');
-      const expressionRule = new ExportableCaretValueRule('');
-      expressionRule.caretPath = 'context[0].expression';
-      expressionRule.value = 'Element';
-      profile.rules = [typeRule, expressionRule];
-      const myPackage = new Package();
-      myPackage.add(profile);
-      optimizer.optimize(myPackage);
-      expect(profile.rules).toHaveLength(2);
+      expect(extension.contexts).toHaveLength(2);
     });
   });
 });

--- a/test/optimizer/plugins/ResolveContextURLsOptimizer.test.ts
+++ b/test/optimizer/plugins/ResolveContextURLsOptimizer.test.ts
@@ -64,7 +64,7 @@ describe('optimizer', () => {
       ]);
     });
 
-    it('should replace an unquoted context with a resource name and no path when the context value is a URL of a known resource no path', () => {
+    it('should replace an unquoted context with a resource name and no path when the context value is a URL of a known resource with no path', () => {
       const extension = new ExportableExtension('MyExtension');
       extension.contexts = [
         {
@@ -133,7 +133,7 @@ describe('optimizer', () => {
       ]);
     });
 
-    it('should not change an unquoted context when the context value is a URL of an unknown resource with a path and the alias option is false', () => {
+    it('should not change an unquoted context when the context value is a URL of an unknown resource with no path and the alias option is false', () => {
       const extension = new ExportableExtension('MyExtension');
       extension.contexts = [
         {
@@ -153,7 +153,7 @@ describe('optimizer', () => {
       expect(myPackage.aliases).toEqual([]);
     });
 
-    it('should not change an unquoted context when the context value is a URL of an unknown resource and the alias option is false', () => {
+    it('should not change an unquoted context when the context value is a URL of an unknown resource with a path and the alias option is false', () => {
       const extension = new ExportableExtension('MyExtension');
       extension.contexts = [
         {

--- a/test/optimizer/plugins/ResolveContextURLsOptimizer.test.ts
+++ b/test/optimizer/plugins/ResolveContextURLsOptimizer.test.ts
@@ -1,0 +1,195 @@
+import path from 'path';
+import '../../helpers/loggerSpy'; // side-effect: suppresses logs
+import { Package } from '../../../src/processor';
+import { MasterFisher } from '../../../src/utils';
+import { loadTestDefinitions, stockLake } from '../../helpers';
+import optimizer from '../../../src/optimizer/plugins/ResolveContextURLsOptimizer';
+import { ExportableExtension } from '../../../src/exportable';
+
+describe('optimizer', () => {
+  describe('#resolve_context_urls', () => {
+    let fisher: MasterFisher;
+
+    beforeAll(() => {
+      const defs = loadTestDefinitions();
+      const lake = stockLake(
+        path.join(__dirname, 'fixtures', 'small-extension.json'),
+        path.join(__dirname, 'fixtures', 'small-profile.json')
+      );
+      fisher = new MasterFisher(lake, defs);
+    });
+
+    it('should have appropriate metadata', () => {
+      expect(optimizer.name).toBe('resolve_context_urls');
+      expect(optimizer.description).toBeDefined();
+      expect(optimizer.runBefore).toBeUndefined();
+      expect(optimizer.runAfter).toBeUndefined();
+    });
+
+    it('should replace an unquoted context with an extension name when the context value is the URL of a known extension', () => {
+      const extension = new ExportableExtension('MyExtension');
+      extension.contexts = [
+        {
+          isQuoted: false,
+          value: 'https://demo.org/StructureDefinition/SmallExtension'
+        }
+      ];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      optimizer.optimize(myPackage, fisher);
+      expect(extension.contexts).toEqual([
+        {
+          isQuoted: false,
+          value: 'SmallExtension'
+        }
+      ]);
+    });
+
+    it('should replace an unquoted context with a resource name and element path when the context value is a URL of a known resource with a path', () => {
+      const extension = new ExportableExtension('MyExtension');
+      extension.contexts = [
+        {
+          isQuoted: false,
+          value: 'https://demo.org/StructureDefinition/SmallPatient#name'
+        }
+      ];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      optimizer.optimize(myPackage, fisher);
+      expect(extension.contexts).toEqual([
+        {
+          isQuoted: false,
+          value: 'SmallPatient.name'
+        }
+      ]);
+    });
+
+    it('should replace an unquoted context with a resource name and no path when the context value is a URL of a known resource no path', () => {
+      const extension = new ExportableExtension('MyExtension');
+      extension.contexts = [
+        {
+          isQuoted: false,
+          value: 'https://demo.org/StructureDefinition/SmallPatient'
+        }
+      ];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      optimizer.optimize(myPackage, fisher);
+      expect(extension.contexts).toEqual([
+        {
+          isQuoted: false,
+          value: 'SmallPatient'
+        }
+      ]);
+    });
+
+    it('should replace an unquoted context with an alias when the context value is a URL of an unknown resource', () => {
+      const extension = new ExportableExtension('MyExtension');
+      extension.contexts = [
+        {
+          isQuoted: false,
+          value: 'https://demo.org/StructureDefinition/MysteriousExtension'
+        }
+      ];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      optimizer.optimize(myPackage, fisher);
+      expect(extension.contexts).toEqual([
+        {
+          isQuoted: false,
+          value: '$MysteriousExtension'
+        }
+      ]);
+      expect(myPackage.aliases).toEqual([
+        {
+          alias: '$MysteriousExtension',
+          url: 'https://demo.org/StructureDefinition/MysteriousExtension'
+        }
+      ]);
+    });
+
+    it('should replace an unquoted context with an alias and path when the context value is a URL of an unknown resource with a path', () => {
+      const extension = new ExportableExtension('MyExtension');
+      extension.contexts = [
+        {
+          isQuoted: false,
+          value: 'https://demo.org/StructureDefinition/UnknownObservation#method'
+        }
+      ];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      optimizer.optimize(myPackage, fisher);
+      expect(extension.contexts).toEqual([
+        {
+          isQuoted: false,
+          value: '$UnknownObservation#method'
+        }
+      ]);
+      expect(myPackage.aliases).toEqual([
+        {
+          alias: '$UnknownObservation',
+          url: 'https://demo.org/StructureDefinition/UnknownObservation'
+        }
+      ]);
+    });
+
+    it('should not change an unquoted context when the context value is a URL of an unknown resource with a path and the alias option is false', () => {
+      const extension = new ExportableExtension('MyExtension');
+      extension.contexts = [
+        {
+          isQuoted: false,
+          value: 'https://demo.org/StructureDefinition/MysteriousExtension'
+        }
+      ];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      optimizer.optimize(myPackage, fisher, { alias: false });
+      expect(extension.contexts).toEqual([
+        {
+          isQuoted: false,
+          value: 'https://demo.org/StructureDefinition/MysteriousExtension'
+        }
+      ]);
+      expect(myPackage.aliases).toEqual([]);
+    });
+
+    it('should not change an unquoted context when the context value is a URL of an unknown resource and the alias option is false', () => {
+      const extension = new ExportableExtension('MyExtension');
+      extension.contexts = [
+        {
+          isQuoted: false,
+          value: 'https://demo.org/StructureDefinition/UnknownObservation#Observation.method'
+        }
+      ];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      optimizer.optimize(myPackage, fisher, { alias: false });
+      expect(extension.contexts).toEqual([
+        {
+          isQuoted: false,
+          value: 'https://demo.org/StructureDefinition/UnknownObservation#Observation.method'
+        }
+      ]);
+      expect(myPackage.aliases).toEqual([]);
+    });
+
+    it('should not change a quoted context', () => {
+      const extension = new ExportableExtension('MyExtension');
+      extension.contexts = [
+        {
+          isQuoted: true,
+          value: 'some.fhirpath("expression")'
+        }
+      ];
+      const myPackage = new Package();
+      myPackage.add(extension);
+      optimizer.optimize(myPackage, fisher);
+      expect(extension.contexts).toEqual([
+        {
+          isQuoted: true,
+          value: 'some.fhirpath("expression")'
+        }
+      ]);
+    });
+  });
+});

--- a/test/processor/StructureDefinitionProcessor.test.ts
+++ b/test/processor/StructureDefinitionProcessor.test.ts
@@ -305,6 +305,32 @@ describe('StructureDefinitionProcessor', () => {
       expect(workingExtension.description).toBe('This is my new Extension. Thank you.');
     });
 
+    it('should get context for an Extension with context', () => {
+      const input = JSON.parse(
+        fs.readFileSync(path.join(__dirname, 'fixtures', 'extension-with-context.json'), 'utf-8')
+      );
+      const workingExtension = new ExportableExtension(input.name);
+      StructureDefinitionProcessor.extractKeywords(input, workingExtension);
+      expect(workingExtension.contexts).toEqual([
+        {
+          value: 'some.fhirpath',
+          isQuoted: true
+        },
+        {
+          value: 'Observation.valueString',
+          isQuoted: false
+        },
+        {
+          value: 'http://hl7.org/fhir/sushi-test/StructureDefinition/MyObservation#valueBoolean',
+          isQuoted: false
+        },
+        {
+          value: 'http://hl7.org/fhir/sushi-test/StructureDefinition/AnotherExtension',
+          isQuoted: false
+        }
+      ]);
+    });
+
     it('should get keywords for a Resource with simple metadata', () => {
       const input = JSON.parse(
         fs.readFileSync(path.join(__dirname, 'fixtures', 'metadata-resource.json'), 'utf-8')

--- a/test/processor/fixtures/extension-with-context.json
+++ b/test/processor/fixtures/extension-with-context.json
@@ -1,0 +1,46 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "ExtensionWithContext",
+  "url": "http://hl7.org/fhir/sushi-test/StructureDefinition/ExtensionWithContext",
+  "name": "ExtensionWithContext",
+  "fhirVersion": "4.0.1",
+  "mapping": [
+    {
+      "identity": "rim",
+      "uri": "http://hl7.org/v3",
+      "name": "RIM Mapping"
+    }
+  ],
+  "kind": "complex-type",
+  "abstract": false,
+  "context": [
+    {
+      "expression": "some.fhirpath",
+      "type": "fhirpath"
+    },
+    {
+      "expression": "Observation.value[x]:valueString",
+      "type": "element"
+    },
+    {
+      "expression": "http://hl7.org/fhir/sushi-test/StructureDefinition/MyObservation#Observation.value[x]:valueBoolean",
+      "type": "element"
+    },
+    {
+      "expression": "http://hl7.org/fhir/sushi-test/StructureDefinition/AnotherExtension",
+      "type": "extension"
+    }
+  ],
+  "type": "Extension",
+  "baseDefinition": "http://hl7.org/fhir/StructureDefinition/Extension",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Extension.url",
+        "path": "Extension.url",
+        "fixedUri": "http://hl7.org/fhir/sushi-test/StructureDefinition/ExtensionWithContext"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Completes #234 and task [CIMPL-1163](https://standardhealthrecord.atlassian.net/browse/CIMPL-1163).

When processing an Extension definition, set the contexts directly on the ExportableExtension object. When doing so, convert paths back to FSH-style paths. When extracting caret value rules on an Extension definition, do not extract any rules for contexts.

Add optimizer plugin to resolve URLs in contexts.

This ended up being a bit simpler than I had anticipated in regards to differentiating between core and non-core resources. Since SUSHI does the hard work of actually resolving contexts, GoFSH gets to use the name of anything that it can fish up, no matter where it came from.