### PR TITLE
Construct inline instances from within more FSH entity types

### DIFF
--- a/src/optimizer/plugins/ConstructInlineInstanceOptimizer.ts
+++ b/src/optimizer/plugins/ConstructInlineInstanceOptimizer.ts
@@ -31,9 +31,16 @@ export default {
 
   optimize(pkg: Package, fisher: MasterFisher, options: ProcessingOptions = {}): void {
     const inlineInstances: ExportableInstance[] = [];
-    // Only construct inline instances in instances, profiles, and extensions.
     // If we add support for other types, update SimplifyInstanceNameOptimizer as well.
-    [...pkg.instances, ...pkg.profiles, ...pkg.extensions].forEach(resource => {
+    [
+      ...pkg.instances,
+      ...pkg.profiles,
+      ...pkg.extensions,
+      ...pkg.logicals,
+      ...pkg.resources,
+      ...pkg.codeSystems,
+      ...pkg.valueSets
+    ].forEach(resource => {
       const ruleType =
         resource instanceof ExportableInstance
           ? ExportableAssignmentRule

--- a/src/optimizer/plugins/SimplifyInstanceNameOptimizer.ts
+++ b/src/optimizer/plugins/SimplifyInstanceNameOptimizer.ts
@@ -35,7 +35,15 @@ export default {
     });
 
     // Fix up inline assignments in types that may have them (see: ConstructInlineInstanceOptimizer)
-    [...pkg.instances, ...pkg.profiles, ...pkg.extensions].forEach(resource => {
+    [
+      ...pkg.instances,
+      ...pkg.profiles,
+      ...pkg.extensions,
+      ...pkg.logicals,
+      ...pkg.resources,
+      ...pkg.codeSystems,
+      ...pkg.valueSets
+    ].forEach(resource => {
       const inlineAssignmentRules = resource.rules.filter(
         rule =>
           (rule instanceof ExportableAssignmentRule || rule instanceof ExportableCaretValueRule) &&

--- a/test/optimizer/plugins/SimplifyInstanceNameOptimizer.test.ts
+++ b/test/optimizer/plugins/SimplifyInstanceNameOptimizer.test.ts
@@ -4,8 +4,13 @@ import { Package } from '../../../src/processor/Package';
 import {
   ExportableAssignmentRule,
   ExportableCaretValueRule,
+  ExportableCodeSystem,
+  ExportableExtension,
   ExportableInstance,
-  ExportableProfile
+  ExportableLogical,
+  ExportableProfile,
+  ExportableResource,
+  ExportableValueSet
 } from '../../../src/exportable';
 import { MasterFisher } from '../../../src/utils';
 import { loadTestDefinitions, stockLake } from '../../helpers';
@@ -134,7 +139,7 @@ describe('optimizer', () => {
       expect(myPackage.instances).toEqual([expectedInstance1, expectedInstance2, expectedBundle]);
     });
 
-    it('should update inlined contained rules in a profile when the inline instance name changes', () => {
+    it('should update inlined contained rules in a profile when the contained instance name changes', () => {
       const instance1 = new ExportableInstance('AmazingThings');
       instance1.instanceOf = 'CodeSystem';
       instance1.name = 'AmazingThings-of-CodeSystem';
@@ -146,19 +151,19 @@ describe('optimizer', () => {
       instance3.name = 'OtherAmazingThings-of-ValueSet';
       const profile = new ExportableProfile('MyObservationProfile');
       profile.parent = 'Observation';
-      const profileContainedRule1 = new ExportableCaretValueRule('');
-      profileContainedRule1.caretPath = 'contained[0]';
-      profileContainedRule1.isInstance = true;
-      profileContainedRule1.value = 'AmazingThings-of-CodeSystem';
-      const profileContainedRule2 = new ExportableCaretValueRule('');
-      profileContainedRule2.caretPath = 'contained[1]';
-      profileContainedRule2.isInstance = true;
-      profileContainedRule2.value = 'AmazingThings-of-ValueSet';
-      const profileContainedRule3 = new ExportableCaretValueRule('');
-      profileContainedRule3.caretPath = 'contained[2]';
-      profileContainedRule3.isInstance = true;
-      profileContainedRule3.value = 'OtherAmazingThings-of-ValueSet';
-      profile.rules = [profileContainedRule1, profileContainedRule2, profileContainedRule3];
+      const containedRule1 = new ExportableCaretValueRule('');
+      containedRule1.caretPath = 'contained[0]';
+      containedRule1.isInstance = true;
+      containedRule1.value = 'AmazingThings-of-CodeSystem';
+      const containedRule2 = new ExportableCaretValueRule('');
+      containedRule2.caretPath = 'contained[1]';
+      containedRule2.isInstance = true;
+      containedRule2.value = 'AmazingThings-of-ValueSet';
+      const containedRule3 = new ExportableCaretValueRule('');
+      containedRule3.caretPath = 'contained[2]';
+      containedRule3.isInstance = true;
+      containedRule3.value = 'OtherAmazingThings-of-ValueSet';
+      profile.rules = [containedRule1, containedRule2, containedRule3];
       const myPackage = new Package();
       myPackage.add(instance1);
       myPackage.add(instance2);
@@ -184,25 +189,370 @@ describe('optimizer', () => {
       // Now check that names have been updated in inline assignments
       const expectedProfile = new ExportableProfile('MyObservationProfile');
       expectedProfile.parent = 'Observation';
-      const expectedProfileRule1 = new ExportableCaretValueRule('');
-      expectedProfileRule1.caretPath = 'contained[0]';
-      expectedProfileRule1.isInstance = true;
-      expectedProfileRule1.value = 'AmazingThings-of-CodeSystem'; // This name did not get changed
-      const expectedProfileRule2 = new ExportableCaretValueRule('');
-      expectedProfileRule2.caretPath = 'contained[1]';
-      expectedProfileRule2.isInstance = true;
-      expectedProfileRule2.value = 'AmazingThings-of-ValueSet'; // This name did not get changed
-      const expectedProfileRule3 = new ExportableCaretValueRule('');
-      expectedProfileRule3.caretPath = 'contained[2]';
-      expectedProfileRule3.isInstance = true;
-      expectedProfileRule3.value = 'OtherAmazingThings'; // This name was changed
-      expectedProfile.rules = [expectedProfileRule1, expectedProfileRule2, expectedProfileRule3];
+      const expectedRule1 = new ExportableCaretValueRule('');
+      expectedRule1.caretPath = 'contained[0]';
+      expectedRule1.isInstance = true;
+      expectedRule1.value = 'AmazingThings-of-CodeSystem'; // This name did not get changed
+      const expectedRule2 = new ExportableCaretValueRule('');
+      expectedRule2.caretPath = 'contained[1]';
+      expectedRule2.isInstance = true;
+      expectedRule2.value = 'AmazingThings-of-ValueSet'; // This name did not get changed
+      const expectedRule3 = new ExportableCaretValueRule('');
+      expectedRule3.caretPath = 'contained[2]';
+      expectedRule3.isInstance = true;
+      expectedRule3.value = 'OtherAmazingThings'; // This name was changed
+      expectedProfile.rules = [expectedRule1, expectedRule2, expectedRule3];
       expect(myPackage.instances).toEqual([
         expectedInstance1,
         expectedInstance2,
         expectedInstance3
       ]);
       expect(myPackage.profiles).toEqual([expectedProfile]);
+    });
+
+    it('should update inlined contained rules in an extension when the contained instance name changes', () => {
+      const instance1 = new ExportableInstance('AmazingThings');
+      instance1.instanceOf = 'CodeSystem';
+      instance1.name = 'AmazingThings-of-CodeSystem';
+      const instance2 = new ExportableInstance('AmazingThings');
+      instance2.instanceOf = 'ValueSet';
+      instance2.name = 'AmazingThings-of-ValueSet';
+      const instance3 = new ExportableInstance('OtherAmazingThings');
+      instance3.instanceOf = 'ValueSet';
+      instance3.name = 'OtherAmazingThings-of-ValueSet';
+      const extension = new ExportableExtension('MyUsefulExtension');
+      const containedRule1 = new ExportableCaretValueRule('');
+      containedRule1.caretPath = 'contained[0]';
+      containedRule1.isInstance = true;
+      containedRule1.value = 'AmazingThings-of-CodeSystem';
+      const containedRule2 = new ExportableCaretValueRule('');
+      containedRule2.caretPath = 'contained[1]';
+      containedRule2.isInstance = true;
+      containedRule2.value = 'AmazingThings-of-ValueSet';
+      const containedRule3 = new ExportableCaretValueRule('');
+      containedRule3.caretPath = 'contained[2]';
+      containedRule3.isInstance = true;
+      containedRule3.value = 'OtherAmazingThings-of-ValueSet';
+      extension.rules = [containedRule1, containedRule2, containedRule3];
+      const myPackage = new Package();
+      myPackage.add(instance1);
+      myPackage.add(instance2);
+      myPackage.add(instance3);
+      myPackage.add(extension);
+      optimizer.optimize(myPackage);
+
+      // Check that instances were renamed when appropriate
+      const amazingThingsIdRule = new ExportableAssignmentRule('id');
+      amazingThingsIdRule.value = 'AmazingThings';
+      const expectedInstance1 = new ExportableInstance('AmazingThings');
+      expectedInstance1.instanceOf = 'CodeSystem';
+      expectedInstance1.name = 'AmazingThings-of-CodeSystem'; // No name simplification since it will conflict with other instances
+      expectedInstance1.rules = [amazingThingsIdRule];
+      const expectedInstance2 = new ExportableInstance('AmazingThings');
+      expectedInstance2.instanceOf = 'ValueSet';
+      expectedInstance2.name = 'AmazingThings-of-ValueSet'; // No name simplification since it will conflict with other instances
+      expectedInstance2.rules = [amazingThingsIdRule];
+      const expectedInstance3 = new ExportableInstance('OtherAmazingThings');
+      expectedInstance3.instanceOf = 'ValueSet';
+      expectedInstance3.name = 'OtherAmazingThings'; // Name simplification since it didn't conflict with any other instances
+      // NOTE: expectedInstance3 should not have id rule since name matches id
+      // Now check that names have been updated in inline assignments
+      const expectedExtension = new ExportableExtension('MyUsefulExtension');
+      const expectedRule1 = new ExportableCaretValueRule('');
+      expectedRule1.caretPath = 'contained[0]';
+      expectedRule1.isInstance = true;
+      expectedRule1.value = 'AmazingThings-of-CodeSystem'; // This name did not get changed
+      const expectedRule2 = new ExportableCaretValueRule('');
+      expectedRule2.caretPath = 'contained[1]';
+      expectedRule2.isInstance = true;
+      expectedRule2.value = 'AmazingThings-of-ValueSet'; // This name did not get changed
+      const expectedRule3 = new ExportableCaretValueRule('');
+      expectedRule3.caretPath = 'contained[2]';
+      expectedRule3.isInstance = true;
+      expectedRule3.value = 'OtherAmazingThings'; // This name was changed
+      expectedExtension.rules = [expectedRule1, expectedRule2, expectedRule3];
+      expect(myPackage.instances).toEqual([
+        expectedInstance1,
+        expectedInstance2,
+        expectedInstance3
+      ]);
+      expect(myPackage.extensions).toEqual([expectedExtension]);
+    });
+
+    it('should update inlined contained rules in a logical when the contained instance name changes', () => {
+      const instance1 = new ExportableInstance('AmazingThings');
+      instance1.instanceOf = 'CodeSystem';
+      instance1.name = 'AmazingThings-of-CodeSystem';
+      const instance2 = new ExportableInstance('AmazingThings');
+      instance2.instanceOf = 'ValueSet';
+      instance2.name = 'AmazingThings-of-ValueSet';
+      const instance3 = new ExportableInstance('OtherAmazingThings');
+      instance3.instanceOf = 'ValueSet';
+      instance3.name = 'OtherAmazingThings-of-ValueSet';
+      const logical = new ExportableLogical('PretzelLogical');
+      const containedRule1 = new ExportableCaretValueRule('');
+      containedRule1.caretPath = 'contained[0]';
+      containedRule1.isInstance = true;
+      containedRule1.value = 'AmazingThings-of-CodeSystem';
+      const containedRule2 = new ExportableCaretValueRule('');
+      containedRule2.caretPath = 'contained[1]';
+      containedRule2.isInstance = true;
+      containedRule2.value = 'AmazingThings-of-ValueSet';
+      const containedRule3 = new ExportableCaretValueRule('');
+      containedRule3.caretPath = 'contained[2]';
+      containedRule3.isInstance = true;
+      containedRule3.value = 'OtherAmazingThings-of-ValueSet';
+      logical.rules = [containedRule1, containedRule2, containedRule3];
+      const myPackage = new Package();
+      myPackage.add(instance1);
+      myPackage.add(instance2);
+      myPackage.add(instance3);
+      myPackage.add(logical);
+      optimizer.optimize(myPackage);
+
+      // Check that instances were renamed when appropriate
+      const amazingThingsIdRule = new ExportableAssignmentRule('id');
+      amazingThingsIdRule.value = 'AmazingThings';
+      const expectedInstance1 = new ExportableInstance('AmazingThings');
+      expectedInstance1.instanceOf = 'CodeSystem';
+      expectedInstance1.name = 'AmazingThings-of-CodeSystem'; // No name simplification since it will conflict with other instances
+      expectedInstance1.rules = [amazingThingsIdRule];
+      const expectedInstance2 = new ExportableInstance('AmazingThings');
+      expectedInstance2.instanceOf = 'ValueSet';
+      expectedInstance2.name = 'AmazingThings-of-ValueSet'; // No name simplification since it will conflict with other instances
+      expectedInstance2.rules = [amazingThingsIdRule];
+      const expectedInstance3 = new ExportableInstance('OtherAmazingThings');
+      expectedInstance3.instanceOf = 'ValueSet';
+      expectedInstance3.name = 'OtherAmazingThings'; // Name simplification since it didn't conflict with any other instances
+      // NOTE: expectedInstance3 should not have id rule since name matches id
+      // Now check that names have been updated in inline assignments
+      const expectedLogical = new ExportableLogical('PretzelLogical');
+      const expectedRule1 = new ExportableCaretValueRule('');
+      expectedRule1.caretPath = 'contained[0]';
+      expectedRule1.isInstance = true;
+      expectedRule1.value = 'AmazingThings-of-CodeSystem'; // This name did not get changed
+      const expectedRule2 = new ExportableCaretValueRule('');
+      expectedRule2.caretPath = 'contained[1]';
+      expectedRule2.isInstance = true;
+      expectedRule2.value = 'AmazingThings-of-ValueSet'; // This name did not get changed
+      const expectedRule3 = new ExportableCaretValueRule('');
+      expectedRule3.caretPath = 'contained[2]';
+      expectedRule3.isInstance = true;
+      expectedRule3.value = 'OtherAmazingThings'; // This name was changed
+      expectedLogical.rules = [expectedRule1, expectedRule2, expectedRule3];
+      expect(myPackage.instances).toEqual([
+        expectedInstance1,
+        expectedInstance2,
+        expectedInstance3
+      ]);
+      expect(myPackage.logicals).toEqual([expectedLogical]);
+    });
+
+    it('should update inlined contained rules in a resource when the contained instance name changes', () => {
+      const instance1 = new ExportableInstance('AmazingThings');
+      instance1.instanceOf = 'CodeSystem';
+      instance1.name = 'AmazingThings-of-CodeSystem';
+      const instance2 = new ExportableInstance('AmazingThings');
+      instance2.instanceOf = 'ValueSet';
+      instance2.name = 'AmazingThings-of-ValueSet';
+      const instance3 = new ExportableInstance('OtherAmazingThings');
+      instance3.instanceOf = 'ValueSet';
+      instance3.name = 'OtherAmazingThings-of-ValueSet';
+      const resource = new ExportableResource('Toast');
+      const containedRule1 = new ExportableCaretValueRule('');
+      containedRule1.caretPath = 'contained[0]';
+      containedRule1.isInstance = true;
+      containedRule1.value = 'AmazingThings-of-CodeSystem';
+      const containedRule2 = new ExportableCaretValueRule('');
+      containedRule2.caretPath = 'contained[1]';
+      containedRule2.isInstance = true;
+      containedRule2.value = 'AmazingThings-of-ValueSet';
+      const containedRule3 = new ExportableCaretValueRule('');
+      containedRule3.caretPath = 'contained[2]';
+      containedRule3.isInstance = true;
+      containedRule3.value = 'OtherAmazingThings-of-ValueSet';
+      resource.rules = [containedRule1, containedRule2, containedRule3];
+      const myPackage = new Package();
+      myPackage.add(instance1);
+      myPackage.add(instance2);
+      myPackage.add(instance3);
+      myPackage.add(resource);
+      optimizer.optimize(myPackage);
+
+      // Check that instances were renamed when appropriate
+      const amazingThingsIdRule = new ExportableAssignmentRule('id');
+      amazingThingsIdRule.value = 'AmazingThings';
+      const expectedInstance1 = new ExportableInstance('AmazingThings');
+      expectedInstance1.instanceOf = 'CodeSystem';
+      expectedInstance1.name = 'AmazingThings-of-CodeSystem'; // No name simplification since it will conflict with other instances
+      expectedInstance1.rules = [amazingThingsIdRule];
+      const expectedInstance2 = new ExportableInstance('AmazingThings');
+      expectedInstance2.instanceOf = 'ValueSet';
+      expectedInstance2.name = 'AmazingThings-of-ValueSet'; // No name simplification since it will conflict with other instances
+      expectedInstance2.rules = [amazingThingsIdRule];
+      const expectedInstance3 = new ExportableInstance('OtherAmazingThings');
+      expectedInstance3.instanceOf = 'ValueSet';
+      expectedInstance3.name = 'OtherAmazingThings'; // Name simplification since it didn't conflict with any other instances
+      // NOTE: expectedInstance3 should not have id rule since name matches id
+      // Now check that names have been updated in inline assignments
+      const expectedResource = new ExportableResource('Toast');
+      const expectedRule1 = new ExportableCaretValueRule('');
+      expectedRule1.caretPath = 'contained[0]';
+      expectedRule1.isInstance = true;
+      expectedRule1.value = 'AmazingThings-of-CodeSystem'; // This name did not get changed
+      const expectedRule2 = new ExportableCaretValueRule('');
+      expectedRule2.caretPath = 'contained[1]';
+      expectedRule2.isInstance = true;
+      expectedRule2.value = 'AmazingThings-of-ValueSet'; // This name did not get changed
+      const expectedRule3 = new ExportableCaretValueRule('');
+      expectedRule3.caretPath = 'contained[2]';
+      expectedRule3.isInstance = true;
+      expectedRule3.value = 'OtherAmazingThings'; // This name was changed
+      expectedResource.rules = [expectedRule1, expectedRule2, expectedRule3];
+      expect(myPackage.instances).toEqual([
+        expectedInstance1,
+        expectedInstance2,
+        expectedInstance3
+      ]);
+      expect(myPackage.resources).toEqual([expectedResource]);
+    });
+
+    it('should update inlined contained rules in a code system when the contained instance name changes', () => {
+      const instance1 = new ExportableInstance('AmazingThings');
+      instance1.instanceOf = 'CodeSystem';
+      instance1.name = 'AmazingThings-of-CodeSystem';
+      const instance2 = new ExportableInstance('AmazingThings');
+      instance2.instanceOf = 'ValueSet';
+      instance2.name = 'AmazingThings-of-ValueSet';
+      const instance3 = new ExportableInstance('OtherAmazingThings');
+      instance3.instanceOf = 'ValueSet';
+      instance3.name = 'OtherAmazingThings-of-ValueSet';
+      const codeSystem = new ExportableCodeSystem('MyCodeSystem');
+      const containedRule1 = new ExportableCaretValueRule('');
+      containedRule1.caretPath = 'contained[0]';
+      containedRule1.isInstance = true;
+      containedRule1.value = 'AmazingThings-of-CodeSystem';
+      const containedRule2 = new ExportableCaretValueRule('');
+      containedRule2.caretPath = 'contained[1]';
+      containedRule2.isInstance = true;
+      containedRule2.value = 'AmazingThings-of-ValueSet';
+      const containedRule3 = new ExportableCaretValueRule('');
+      containedRule3.caretPath = 'contained[2]';
+      containedRule3.isInstance = true;
+      containedRule3.value = 'OtherAmazingThings-of-ValueSet';
+      codeSystem.rules = [containedRule1, containedRule2, containedRule3];
+      const myPackage = new Package();
+      myPackage.add(instance1);
+      myPackage.add(instance2);
+      myPackage.add(instance3);
+      myPackage.add(codeSystem);
+      optimizer.optimize(myPackage);
+
+      // Check that instances were renamed when appropriate
+      const amazingThingsIdRule = new ExportableAssignmentRule('id');
+      amazingThingsIdRule.value = 'AmazingThings';
+      const expectedInstance1 = new ExportableInstance('AmazingThings');
+      expectedInstance1.instanceOf = 'CodeSystem';
+      expectedInstance1.name = 'AmazingThings-of-CodeSystem'; // No name simplification since it will conflict with other instances
+      expectedInstance1.rules = [amazingThingsIdRule];
+      const expectedInstance2 = new ExportableInstance('AmazingThings');
+      expectedInstance2.instanceOf = 'ValueSet';
+      expectedInstance2.name = 'AmazingThings-of-ValueSet'; // No name simplification since it will conflict with other instances
+      expectedInstance2.rules = [amazingThingsIdRule];
+      const expectedInstance3 = new ExportableInstance('OtherAmazingThings');
+      expectedInstance3.instanceOf = 'ValueSet';
+      expectedInstance3.name = 'OtherAmazingThings'; // Name simplification since it didn't conflict with any other instances
+      // NOTE: expectedInstance3 should not have id rule since name matches id
+      // Now check that names have been updated in inline assignments
+      const expectedCodeSystem = new ExportableCodeSystem('MyCodeSystem');
+      const expectedRule1 = new ExportableCaretValueRule('');
+      expectedRule1.caretPath = 'contained[0]';
+      expectedRule1.isInstance = true;
+      expectedRule1.value = 'AmazingThings-of-CodeSystem'; // This name did not get changed
+      const expectedRule2 = new ExportableCaretValueRule('');
+      expectedRule2.caretPath = 'contained[1]';
+      expectedRule2.isInstance = true;
+      expectedRule2.value = 'AmazingThings-of-ValueSet'; // This name did not get changed
+      const expectedRule3 = new ExportableCaretValueRule('');
+      expectedRule3.caretPath = 'contained[2]';
+      expectedRule3.isInstance = true;
+      expectedRule3.value = 'OtherAmazingThings'; // This name was changed
+      expectedCodeSystem.rules = [expectedRule1, expectedRule2, expectedRule3];
+      expect(myPackage.instances).toEqual([
+        expectedInstance1,
+        expectedInstance2,
+        expectedInstance3
+      ]);
+      expect(myPackage.codeSystems).toEqual([expectedCodeSystem]);
+    });
+
+    it('should update inlined contained rules in a value set when the contained instance name changes', () => {
+      const instance1 = new ExportableInstance('AmazingThings');
+      instance1.instanceOf = 'CodeSystem';
+      instance1.name = 'AmazingThings-of-CodeSystem';
+      const instance2 = new ExportableInstance('AmazingThings');
+      instance2.instanceOf = 'ValueSet';
+      instance2.name = 'AmazingThings-of-ValueSet';
+      const instance3 = new ExportableInstance('OtherAmazingThings');
+      instance3.instanceOf = 'ValueSet';
+      instance3.name = 'OtherAmazingThings-of-ValueSet';
+      const valueSet = new ExportableValueSet('MyValueSet');
+      const containedRule1 = new ExportableCaretValueRule('');
+      containedRule1.caretPath = 'contained[0]';
+      containedRule1.isInstance = true;
+      containedRule1.value = 'AmazingThings-of-CodeSystem';
+      const containedRule2 = new ExportableCaretValueRule('');
+      containedRule2.caretPath = 'contained[1]';
+      containedRule2.isInstance = true;
+      containedRule2.value = 'AmazingThings-of-ValueSet';
+      const containedRule3 = new ExportableCaretValueRule('');
+      containedRule3.caretPath = 'contained[2]';
+      containedRule3.isInstance = true;
+      containedRule3.value = 'OtherAmazingThings-of-ValueSet';
+      valueSet.rules = [containedRule1, containedRule2, containedRule3];
+      const myPackage = new Package();
+      myPackage.add(instance1);
+      myPackage.add(instance2);
+      myPackage.add(instance3);
+      myPackage.add(valueSet);
+      optimizer.optimize(myPackage);
+
+      // Check that instances were renamed when appropriate
+      const amazingThingsIdRule = new ExportableAssignmentRule('id');
+      amazingThingsIdRule.value = 'AmazingThings';
+      const expectedInstance1 = new ExportableInstance('AmazingThings');
+      expectedInstance1.instanceOf = 'CodeSystem';
+      expectedInstance1.name = 'AmazingThings-of-CodeSystem'; // No name simplification since it will conflict with other instances
+      expectedInstance1.rules = [amazingThingsIdRule];
+      const expectedInstance2 = new ExportableInstance('AmazingThings');
+      expectedInstance2.instanceOf = 'ValueSet';
+      expectedInstance2.name = 'AmazingThings-of-ValueSet'; // No name simplification since it will conflict with other instances
+      expectedInstance2.rules = [amazingThingsIdRule];
+      const expectedInstance3 = new ExportableInstance('OtherAmazingThings');
+      expectedInstance3.instanceOf = 'ValueSet';
+      expectedInstance3.name = 'OtherAmazingThings'; // Name simplification since it didn't conflict with any other instances
+      // NOTE: expectedInstance3 should not have id rule since name matches id
+      // Now check that names have been updated in inline assignments
+      const expectedValueSet = new ExportableValueSet('MyValueSet');
+      const expectedRule1 = new ExportableCaretValueRule('');
+      expectedRule1.caretPath = 'contained[0]';
+      expectedRule1.isInstance = true;
+      expectedRule1.value = 'AmazingThings-of-CodeSystem'; // This name did not get changed
+      const expectedRule2 = new ExportableCaretValueRule('');
+      expectedRule2.caretPath = 'contained[1]';
+      expectedRule2.isInstance = true;
+      expectedRule2.value = 'AmazingThings-of-ValueSet'; // This name did not get changed
+      const expectedRule3 = new ExportableCaretValueRule('');
+      expectedRule3.caretPath = 'contained[2]';
+      expectedRule3.isInstance = true;
+      expectedRule3.value = 'OtherAmazingThings'; // This name was changed
+      expectedValueSet.rules = [expectedRule1, expectedRule2, expectedRule3];
+      expect(myPackage.instances).toEqual([
+        expectedInstance1,
+        expectedInstance2,
+        expectedInstance3
+      ]);
+      expect(myPackage.valueSets).toEqual([expectedValueSet]);
     });
 
     it('should still rename instances when there is a different instance with the same id but it is inline only', () => {


### PR DESCRIPTION
**Description:**
Logical models, Resources, CodeSystems, and ValueSets are now checked for rules that could be used to define an inline instance. Since this means those entities will now contain rules that assign inline instances, check those entity types when simplifying instance names.

**Testing Instructions:**
Confirm that the new test cases demonstrate that inline instances are created for rules contained on the newly added FSH entity types. Confirm that the sample JSON in the related issue now results in an inline instance of CodeSystem. Note that a round trip will not be successful with the sample JSON, since `#example-codesystem` is not a value that should be used for referring to a contained CodeSystem. The correct output for this JSON is shown in https://github.com/FHIR/sushi/pull/1520.

**Related Issue:**
Fixes #252 