### PR TITLE
Create Aliases with supported characters (and warn on provided unsupported aliases)

### DIFF
--- a/src/optimizer/utils.ts
+++ b/src/optimizer/utils.ts
@@ -11,6 +11,8 @@ import {
   ExportableAlias
 } from '../exportable';
 
+const unsupportedAliasCharRegex = /[^a-zA-z0-9_\-\.]/g;
+
 export function optimizeURL(
   url: string,
   aliases: ExportableAlias[],
@@ -101,6 +103,9 @@ export function resolveAliasFromURL(url: string, aliases: ExportableAlias[]): st
       counterPart += 1;
       alias = `${aliasPart}_${counterPart}`;
     }
+
+    // Replace unsupported characters, but allow $ at the start
+    alias = `$${alias.substring(1).replace(unsupportedAliasCharRegex, '-')}`;
 
     aliases.push(new ExportableAlias(alias, url));
     return alias;

--- a/src/processor/AliasProcessor.ts
+++ b/src/processor/AliasProcessor.ts
@@ -8,6 +8,8 @@ import { InputStream, CommonTokenStream } from 'antlr4';
 import FSHLexer from 'fsh-sushi/dist/import/generated/FSHLexer';
 import FSHParser from 'fsh-sushi/dist/import/generated/FSHParser';
 
+const aliasRegex = /^\$?[a-zA-z0-9_\-\.]*$/;
+
 export class AliasProcessor {
   static process(aliasFile: string): ExportableAlias[] {
     // Load aliases from alias-file option.
@@ -61,6 +63,10 @@ export class AliasProcessor {
             `Alias ${name} cannot include "|" since the "|" character is reserved for indicating a version`
           );
           return;
+        } else if (!aliasRegex.test(name)) {
+          logger.warn(
+            `Alias ${name} includes unsupported characters. Alias names can only contain letters, numbers, underscores ("_"), hyphens ("-"), and dots (".").`
+          );
         }
         if (aliases.has(name) && aliases.get(name) !== value) {
           logger.error(

--- a/test/optimizer/utils.test.ts
+++ b/test/optimizer/utils.test.ts
@@ -218,6 +218,18 @@ describe('optimizer', () => {
           url: 'http://example.org/bar/foo'
         });
       });
+
+      it('should ensure newly created aliases only use allowed characters', () => {
+        const originalLength = aliases.length;
+        expect(resolveAliasFromURL('http://example.org/foo-bar_3.1~te$t', aliases)).toBe(
+          '$foo-bar_3.1-te-t'
+        );
+        expect(aliases).toHaveLength(originalLength + 1);
+        expect(aliases[aliases.length - 1]).toEqual({
+          alias: '$foo-bar_3.1-te-t',
+          url: 'http://example.org/foo-bar_3.1~te$t'
+        });
+      });
     });
   });
 });

--- a/test/processor/AliasProcessor.test.ts
+++ b/test/processor/AliasProcessor.test.ts
@@ -88,11 +88,16 @@ describe('AliasProcessor', () => {
     it('should log errors for invalid aliases', () => {
       const aliasFile = path.join(__dirname, 'fixtures', 'invalid-alias.fsh');
       const result = AliasProcessor.process(aliasFile);
-      expect(result).toHaveLength(2);
+      expect(result).toHaveLength(3);
+      expect(loggerSpy.getAllMessages('error')).toHaveLength(2);
       expect(loggerSpy.getMessageAtIndex(0, 'error')).toMatch(
         /Alias \$not\|valid cannot include "\|"/s
       );
       expect(loggerSpy.getMessageAtIndex(1, 'error')).toMatch(/Alias \$valid cannot be redefined/s);
+      expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
+      expect(loggerSpy.getLastMessage('warn')).toMatch(
+        /Alias \$valid~ish includes unsupported characters/
+      );
     });
   });
 });

--- a/test/processor/fixtures/invalid-alias.fsh
+++ b/test/processor/fixtures/invalid-alias.fsh
@@ -6,3 +6,5 @@ Alias: $not|valid = http://example.org/CodeSystem/not-valid
 Alias: somethingGood = http://example.org/ValueSet/something-good
 // this alias is invalid, since it is already defined
 Alias: $valid = http://example.org/already-defined
+// this alias is valid, but it has unsupported characters
+Alias: $valid~ish = http://example.org/sort-of-valid


### PR DESCRIPTION
This PR updates that aliases that GoFSH creates to ensure that only supported characters are included in the Alias name. To do this, I replaced any unsupported character with `-`. The PR also makes it so that when provided Aliases use unsupported characters, GoFSH logs the same warning that SUSHI now does.

I couldn't figure out a more elegant way to ignore the leading `$` in alias names with the regex, so if I missed something obvious, I'm happy to make the regex ignore that character so the full replacement can be done with `alias.replace(...)`