### PR TITLE
Do not create blank alias names + Update ANTLR

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "antlr4": "~4.8.0",
+        "antlr4": "~4.13.1-patch-1",
         "chalk": "^4.1.0",
         "commander": "^6.0.0",
         "diff": "^5.0.0",
@@ -1873,9 +1873,12 @@
       }
     },
     "node_modules/antlr4": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.8.0.tgz",
-      "integrity": "sha512-en/MxQ4OkPgGJQ3wD/muzj1uDnFSzdFIhc2+c6bHZokWkuBb6RRvFjpWhPxWLbgQvaEzldJZ0GSQpfSAaE3hqg=="
+      "version": "4.13.1-patch-1",
+      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.13.1-patch-1.tgz",
+      "integrity": "sha512-OjFLWWLzDMV9rdFhpvroCWR4ooktNg9/nvVYSA5z28wuVpU36QUNuioR1XLnQtcjVlf8npjyz593PxnU/f/Cow==",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
@@ -8320,9 +8323,9 @@
       }
     },
     "antlr4": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.8.0.tgz",
-      "integrity": "sha512-en/MxQ4OkPgGJQ3wD/muzj1uDnFSzdFIhc2+c6bHZokWkuBb6RRvFjpWhPxWLbgQvaEzldJZ0GSQpfSAaE3hqg=="
+      "version": "4.13.1-patch-1",
+      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.13.1-patch-1.tgz",
+      "integrity": "sha512-OjFLWWLzDMV9rdFhpvroCWR4ooktNg9/nvVYSA5z28wuVpU36QUNuioR1XLnQtcjVlf8npjyz593PxnU/f/Cow=="
     },
     "anymatch": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "antlr4": "~4.8.0",
+    "antlr4": "~4.13.1-patch-1",
     "chalk": "^4.1.0",
     "commander": "^6.0.0",
     "diff": "^5.0.0",

--- a/src/optimizer/utils.ts
+++ b/src/optimizer/utils.ts
@@ -88,7 +88,7 @@ export function resolveAliasFromURL(url: string, aliases: ExportableAlias[]): st
     const parsedURL = new URL(url);
     const rawAlias =
       parsedURL.pathname && parsedURL.pathname !== '/'
-        ? parsedURL.pathname?.split('/').slice(-1)[0]
+        ? parsedURL.pathname?.split('/').slice(parsedURL.pathname.endsWith('/') ? -2 : -1)[0]
         : parsedURL.hostname?.replace('www.', '').split('.')[0];
 
     if (rawAlias == null) {

--- a/test/optimizer/utils.test.ts
+++ b/test/optimizer/utils.test.ts
@@ -230,6 +230,16 @@ describe('optimizer', () => {
           url: 'http://example.org/foo-bar_3.1~te$t'
         });
       });
+
+      it('should ensure newly created aliases are not ONLY $', () => {
+        const originalLength = aliases.length;
+        expect(resolveAliasFromURL('http://example.org/foo-bar/', aliases)).toBe('$foo-bar');
+        expect(aliases).toHaveLength(originalLength + 1);
+        expect(aliases[aliases.length - 1]).toEqual({
+          alias: '$foo-bar',
+          url: 'http://example.org/foo-bar/'
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
This PR makes a small update to no longer create empty string Alias names. This would happen when a URL that GoFSH tried to make an alias for ended in a `/`, such as `http://example.org/test/url/`. If the URL was just `http://example.org/`, GoFSH already properly handled using the hostname as an alias instead.

I also combined this with updating to the same ANTLR version that SUSHI is using, `4.13.1-patch-1`, because the update didn't require any code changes. I'm happy to separate these out if that is preferred. I ran the tests, and they still work with the new antlr version, and there were no changes when running this branch on US Core.