### PR TITLE
v2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gofsh",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gofsh",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "antlr4": "~4.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "fhir-package-loader": "^0.5.0",
         "flat": "^5.0.2",
         "fs-extra": "^9.0.1",
-        "fsh-sushi": "^3.6.0",
+        "fsh-sushi": "^3.6.1",
         "ini": "^1.3.8",
         "lodash": "^4.17.21",
         "readline-sync": "^1.4.10",
@@ -3214,9 +3214,9 @@
       }
     },
     "node_modules/fsh-sushi": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.6.0.tgz",
-      "integrity": "sha512-G6JLb3FTnVrUkFppXzhUGDJcD0s3pljlS5iq+0P1UIvOxI+pR9qKVTZXELh2vDf4tDwNUkIiK33AD+njHKihJg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.6.1.tgz",
+      "integrity": "sha512-pLaUIGbErhUU63WUz25HRQQLuDZpcTyh+o7pFGOjbg6AO7wg0o3Rw3AiPEYCw8Ciy4ezEfF3hiJI4J8FBkWR0g==",
       "dependencies": {
         "ajv": "^8.12.0",
         "antlr4": "~4.13.1",
@@ -9257,9 +9257,9 @@
       "optional": true
     },
     "fsh-sushi": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.6.0.tgz",
-      "integrity": "sha512-G6JLb3FTnVrUkFppXzhUGDJcD0s3pljlS5iq+0P1UIvOxI+pR9qKVTZXELh2vDf4tDwNUkIiK33AD+njHKihJg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.6.1.tgz",
+      "integrity": "sha512-pLaUIGbErhUU63WUz25HRQQLuDZpcTyh+o7pFGOjbg6AO7wg0o3Rw3AiPEYCw8Ciy4ezEfF3hiJI4J8FBkWR0g==",
       "requires": {
         "ajv": "^8.12.0",
         "antlr4": "~4.13.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "fhir-package-loader": "^0.5.0",
     "flat": "^5.0.2",
     "fs-extra": "^9.0.1",
-    "fsh-sushi": "^3.6.0",
+    "fsh-sushi": "^3.6.1",
     "ini": "^1.3.8",
     "lodash": "^4.17.21",
     "readline-sync": "^1.4.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gofsh",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "GoFSH is a FHIR Shorthand (FSH) decompiler, able to convert formal FHIR definitions from JSON to FSH.",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Completes task [CIMPL-1208](https://standardhealthrecord.atlassian.net/browse/CIMPL-1208).

A SUSHI patch was recently released, so this also updates the dependency to include that patch.