### PR TITLE
Track code caret rules when simplifying array indexing

### DIFF
--- a/test/optimizer/plugins/SimplifyArrayIndexingOptimizer.test.ts
+++ b/test/optimizer/plugins/SimplifyArrayIndexingOptimizer.test.ts
@@ -6,7 +6,8 @@ import {
   ExportableInstance,
   ExportableProfile,
   ExportableLogical,
-  ExportableResource
+  ExportableResource,
+  ExportableCodeSystem
 } from '../../../src/exportable';
 import optimizer from '../../../src/optimizer/plugins/SimplifyArrayIndexingOptimizer';
 
@@ -166,6 +167,67 @@ describe('optimizer', () => {
       expect(optimizedCaretRules[1].caretPath).toBe('contact[=].phone');
       expect(optimizedCaretRules[2].caretPath).toBe('contact[=].email');
       expect(optimizedCaretRules[3].caretPath).toBe('contact[+].phone');
+    });
+
+    it('should apply soft indexing on caret paths on concepts for a CodeSystem', () => {
+      const codeSystem = new ExportableCodeSystem('MyCS');
+
+      // const bread = new ExportableConceptRule('bread');
+      const breadProperty = new ExportableCaretValueRule('');
+      breadProperty.isCodeCaretRule = true;
+      breadProperty.pathArray = ['bread'];
+      breadProperty.caretPath = 'property[0].code';
+      const breadLanguage = new ExportableCaretValueRule('');
+      breadLanguage.isCodeCaretRule = true;
+      breadLanguage.pathArray = ['bread'];
+      breadLanguage.caretPath = 'designation[0].language';
+      const breadUse = new ExportableCaretValueRule('');
+      breadUse.isCodeCaretRule = true;
+      breadUse.pathArray = ['bread'];
+      breadUse.caretPath = 'designation[0].use';
+
+      // const cake = new ExportableConceptRule('cake');
+      const cakeLanguage0 = new ExportableCaretValueRule('');
+      cakeLanguage0.isCodeCaretRule = true;
+      cakeLanguage0.pathArray = ['cake'];
+      cakeLanguage0.caretPath = 'designation[0].language';
+      const cakeUse0 = new ExportableCaretValueRule('');
+      cakeUse0.isCodeCaretRule = true;
+      cakeUse0.pathArray = ['cake'];
+      cakeUse0.caretPath = 'designation[0].use';
+      const cakeLanguage1 = new ExportableCaretValueRule('');
+      cakeLanguage1.isCodeCaretRule = true;
+      cakeLanguage1.pathArray = ['cake'];
+      cakeLanguage1.caretPath = 'designation[1].language';
+      const cakeUse1 = new ExportableCaretValueRule('');
+      cakeUse1.isCodeCaretRule = true;
+      cakeUse1.pathArray = ['cake'];
+      cakeUse1.caretPath = 'designation[1].use';
+
+      codeSystem.rules.push(
+        // bread,
+        breadProperty,
+        breadLanguage,
+        breadUse,
+        // cake,
+        cakeLanguage0,
+        cakeUse0,
+        cakeLanguage1,
+        cakeUse1
+      );
+
+      const myPackage = new Package();
+      myPackage.add(codeSystem);
+      optimizer.optimize(myPackage);
+
+      const optimizedCaretRules = myPackage.codeSystems[0].rules as ExportableCaretValueRule[];
+      expect(optimizedCaretRules[0].caretPath).toBe('property.code');
+      expect(optimizedCaretRules[1].caretPath).toBe('designation[0].language');
+      expect(optimizedCaretRules[2].caretPath).toBe('designation[=].use');
+      expect(optimizedCaretRules[3].caretPath).toBe('designation[0].language');
+      expect(optimizedCaretRules[4].caretPath).toBe('designation[=].use');
+      expect(optimizedCaretRules[5].caretPath).toBe('designation[+].language');
+      expect(optimizedCaretRules[6].caretPath).toBe('designation[=].use');
     });
   });
 });


### PR DESCRIPTION
Fixes #245 and completes task [CIMPL-1190](https://standardhealthrecord.atlassian.net/browse/CIMPL-1190).

A code caret rule will have an empty path and a non-empty path array. Track them using the path array so that caret paths receive the correct soft indices.

Additionally, update the optimizer to use the now-correct SUSHI functions for path operations.