### PR TITLE
Update to SUSHI 3.5.0 and bump to v2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gofsh",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gofsh",
-      "version": "2.1.2",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "antlr4": "~4.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "fhir-package-loader": "^0.5.0",
         "flat": "^5.0.2",
         "fs-extra": "^9.0.1",
-        "fsh-sushi": "^3.4.0",
+        "fsh-sushi": "^3.5.0",
         "ini": "^1.3.8",
         "lodash": "^4.17.21",
         "readline-sync": "^1.4.10",
@@ -3223,13 +3223,12 @@
       }
     },
     "node_modules/fsh-sushi": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.4.0.tgz",
-      "integrity": "sha512-F07kXHydr1FM2elL7RT9lY7xRkGH9LXD6Qzl19ZRS15gXuPid/0xkRF5qn4h4skQIkZQqdZtQxgW0dTwn6pXdg==",
-      "hasInstallScript": true,
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.5.0.tgz",
+      "integrity": "sha512-Qd5ka92bwbWlH5fSYbFVZRTNn3QO+moXnARn2jCZ+S2veYDfkwkIys6BOUSQV6e0unm98zkk/DMmDHohhA0Z3A==",
       "dependencies": {
         "ajv": "^8.12.0",
-        "antlr4": "~4.13.0",
+        "antlr4": "~4.13.1",
         "axios": "^0.21.4",
         "chalk": "^3.0.0",
         "commander": "^8.2.0",
@@ -3284,9 +3283,9 @@
       }
     },
     "node_modules/fsh-sushi/node_modules/antlr4": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.13.0.tgz",
-      "integrity": "sha512-zooUbt+UscjnWyOrsuY/tVFL4rwrAGwOivpQmvmUDE22hy/lUA467Rc1rcixyRwcRUIXFYBwv7+dClDSHdmmew==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.13.1.tgz",
+      "integrity": "sha512-kiXTspaRYvnIArgE97z5YVVf/cDVQABr3abFRR6mE7yesLMkgu4ujuyV/sgxafQ8wgve0DJQUJ38Z8tkgA2izA==",
       "engines": {
         "node": ">=16"
       }
@@ -9429,12 +9428,12 @@
       "optional": true
     },
     "fsh-sushi": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.4.0.tgz",
-      "integrity": "sha512-F07kXHydr1FM2elL7RT9lY7xRkGH9LXD6Qzl19ZRS15gXuPid/0xkRF5qn4h4skQIkZQqdZtQxgW0dTwn6pXdg==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.5.0.tgz",
+      "integrity": "sha512-Qd5ka92bwbWlH5fSYbFVZRTNn3QO+moXnARn2jCZ+S2veYDfkwkIys6BOUSQV6e0unm98zkk/DMmDHohhA0Z3A==",
       "requires": {
         "ajv": "^8.12.0",
-        "antlr4": "~4.13.0",
+        "antlr4": "~4.13.1",
         "axios": "^0.21.4",
         "chalk": "^3.0.0",
         "commander": "^8.2.0",
@@ -9476,9 +9475,9 @@
           }
         },
         "antlr4": {
-          "version": "4.13.0",
-          "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.13.0.tgz",
-          "integrity": "sha512-zooUbt+UscjnWyOrsuY/tVFL4rwrAGwOivpQmvmUDE22hy/lUA467Rc1rcixyRwcRUIXFYBwv7+dClDSHdmmew=="
+          "version": "4.13.1",
+          "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.13.1.tgz",
+          "integrity": "sha512-kiXTspaRYvnIArgE97z5YVVf/cDVQABr3abFRR6mE7yesLMkgu4ujuyV/sgxafQ8wgve0DJQUJ38Z8tkgA2izA=="
         },
         "chalk": {
           "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gofsh",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "description": "GoFSH is a FHIR Shorthand (FSH) decompiler, able to convert formal FHIR definitions from JSON to FSH.",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "fhir-package-loader": "^0.5.0",
     "flat": "^5.0.2",
     "fs-extra": "^9.0.1",
-    "fsh-sushi": "^3.4.0",
+    "fsh-sushi": "^3.5.0",
     "ini": "^1.3.8",
     "lodash": "^4.17.21",
     "readline-sync": "^1.4.10",


### PR DESCRIPTION
This PR preps for the next GoFSH release by bumping GoFSH to the next minor version and using the latest SUSHI version.