### PR TITLE
Warn when temporal primitive is not formatted correctly

### DIFF
--- a/src/extractor/AssignmentRuleExtractor.ts
+++ b/src/extractor/AssignmentRuleExtractor.ts
@@ -1,7 +1,7 @@
 import { fhirtypes, fshtypes } from 'fsh-sushi';
 import { ProcessableElementDefinition } from '../processor';
 import { ExportableAssignmentRule } from '../exportable';
-import { getPath } from '../utils';
+import { dateRegex, dateTimeRegex, getPath, instantRegex, timeRegex, logger } from '../utils';
 import { fshifyString } from '../exportable/common';
 
 export class AssignmentRuleExtractor {
@@ -28,6 +28,31 @@ export class AssignmentRuleExtractor {
             assignmentRule.value = BigInt(matchingValue);
           } else {
             assignmentRule.value = matchingValue;
+            if (matchingKey.endsWith('DateTime')) {
+              if (!dateTimeRegex.test(matchingValue)) {
+                logger.warn(
+                  `Value ${matchingValue} on element ${assignmentRule.path} is not a valid FHIR dateTime`
+                );
+              }
+            } else if (matchingKey.endsWith('Date')) {
+              if (!dateRegex.test(matchingValue)) {
+                logger.warn(
+                  `Value ${matchingValue} on element ${assignmentRule.path} is not a valid FHIR date`
+                );
+              }
+            } else if (matchingKey.endsWith('Time')) {
+              if (!timeRegex.test(matchingValue)) {
+                logger.warn(
+                  `Value ${matchingValue} on element ${assignmentRule.path} is not a valid FHIR time`
+                );
+              }
+            } else if (matchingKey.endsWith('Instant')) {
+              if (!instantRegex.test(matchingValue)) {
+                logger.warn(
+                  `Value ${matchingValue} on element ${assignmentRule.path} is not a valid FHIR instant`
+                );
+              }
+            }
           }
         } else {
           assignmentRule.value = matchingValue;

--- a/src/extractor/AssignmentRuleExtractor.ts
+++ b/src/extractor/AssignmentRuleExtractor.ts
@@ -5,7 +5,10 @@ import { dateRegex, dateTimeRegex, getPath, instantRegex, timeRegex, logger } fr
 import { fshifyString } from '../exportable/common';
 
 export class AssignmentRuleExtractor {
-  static process(input: ProcessableElementDefinition): ExportableAssignmentRule[] {
+  static process(
+    input: ProcessableElementDefinition,
+    entityName: string
+  ): ExportableAssignmentRule[] {
     // check for fixedSomething or patternSomething
     // pattern and fixed are mutually exclusive
     // these are on one-type elements, so if our SD has value[x],
@@ -31,25 +34,25 @@ export class AssignmentRuleExtractor {
             if (matchingKey.endsWith('DateTime')) {
               if (!dateTimeRegex.test(matchingValue)) {
                 logger.warn(
-                  `Value ${matchingValue} on element ${assignmentRule.path} is not a valid FHIR dateTime`
+                  `Value ${matchingValue} on ${entityName} element ${assignmentRule.path} is not a valid FHIR dateTime`
                 );
               }
             } else if (matchingKey.endsWith('Date')) {
               if (!dateRegex.test(matchingValue)) {
                 logger.warn(
-                  `Value ${matchingValue} on element ${assignmentRule.path} is not a valid FHIR date`
+                  `Value ${matchingValue} on ${entityName} element ${assignmentRule.path} is not a valid FHIR date`
                 );
               }
             } else if (matchingKey.endsWith('Time')) {
               if (!timeRegex.test(matchingValue)) {
                 logger.warn(
-                  `Value ${matchingValue} on element ${assignmentRule.path} is not a valid FHIR time`
+                  `Value ${matchingValue} on ${entityName} element ${assignmentRule.path} is not a valid FHIR time`
                 );
               }
             } else if (matchingKey.endsWith('Instant')) {
               if (!instantRegex.test(matchingValue)) {
                 logger.warn(
-                  `Value ${matchingValue} on element ${assignmentRule.path} is not a valid FHIR instant`
+                  `Value ${matchingValue} on ${entityName} element ${assignmentRule.path} is not a valid FHIR instant`
                 );
               }
             }

--- a/src/extractor/CaretValueRuleExtractor.ts
+++ b/src/extractor/CaretValueRuleExtractor.ts
@@ -24,10 +24,17 @@ export class CaretValueRuleExtractor {
     const remainingFlatElementArray = flatElementArray.filter(
       ([key]) => !input.processedPaths.includes(key)
     );
+    const entityPath = path === '' ? structDef.name : `${structDef.name}.${path}`;
     remainingFlatElementArray.forEach(([key], i) => {
       const caretValueRule = new ExportableCaretValueRule(path);
       caretValueRule.caretPath = key;
-      caretValueRule.value = getFSHValue(i, remainingFlatElementArray, 'ElementDefinition', fisher);
+      caretValueRule.value = getFSHValue(
+        i,
+        remainingFlatElementArray,
+        'ElementDefinition',
+        entityPath,
+        fisher
+      );
       // If the value is empty, we can't use it. Log an error and give up on trying to use this key.
       if (isFSHValueEmpty(caretValueRule.value)) {
         logger.error(
@@ -207,7 +214,7 @@ export class CaretValueRuleExtractor {
         }
         const caretValueRule = new ExportableCaretValueRule('');
         caretValueRule.caretPath = key;
-        caretValueRule.value = getFSHValue(i, flatArray, 'StructureDefinition', fisher);
+        caretValueRule.value = getFSHValue(i, flatArray, 'StructureDefinition', input.name, fisher);
         if (isFSHValueEmpty(caretValueRule.value)) {
           logger.error(
             `Value in StructureDefinition ${input.name} for element ${key} is empty. No caret value rule will be created.`
@@ -241,7 +248,13 @@ export class CaretValueRuleExtractor {
       }
       const caretValueRule = new ExportableCaretValueRule('');
       caretValueRule.caretPath = key;
-      caretValueRule.value = getFSHValue(i, flatArray, resourceType, fisher);
+      caretValueRule.value = getFSHValue(
+        i,
+        flatArray,
+        resourceType,
+        input.name ?? input.id,
+        fisher
+      );
       if (isFSHValueEmpty(caretValueRule.value)) {
         logger.error(
           `Value in ${resourceType} ${
@@ -272,7 +285,7 @@ export class CaretValueRuleExtractor {
     flatArray.forEach(([key], i) => {
       const caretValueRule = new ExportableCaretValueRule('');
       caretValueRule.caretPath = key;
-      caretValueRule.value = getFSHValue(i, flatArray, 'Concept', fisher);
+      caretValueRule.value = getFSHValue(i, flatArray, 'Concept', entityName, fisher);
       caretValueRule.isCodeCaretRule = true;
       caretValueRule.pathArray = [...pathArray];
       if (isFSHValueEmpty(caretValueRule.value)) {

--- a/src/extractor/CaretValueRuleExtractor.ts
+++ b/src/extractor/CaretValueRuleExtractor.ts
@@ -285,7 +285,13 @@ export class CaretValueRuleExtractor {
     flatArray.forEach(([key], i) => {
       const caretValueRule = new ExportableCaretValueRule('');
       caretValueRule.caretPath = key;
-      caretValueRule.value = getFSHValue(i, flatArray, 'Concept', entityName, fisher);
+      caretValueRule.value = getFSHValue(
+        i,
+        flatArray,
+        'Concept',
+        `${entityName} ${pathArray.join('.')}`,
+        fisher
+      );
       caretValueRule.isCodeCaretRule = true;
       caretValueRule.pathArray = [...pathArray];
       if (isFSHValueEmpty(caretValueRule.value)) {

--- a/src/processor/InstanceProcessor.ts
+++ b/src/processor/InstanceProcessor.ts
@@ -114,7 +114,7 @@ export class InstanceProcessor {
         i,
         flatInstanceArray,
         instanceOfJSON.type,
-        target.name,
+        target.id,
         fisher
       );
       // if the value is empty, we can't use that

--- a/src/processor/InstanceProcessor.ts
+++ b/src/processor/InstanceProcessor.ts
@@ -114,7 +114,7 @@ export class InstanceProcessor {
         i,
         flatInstanceArray,
         instanceOfJSON.type,
-        target.id,
+        `${target.instanceOf} ${target.id}`,
         fisher
       );
       // if the value is empty, we can't use that

--- a/src/processor/InstanceProcessor.ts
+++ b/src/processor/InstanceProcessor.ts
@@ -110,7 +110,13 @@ export class InstanceProcessor {
     const flatInstanceArray = toPairs(getPathValuePairs(inputJSON));
     flatInstanceArray.forEach(([path], i) => {
       const assignmentRule = new ExportableAssignmentRule(path);
-      assignmentRule.value = getFSHValue(i, flatInstanceArray, instanceOfJSON.type, fisher);
+      assignmentRule.value = getFSHValue(
+        i,
+        flatInstanceArray,
+        instanceOfJSON.type,
+        target.name,
+        fisher
+      );
       // if the value is empty, we can't use that
       if (isFSHValueEmpty(assignmentRule.value)) {
         logger.error(

--- a/src/processor/StructureDefinitionProcessor.ts
+++ b/src/processor/StructureDefinitionProcessor.ts
@@ -225,13 +225,13 @@ export class StructureDefinitionProcessor {
         newRules.push(
           BindingRuleExtractor.process(element),
           ObeysRuleExtractor.process(element),
-          ...AssignmentRuleExtractor.process(element)
+          ...AssignmentRuleExtractor.process(element, target.name)
         );
       } else if (isNewSlice) {
         newRules.push(
           ContainsRuleExtractor.process(element, input, fisher),
           OnlyRuleExtractor.process(element),
-          ...AssignmentRuleExtractor.process(element),
+          ...AssignmentRuleExtractor.process(element, target.name),
           BindingRuleExtractor.process(element),
           ObeysRuleExtractor.process(element)
         );
@@ -239,7 +239,7 @@ export class StructureDefinitionProcessor {
         newRules.push(
           CardRuleExtractor.process(element, input, fisher),
           OnlyRuleExtractor.process(element),
-          ...AssignmentRuleExtractor.process(element),
+          ...AssignmentRuleExtractor.process(element, target.name),
           FlagRuleExtractor.process(element),
           BindingRuleExtractor.process(element),
           ObeysRuleExtractor.process(element)

--- a/src/utils/element.ts
+++ b/src/utils/element.ts
@@ -86,6 +86,7 @@ export function getFSHValue(
   index: number,
   flatArray: [string, string | number | boolean][],
   resourceType: string,
+  resourceName: string,
   fisher: utils.Fishable
 ): number | boolean | string | fshtypes.FshCode | bigint {
   const [key, value] = flatArray[index];
@@ -103,23 +104,31 @@ export function getFSHValue(
     return BigInt(value);
   } else if (type === 'dateTime') {
     if (!dateTimeRegex.test(value.toString())) {
-      logger.warn(`Value ${value.toString()} on element ${key} is not a valid FHIR dateTime`);
+      logger.warn(
+        `Value ${value.toString()} on ${resourceName} element ${key} is not a valid FHIR dateTime`
+      );
     }
     return value;
   } else if (type === 'date') {
     if (!dateRegex.test(value.toString())) {
-      logger.warn(`Value ${value.toString()} on element ${key} is not a valid FHIR date`);
+      logger.warn(
+        `Value ${value.toString()} on ${resourceName} element ${key} is not a valid FHIR date`
+      );
     }
     return value;
   } else if (type === 'time') {
     if (!timeRegex.test(value.toString())) {
-      logger.warn(`Value ${value.toString()} on element ${key} is not a valid FHIR time`);
+      logger.warn(
+        `Value ${value.toString()} on ${resourceName} element ${key} is not a valid FHIR time`
+      );
     }
     return value;
   } else if (type === 'instant') {
     typeCache.get(resourceType).set(pathWithoutIndex, 'instant');
     if (!instantRegex.test(value.toString())) {
-      logger.warn(`Value ${value.toString()} on element ${key} is not a valid FHIR instant`);
+      logger.warn(
+        `Value ${value.toString()} on ${resourceName} element ${key} is not a valid FHIR instant`
+      );
     }
     return value;
   } else if (type) {
@@ -150,9 +159,10 @@ export function getFSHValue(
       ]) as [string, string | number | boolean][];
     const containedResourceType = subArray.find(([key]) => key === 'resourceType')?.[1] as string;
     const newIndex = subArray.findIndex(([key]) => key === newKey);
+    const containedResourceName = `${resourceName}.${baseKey}`;
 
     // Get the FSH value based on the contained resource type. Use paths relative to the contained resource.
-    return getFSHValue(newIndex, subArray, containedResourceType, fisher);
+    return getFSHValue(newIndex, subArray, containedResourceType, containedResourceName, fisher);
   }
   if (!typeCache.has(resourceType)) {
     typeCache.set(resourceType, new Map());
@@ -170,25 +180,33 @@ export function getFSHValue(
   } else if (element?.type?.[0]?.code === 'dateTime') {
     typeCache.get(resourceType).set(pathWithoutIndex, 'dateTime');
     if (!dateTimeRegex.test(value.toString())) {
-      logger.warn(`Value ${value.toString()} on element ${key} is not a valid FHIR dateTime`);
+      logger.warn(
+        `Value ${value.toString()} on ${resourceName} element ${key} is not a valid FHIR dateTime`
+      );
     }
     return value;
   } else if (element?.type?.[0]?.code === 'date') {
     typeCache.get(resourceType).set(pathWithoutIndex, 'date');
     if (!dateRegex.test(value.toString())) {
-      logger.warn(`Value ${value.toString()} on element ${key} is not a valid FHIR date`);
+      logger.warn(
+        `Value ${value.toString()} on ${resourceName} element ${key} is not a valid FHIR date`
+      );
     }
     return value;
   } else if (element?.type?.[0]?.code === 'time') {
     typeCache.get(resourceType).set(pathWithoutIndex, 'time');
     if (!timeRegex.test(value.toString())) {
-      logger.warn(`Value ${value.toString()} on element ${key} is not a valid FHIR time`);
+      logger.warn(
+        `Value ${value.toString()} on ${resourceName} element ${key} is not a valid FHIR time`
+      );
     }
     return value;
   } else if (element?.type?.[0]?.code === 'instant') {
     typeCache.get(resourceType).set(pathWithoutIndex, 'instant');
     if (!instantRegex.test(value.toString())) {
-      logger.warn(`Value ${value.toString()} on element ${key} is not a valid FHIR instant`);
+      logger.warn(
+        `Value ${value.toString()} on ${resourceName} element ${key} is not a valid FHIR instant`
+      );
     }
     return value;
   } else {

--- a/test/extractor/AssignmentRuleExtractor.test.ts
+++ b/test/extractor/AssignmentRuleExtractor.test.ts
@@ -13,6 +13,7 @@ describe('AssignmentRuleExtractor', () => {
 
   describe('#simple-values', () => {
     let looseSD: any;
+    const entityName = 'AssignedValueObservation';
 
     beforeAll(() => {
       looseSD = JSON.parse(
@@ -24,7 +25,7 @@ describe('AssignmentRuleExtractor', () => {
 
     it('should extract an assigned value rule with a fixed number value', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[0]);
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedRule = new ExportableAssignmentRule('valueInteger');
       expectedRule.value = 0;
       expectedRule.exactly = true;
@@ -35,7 +36,7 @@ describe('AssignmentRuleExtractor', () => {
 
     it('should extract an assigned value rule with a pattern number value', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[1]);
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedRule = new ExportableAssignmentRule('component.valueInteger');
       expectedRule.value = 8;
       expect(assignmentRules).toHaveLength(1);
@@ -45,7 +46,7 @@ describe('AssignmentRuleExtractor', () => {
 
     it('should extract an assigned value rule with a fixed string value', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[2]);
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedRule = new ExportableAssignmentRule('effectiveInstant');
       expectedRule.value = '2020-07-24T9:31:23.745-04:00';
       expectedRule.exactly = true;
@@ -56,7 +57,7 @@ describe('AssignmentRuleExtractor', () => {
 
     it('should extract an assigned value rule with a pattern string value', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[3]);
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedRule = new ExportableAssignmentRule('note.text');
       expectedRule.value = 'This is the "note" text.\nThere are two lines.';
       expect(assignmentRules).toHaveLength(1);
@@ -66,7 +67,7 @@ describe('AssignmentRuleExtractor', () => {
 
     it('should extract an assigned value rule with a fixed boolean value', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[4]);
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedRule = new ExportableAssignmentRule('valueBoolean');
       expectedRule.value = true;
       expectedRule.exactly = true;
@@ -77,7 +78,7 @@ describe('AssignmentRuleExtractor', () => {
 
     it('should extract an assigned value rule with a pattern boolean value', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[5]);
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedRule = new ExportableAssignmentRule('component.valueBoolean');
       expectedRule.value = false;
       expect(assignmentRules).toHaveLength(1);
@@ -87,7 +88,7 @@ describe('AssignmentRuleExtractor', () => {
 
     it('should extract an assigned value rule with a fixed integer64 value', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[8]);
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedRule = new ExportableAssignmentRule('valueInteger64');
       expectedRule.value = BigInt('9223372036854775807');
       expectedRule.exactly = true;
@@ -98,7 +99,7 @@ describe('AssignmentRuleExtractor', () => {
 
     it('should extract an assigned value rule with a pattern integer64 value', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[9]);
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedRule = new ExportableAssignmentRule('valueInteger64');
       expectedRule.value = BigInt('9223372036854775807');
       expect(assignmentRules).toHaveLength(1);
@@ -108,7 +109,7 @@ describe('AssignmentRuleExtractor', () => {
 
     it('should extract an assigned value rule with a pattern code', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[6]);
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedRule = new ExportableAssignmentRule('status');
       expectedRule.value = new fshtypes.FshCode('final');
       expect(assignmentRules).toHaveLength(1);
@@ -118,7 +119,7 @@ describe('AssignmentRuleExtractor', () => {
 
     it('should return no rules when an element does not have a fixed or pattern value', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[7]);
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       expect(assignmentRules).toHaveLength(0);
       expect(element.processedPaths).toHaveLength(0);
     });
@@ -126,6 +127,7 @@ describe('AssignmentRuleExtractor', () => {
 
   describe('#simple-date-and-time-values', () => {
     let looseSD: any;
+    const entityName = 'TemporalAssignedValueObservation';
 
     beforeAll(() => {
       looseSD = JSON.parse(
@@ -140,7 +142,7 @@ describe('AssignmentRuleExtractor', () => {
 
     it('should extract an assigned value rule with an instant value', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[0]);
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedRule = new ExportableAssignmentRule('effectiveInstant');
       expectedRule.value = '2020-07-24T09:31:23.745-04:00';
       expect(assignmentRules).toHaveLength(1);
@@ -151,7 +153,7 @@ describe('AssignmentRuleExtractor', () => {
 
     it('should extract an assigned value with a dateTime value', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[1]);
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedRule = new ExportableAssignmentRule('valueDateTime');
       expectedRule.value = '2013-01-01T00:00:00.000Z';
       expect(assignmentRules).toHaveLength(1);
@@ -162,7 +164,7 @@ describe('AssignmentRuleExtractor', () => {
 
     it('should extract an assigned value with a time value', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[2]);
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedRule = new ExportableAssignmentRule('valueTime');
       expectedRule.value = '15:45:00';
       expectedRule.exactly = true;
@@ -174,7 +176,7 @@ describe('AssignmentRuleExtractor', () => {
 
     it('should extract an assigned value with a date value', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[3]);
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedRule = new ExportableAssignmentRule('extension.valueDate');
       expectedRule.value = '2023-09-21';
       expectedRule.exactly = true;
@@ -187,6 +189,7 @@ describe('AssignmentRuleExtractor', () => {
 
   describe('#simple-date-and-time-warnings', () => {
     let looseSD: any;
+    const entityName = 'TemporalWarningValueObservation';
 
     beforeAll(() => {
       looseSD = JSON.parse(
@@ -201,7 +204,7 @@ describe('AssignmentRuleExtractor', () => {
 
     it('should extract an assigned value rule with an incorrectly formatted instant value and log a warning', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[0]);
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedRule = new ExportableAssignmentRule('effectiveInstant');
       expectedRule.value = '2020-07-24 9:31:23.745-04:00';
       expect(assignmentRules).toHaveLength(1);
@@ -209,13 +212,13 @@ describe('AssignmentRuleExtractor', () => {
       expect(element.processedPaths).toContain('patternInstant');
       expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
       expect(loggerSpy.getLastMessage('warn')).toMatch(
-        /Value 2020-07-24 9:31:23\.745-04:00 on element effectiveInstant is not a valid FHIR instant/s
+        /Value 2020-07-24 9:31:23\.745-04:00 on TemporalWarningValueObservation element effectiveInstant is not a valid FHIR instant/s
       );
     });
 
     it('should extract an assigned value with an incorrectly formatted dateTime value and log a warning', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[1]);
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedRule = new ExportableAssignmentRule('valueDateTime');
       expectedRule.value = '2013-01-01 00:00:00.000';
       expect(assignmentRules).toHaveLength(1);
@@ -223,13 +226,13 @@ describe('AssignmentRuleExtractor', () => {
       expect(element.processedPaths).toContain('patternDateTime');
       expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
       expect(loggerSpy.getLastMessage('warn')).toMatch(
-        /Value 2013-01-01 00:00:00\.000 on element valueDateTime is not a valid FHIR dateTime/s
+        /Value 2013-01-01 00:00:00\.000 on TemporalWarningValueObservation element valueDateTime is not a valid FHIR dateTime/s
       );
     });
 
     it('should extract an assigned value with an incorrectly formatted time value and log a warning', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[2]);
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedRule = new ExportableAssignmentRule('valueTime');
       expectedRule.value = '15:45';
       expectedRule.exactly = true;
@@ -238,13 +241,13 @@ describe('AssignmentRuleExtractor', () => {
       expect(element.processedPaths).toContain('fixedTime');
       expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
       expect(loggerSpy.getLastMessage('warn')).toMatch(
-        /Value 15:45 on element valueTime is not a valid FHIR time/s
+        /Value 15:45 on TemporalWarningValueObservation element valueTime is not a valid FHIR time/s
       );
     });
 
     it('should extract an assigned value with an incorrectly formatted date value and log a warning', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[3]);
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedRule = new ExportableAssignmentRule('extension.valueDate');
       expectedRule.value = '2023/09/21';
       expectedRule.exactly = true;
@@ -253,13 +256,14 @@ describe('AssignmentRuleExtractor', () => {
       expect(element.processedPaths).toContain('fixedDate');
       expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
       expect(loggerSpy.getLastMessage('warn')).toMatch(
-        /Value 2023\/09\/21 on element extension\.valueDate is not a valid FHIR date/s
+        /Value 2023\/09\/21 on TemporalWarningValueObservation element extension\.valueDate is not a valid FHIR date/s
       );
     });
   });
 
   describe('#complex-values', () => {
     let looseSD: any;
+    const entityName = 'AssignedValueObservation';
 
     beforeAll(() => {
       looseSD = JSON.parse(
@@ -274,7 +278,7 @@ describe('AssignmentRuleExtractor', () => {
 
     it('should extract an assigned value rule with a fixed Coding value', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[5]);
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedRule = new ExportableAssignmentRule('dataAbsentReason.coding');
       expectedRule.value = new fshtypes.FshCode('DNE', 'http://example.com/codes');
       expect(assignmentRules).toHaveLength(1);
@@ -287,7 +291,7 @@ describe('AssignmentRuleExtractor', () => {
 
     it('should extract an assigned value rule with a fixed CodeableConcept value', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[0]);
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedRule = new ExportableAssignmentRule('code');
       expectedRule.value = new fshtypes.FshCode(
         '12343',
@@ -304,7 +308,7 @@ describe('AssignmentRuleExtractor', () => {
 
     it('should extract an assigned value rule with a fixed Quantity value', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[1]);
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedRule = new ExportableAssignmentRule('valueQuantity');
       expectedRule.value = new fshtypes.FshQuantity(
         1.21,
@@ -322,7 +326,7 @@ describe('AssignmentRuleExtractor', () => {
     it('should extract an assigned value rule with a fixed Quantity value that does not have quantity.value', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[1]);
       delete element.patternQuantity.value;
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedRule = new ExportableAssignmentRule('valueQuantity');
       expectedRule.value = new fshtypes.FshCode('GW', 'http://unitsofmeasure.org');
       expect(assignmentRules).toHaveLength(1);
@@ -336,7 +340,7 @@ describe('AssignmentRuleExtractor', () => {
 
     it('should extract an assigned value rule with a fixed Ratio value', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[2]);
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedRule = new ExportableAssignmentRule('valueRatio');
       expectedRule.value = new fshtypes.FshRatio(
         new fshtypes.FshQuantity(5, new fshtypes.FshCode('cm', 'http://other-units.org')),
@@ -358,7 +362,7 @@ describe('AssignmentRuleExtractor', () => {
     it('should extract assigned value rules when the numerator quantity does not contain a value property', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[2]);
       delete element.patternRatio.numerator.value;
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedNumeratorRule = new ExportableAssignmentRule('valueRatio.numerator');
       expectedNumeratorRule.value = new fshtypes.FshCode('cm', 'http://other-units.org');
       const expectedDenominatorRule = new ExportableAssignmentRule('valueRatio.denominator');
@@ -382,7 +386,7 @@ describe('AssignmentRuleExtractor', () => {
     it('should extract assigned value rules when the denominator quantity does not contain a value property', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[2]);
       delete element.patternRatio.denominator.value;
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedNumeratorRule = new ExportableAssignmentRule('valueRatio.numerator');
       expectedNumeratorRule.value = new fshtypes.FshQuantity(
         5,
@@ -405,7 +409,7 @@ describe('AssignmentRuleExtractor', () => {
 
     it('should extract an assigned value rule with a fixed Reference value', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[3]);
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedRule = new ExportableAssignmentRule('subject');
       expectedRule.value = new fshtypes.FshReference(
         'http://example.com/PaulBunyan',
@@ -420,7 +424,7 @@ describe('AssignmentRuleExtractor', () => {
 
     it.skip('should extract an assigned value rule with a fixed Instance value', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[4]);
-      const assignmentRules = AssignmentRuleExtractor.process(element);
+      const assignmentRules = AssignmentRuleExtractor.process(element, entityName);
       const expectedRule = new ExportableAssignmentRule('note');
       const expectedValue = new fhirtypes.InstanceDefinition();
       expectedValue.resourceType = 'Annotation';

--- a/test/extractor/CaretValueRuleExtractor.test.ts
+++ b/test/extractor/CaretValueRuleExtractor.test.ts
@@ -1042,5 +1042,19 @@ describe('CaretValueRuleExtractor', () => {
         'Value in StructureDefinition ObservationWithCaret for element partOf.base is empty.'
       );
     });
+
+    it('should log a warning with element paths when a dateTime value is not correctly formatted', () => {
+      const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[12]);
+      const caretRules = CaretValueRuleExtractor.process(element, looseSD, defs);
+      const expectedRule = new ExportableCaretValueRule('component.valueDateTime');
+      expectedRule.caretPath = 'patternDateTime';
+      expectedRule.value = '2013-01-01 00:00:00.000';
+      expect(caretRules).toHaveLength(1);
+      expect(caretRules[0]).toEqual<ExportableCaretValueRule>(expectedRule);
+      expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
+      expect(loggerSpy.getLastMessage('warn')).toMatch(
+        /Value 2013-01-01 00:00:00\.000 on ObservationWithCaret\.component\.valueDateTime element patternDateTime is not a valid FHIR dateTime/s
+      );
+    });
   });
 });

--- a/test/extractor/CaretValueRuleExtractor.test.ts
+++ b/test/extractor/CaretValueRuleExtractor.test.ts
@@ -1076,13 +1076,13 @@ describe('CaretValueRuleExtractor', () => {
       const element = ProcessableElementDefinition.fromJSON(looseSD.differential.element[12]);
       const caretRules = CaretValueRuleExtractor.process(element, looseSD, defs);
       const expectedRule = new ExportableCaretValueRule('component.valueDateTime');
-      expectedRule.caretPath = 'patternDateTime';
+      expectedRule.caretPath = 'minValueDateTime';
       expectedRule.value = '2013-01-01 00:00:00.000';
       expect(caretRules).toHaveLength(1);
       expect(caretRules[0]).toEqual<ExportableCaretValueRule>(expectedRule);
       expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
       expect(loggerSpy.getLastMessage('warn')).toMatch(
-        /Value 2013-01-01 00:00:00\.000 on ObservationWithCaret\.component\.valueDateTime element patternDateTime is not a valid FHIR dateTime/s
+        /Value 2013-01-01 00:00:00\.000 on ObservationWithCaret\.component\.valueDateTime element minValueDateTime is not a valid FHIR dateTime/s
       );
     });
   });

--- a/test/extractor/CaretValueRuleExtractor.test.ts
+++ b/test/extractor/CaretValueRuleExtractor.test.ts
@@ -677,7 +677,7 @@ describe('CaretValueRuleExtractor', () => {
 
       const caretRules = CaretValueRuleExtractor.processConcept(
         testConcept,
-        ['testConcept'],
+        ['#testConcept'],
         'testCS',
         'CodeSystem',
         defs
@@ -685,6 +685,7 @@ describe('CaretValueRuleExtractor', () => {
       expect(caretRules).toContainEqual(
         expect.objectContaining({
           path: '',
+          pathArray: ['#testConcept'],
           caretPath: 'property[0].valueString'
         })
       );
@@ -705,6 +706,34 @@ describe('CaretValueRuleExtractor', () => {
           path: '',
           caretPath: 'definition'
         })
+      );
+    });
+
+    it('should log a warning with a concept path when a dateTime value is not correctly formatted', () => {
+      const testConcept = {
+        code: 'testConcept',
+        display: 'Test Concept',
+        definition: 'A concept, just for tests though',
+        property: [{ code: 'test', valueDateTime: '2013-01-01 00:00:00.000' }]
+      };
+      const caretRules = CaretValueRuleExtractor.processConcept(
+        testConcept,
+        ['#bigConcept', '#testConcept'],
+        'testCS',
+        'CodeSystem',
+        defs
+      );
+      expect(caretRules).toContainEqual(
+        expect.objectContaining({
+          path: '',
+          pathArray: ['#bigConcept', '#testConcept'],
+          caretPath: 'property[0].valueDateTime',
+          value: '2013-01-01 00:00:00.000'
+        })
+      );
+      expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
+      expect(loggerSpy.getLastMessage('warn')).toMatch(
+        /Value 2013-01-01 00:00:00\.000 on testCS #bigConcept\.#testConcept element property\[0\]\.valueDateTime is not a valid FHIR dateTime/s
       );
     });
 

--- a/test/extractor/fixtures/caret-value-profile.json
+++ b/test/extractor/fixtures/caret-value-profile.json
@@ -175,7 +175,7 @@
       {
         "id": "Observation.component.valueDateTime",
         "path": "Observation.component.valueDateTime",
-        "patternDateTime": "2013-01-01 00:00:00.000"
+        "minValueDateTime": "2013-01-01 00:00:00.000"
       }
     ]
   }

--- a/test/extractor/fixtures/caret-value-profile.json
+++ b/test/extractor/fixtures/caret-value-profile.json
@@ -89,10 +89,7 @@
       {
         "id": "Observation.category",
         "path": "Observation.category",
-        "alias": [
-          "foo",
-          "bar"
-        ]
+        "alias": ["foo", "bar"]
       },
       {
         "id": "Observation.code",
@@ -121,10 +118,7 @@
           },
           {
             "code": "baz",
-            "targetProfile": [
-              "profile1",
-              "profile2"
-            ],
+            "targetProfile": ["profile1", "profile2"],
             "versioning": "specific"
           }
         ]
@@ -177,6 +171,11 @@
             "human": "It must choose to foo"
           }
         ]
+      },
+      {
+        "id": "Observation.component.valueDateTime",
+        "path": "Observation.component.valueDateTime",
+        "patternDateTime": "2013-01-01 00:00:00.000"
       }
     ]
   }

--- a/test/extractor/fixtures/obeys-profile.json
+++ b/test/extractor/fixtures/obeys-profile.json
@@ -63,6 +63,26 @@
         "id": "Observation.issued",
         "path": "Observation.issued",
         "min": 1
+      },
+      {
+        "id": "Observation.subject",
+        "path": "Observation.subject",
+        "constraint": [
+          {
+            "key": "zig-6",
+            "severity": "warning",
+            "human": "This constraint has an incorrectly formatted date value.",
+            "_human": {
+              "extension": [
+                {
+                  "url": "http://example.org/SomeExtension",
+                  "valueDate": "2023/09/21"
+                }
+              ]
+            },
+            "expression": "subject.date.exists()"
+          }
+        ]
       }
     ]
   }

--- a/test/extractor/fixtures/temporal-assigned-value-profile.json
+++ b/test/extractor/fixtures/temporal-assigned-value-profile.json
@@ -1,0 +1,26 @@
+{
+  "resourceType": "StructureDefinition",
+  "kind": "resource",
+  "type": "Observation",
+  "name": "TemporalAssignedValueObservation",
+  "differential": {
+    "element": [
+      {
+        "id": "Observation.effectiveInstant",
+        "patternInstant": "2020-07-24T09:31:23.745-04:00"
+      },
+      {
+        "id": "Observation.valueDateTime",
+        "patternDateTime": "2013-01-01T00:00:00.000Z"
+      },
+      {
+        "id": "Observation.valueTime",
+        "fixedTime": "15:45:00"
+      },
+      {
+        "id": "Observation.extension.valueDate",
+        "fixedDate": "2023-09-21"
+      }
+    ]
+  }
+}

--- a/test/extractor/fixtures/temporal-warning-value-profile.json
+++ b/test/extractor/fixtures/temporal-warning-value-profile.json
@@ -1,0 +1,26 @@
+{
+  "resourceType": "StructureDefinition",
+  "kind": "resource",
+  "type": "Observation",
+  "name": "TemporalWarningValueObservation",
+  "differential": {
+    "element": [
+      {
+        "id": "Observation.effectiveInstant",
+        "patternInstant": "2020-07-24 9:31:23.745-04:00"
+      },
+      {
+        "id": "Observation.valueDateTime",
+        "patternDateTime": "2013-01-01 00:00:00.000"
+      },
+      {
+        "id": "Observation.valueTime",
+        "fixedTime": "15:45"
+      },
+      {
+        "id": "Observation.extension.valueDate",
+        "fixedDate": "2023/09/21"
+      }
+    ]
+  }
+}

--- a/test/processor/InstanceProcessor.test.ts
+++ b/test/processor/InstanceProcessor.test.ts
@@ -494,7 +494,7 @@ describe('InstanceProcessor', () => {
       expect(result.rules).toContainEqual(birthDateRule);
       expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
       expect(loggerSpy.getLastMessage('warn')).toMatch(
-        /Value 1985\/07\/12 on invalid-date-patient element birthDate is not a valid FHIR date/s
+        /Value 1985\/07\/12 on Patient invalid-date-patient element birthDate is not a valid FHIR date/s
       );
     });
 

--- a/test/processor/InstanceProcessor.test.ts
+++ b/test/processor/InstanceProcessor.test.ts
@@ -481,6 +481,23 @@ describe('InstanceProcessor', () => {
       expect(result.rules).toContainEqual(edgesRule);
     });
 
+    it('should log a warning when a date value is not correctly formatted', () => {
+      const input = JSON.parse(
+        fs.readFileSync(path.join(__dirname, 'fixtures', 'invalid-date-patient.json'), 'utf-8')
+      );
+      const result = InstanceProcessor.process(input, simpleIg, defs);
+      expect(result).toBeInstanceOf(ExportableInstance);
+      expect(result.name).toBe('invalid-date-patient-of-Patient');
+      expect(result.id).toBe('invalid-date-patient');
+      const birthDateRule = new ExportableAssignmentRule('birthDate');
+      birthDateRule.value = '1985/07/12';
+      expect(result.rules).toContainEqual(birthDateRule);
+      expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
+      expect(loggerSpy.getLastMessage('warn')).toMatch(
+        /Value 1985\/07\/12 on invalid-date-patient element birthDate is not a valid FHIR date/s
+      );
+    });
+
     it('should use entry resource type to determine assignment rule value types on bundle entry resources', () => {
       const input = JSON.parse(
         fs.readFileSync(path.join(__dirname, 'fixtures', 'simple-bundle.json'), 'utf-8')

--- a/test/processor/StructureDefinitionProcessor.test.ts
+++ b/test/processor/StructureDefinitionProcessor.test.ts
@@ -766,7 +766,7 @@ describe('StructureDefinitionProcessor', () => {
         }) ?? [];
       const result = StructureDefinitionProcessor.extractInvariants(input, elements, [], defs);
 
-      expect(result).toHaveLength(5);
+      expect(result).toHaveLength(6);
     });
   });
 

--- a/test/processor/fixtures/invalid-date-patient.json
+++ b/test/processor/fixtures/invalid-date-patient.json
@@ -1,0 +1,5 @@
+{
+  "resourceType": "Patient",
+  "id": "invalid-date-patient",
+  "birthDate": "1985/07/12"
+}

--- a/test/utils/element.test.ts
+++ b/test/utils/element.test.ts
@@ -143,11 +143,13 @@ describe('element', () => {
   });
 
   describe('#getFSHValue', () => {
+    const entityName = 'MyObservation';
     it('should convert a code value into a FSHCode', () => {
       const value = getFSHValue(
         0,
         [['type[0].aggregation[0]', 'contained']],
         'ElementDefinition',
+        entityName,
         defs
       );
       expect(value).toEqual(new fshtypes.FshCode('contained'));
@@ -158,6 +160,7 @@ describe('element', () => {
         0,
         [['type[0].profile[0]', 'http://foo.com/bar']],
         'ElementDefinition',
+        entityName,
         defs
       );
       expect(value).toEqual('http://foo.com/bar');
@@ -168,6 +171,7 @@ describe('element', () => {
         0,
         [['valueDateTime', '2013-01-01T00:00:00.000Z']],
         'Observation',
+        entityName,
         defs
       );
       expect(value).toEqual('2013-01-01T00:00:00.000Z');
@@ -179,42 +183,55 @@ describe('element', () => {
         0,
         [['valueDateTime', '2013-01-01 00:00:00.000']],
         'Observation',
+        entityName,
         defs
       );
       expect(value).toEqual('2013-01-01 00:00:00.000');
       expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
       expect(loggerSpy.getLastMessage('warn')).toMatch(
-        /Value 2013-01-01 00:00:00\.000 on element valueDateTime is not a valid FHIR dateTime/s
+        /Value 2013-01-01 00:00:00\.000 on MyObservation element valueDateTime is not a valid FHIR dateTime/s
       );
     });
 
     it('should get a date value', () => {
-      const value = getFSHValue(0, [['extension.valueDate', '2023-09-21']], 'Observation', defs);
+      const value = getFSHValue(
+        0,
+        [['extension.valueDate', '2023-09-21']],
+        'Observation',
+        entityName,
+        defs
+      );
       expect(value).toEqual('2023-09-21');
       expect(loggerSpy.getAllMessages()).toHaveLength(0);
     });
 
     it('should emit a warning when it gets an incorrectly formatted date value', () => {
-      const value = getFSHValue(0, [['extension.valueDate', '2023/09/21']], 'Observation', defs);
+      const value = getFSHValue(
+        0,
+        [['extension.valueDate', '2023/09/21']],
+        'Observation',
+        entityName,
+        defs
+      );
       expect(value).toEqual('2023/09/21');
       expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
       expect(loggerSpy.getLastMessage('warn')).toMatch(
-        /Value 2023\/09\/21 on element extension\.valueDate is not a valid FHIR date/s
+        /Value 2023\/09\/21 on MyObservation element extension\.valueDate is not a valid FHIR date/s
       );
     });
 
     it('should get a time value', () => {
-      const value = getFSHValue(0, [['valueTime', '15:45:00']], 'Observation', defs);
+      const value = getFSHValue(0, [['valueTime', '15:45:00']], 'Observation', entityName, defs);
       expect(value).toEqual('15:45:00');
       expect(loggerSpy.getAllMessages()).toHaveLength(0);
     });
 
     it('should emit a warning when it gets an incorrectly formatted time value', () => {
-      const value = getFSHValue(0, [['valueTime', '15:45']], 'Observation', defs);
+      const value = getFSHValue(0, [['valueTime', '15:45']], 'Observation', entityName, defs);
       expect(value).toEqual('15:45');
       expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
       expect(loggerSpy.getLastMessage('warn')).toMatch(
-        /Value 15:45 on element valueTime is not a valid FHIR time/s
+        /Value 15:45 on MyObservation element valueTime is not a valid FHIR time/s
       );
     });
 
@@ -223,6 +240,7 @@ describe('element', () => {
         0,
         [['effectiveInstant', '2020-07-24T09:31:23.745-04:00']],
         'Observation',
+        entityName,
         defs
       );
       expect(value).toEqual('2020-07-24T09:31:23.745-04:00');
@@ -234,12 +252,31 @@ describe('element', () => {
         0,
         [['effectiveInstant', '2020-07-24 9:31:23.745-04:00']],
         'Observation',
+        entityName,
         defs
       );
       expect(value).toEqual('2020-07-24 9:31:23.745-04:00');
       expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
       expect(loggerSpy.getLastMessage('warn')).toMatch(
-        /Value 2020-07-24 9:31:23\.745-04:00 on element effectiveInstant is not a valid FHIR instant/s
+        /Value 2020-07-24 9:31:23\.745-04:00 on MyObservation element effectiveInstant is not a valid FHIR instant/s
+      );
+    });
+
+    it('should emit a warning with the full path to the contained resource element when it gets an incorrectly formatted dateTime value', () => {
+      const value = getFSHValue(
+        0,
+        [
+          ['entry[0].resource.valueDateTime', '2013-01-01 00:00:00.000'],
+          ['entry[0].resource.resourceType', 'Observation']
+        ],
+        'Bundle',
+        'MyBundle',
+        defs
+      );
+      expect(value).toEqual('2013-01-01 00:00:00.000');
+      expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
+      expect(loggerSpy.getLastMessage('warn')).toMatch(
+        /Value 2013-01-01 00:00:00\.000 on MyBundle\.entry\[0\]\.resource element valueDateTime is not a valid FHIR dateTime/s
       );
     });
   });

--- a/test/utils/element.test.ts
+++ b/test/utils/element.test.ts
@@ -12,6 +12,7 @@ import {
   getAncestorSliceDefinition
 } from '../../src/utils';
 import { ProcessableElementDefinition, ProcessableStructureDefinition } from '../../src/processor';
+import { loggerSpy } from '../helpers/loggerSpy';
 
 import { loadTestDefinitions } from '../helpers/loadTestDefinitions';
 
@@ -20,6 +21,10 @@ describe('element', () => {
 
   beforeAll(() => {
     defs = loadTestDefinitions();
+  });
+
+  beforeEach(() => {
+    loggerSpy.reset();
   });
 
   describe('#getPath', () => {
@@ -156,6 +161,86 @@ describe('element', () => {
         defs
       );
       expect(value).toEqual('http://foo.com/bar');
+    });
+
+    it('should get a dateTime value', () => {
+      const value = getFSHValue(
+        0,
+        [['valueDateTime', '2013-01-01T00:00:00.000Z']],
+        'Observation',
+        defs
+      );
+      expect(value).toEqual('2013-01-01T00:00:00.000Z');
+      expect(loggerSpy.getAllMessages()).toHaveLength(0);
+    });
+
+    it('should emit a warning when it gets an incorrectly formatted dateTime value', () => {
+      const value = getFSHValue(
+        0,
+        [['valueDateTime', '2013-01-01 00:00:00.000']],
+        'Observation',
+        defs
+      );
+      expect(value).toEqual('2013-01-01 00:00:00.000');
+      expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
+      expect(loggerSpy.getLastMessage('warn')).toMatch(
+        /Value 2013-01-01 00:00:00\.000 on element valueDateTime is not a valid FHIR dateTime/s
+      );
+    });
+
+    it('should get a date value', () => {
+      const value = getFSHValue(0, [['extension.valueDate', '2023-09-21']], 'Observation', defs);
+      expect(value).toEqual('2023-09-21');
+      expect(loggerSpy.getAllMessages()).toHaveLength(0);
+    });
+
+    it('should emit a warning when it gets an incorrectly formatted date value', () => {
+      const value = getFSHValue(0, [['extension.valueDate', '2023/09/21']], 'Observation', defs);
+      expect(value).toEqual('2023/09/21');
+      expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
+      expect(loggerSpy.getLastMessage('warn')).toMatch(
+        /Value 2023\/09\/21 on element extension\.valueDate is not a valid FHIR date/s
+      );
+    });
+
+    it('should get a time value', () => {
+      const value = getFSHValue(0, [['valueTime', '15:45:00']], 'Observation', defs);
+      expect(value).toEqual('15:45:00');
+      expect(loggerSpy.getAllMessages()).toHaveLength(0);
+    });
+
+    it('should emit a warning when it gets an incorrectly formatted time value', () => {
+      const value = getFSHValue(0, [['valueTime', '15:45']], 'Observation', defs);
+      expect(value).toEqual('15:45');
+      expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
+      expect(loggerSpy.getLastMessage('warn')).toMatch(
+        /Value 15:45 on element valueTime is not a valid FHIR time/s
+      );
+    });
+
+    it('should get a instant value', () => {
+      const value = getFSHValue(
+        0,
+        [['effectiveInstant', '2020-07-24T09:31:23.745-04:00']],
+        'Observation',
+        defs
+      );
+      expect(value).toEqual('2020-07-24T09:31:23.745-04:00');
+      expect(loggerSpy.getAllMessages()).toHaveLength(0);
+    });
+
+    it('should emit a warning when it gets an incorrectly formatted instant value', () => {
+      const value = getFSHValue(
+        0,
+        [['effectiveInstant', '2020-07-24 9:31:23.745-04:00']],
+        'Observation',
+        defs
+      );
+      expect(value).toEqual('2020-07-24 9:31:23.745-04:00');
+      expect(loggerSpy.getAllMessages('warn')).toHaveLength(1);
+      expect(loggerSpy.getLastMessage('warn')).toMatch(
+        /Value 2020-07-24 9:31:23\.745-04:00 on element effectiveInstant is not a valid FHIR instant/s
+      );
     });
   });
 


### PR DESCRIPTION
Completes task [CIMPL-1241](https://standardhealthrecord.atlassian.net/browse/CIMPL-1241). See also [FSHOnline #152](https://github.com/FSHSchool/FSHOnline/issues/152).

The FHIR types dateTime, date, time, and instant all have required formats. If a value of one of these types does not match the format, emit a warning. The rule to set this value is still created.

Something I'm thinking about for this is the usefulness of the warning message. Right now, it has the rule path, but no indication of what entity has the incorrectly formatted value. I could send along the entity name to `getFshValue` to use in the message, since by the time the value is returned, the information about the FHIR type is gone. Please let me know what you think about this warning message.