### PR TITLE
Support FHIR R6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "fhir-package-loader": "^1.0.0",
         "flat": "^5.0.2",
         "fs-extra": "^11.2.0",
-        "fsh-sushi": "^3.11.0",
+        "fsh-sushi": "^3.12.0",
         "ini": "^4.1.3",
         "lodash": "^4.17.21",
         "readline-sync": "^1.4.10",
@@ -1824,9 +1824,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -2816,6 +2816,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "node_modules/fast-uri": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.2.tgz",
+      "integrity": "sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row=="
+    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -3139,31 +3144,31 @@
       }
     },
     "node_modules/fsh-sushi": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.11.0.tgz",
-      "integrity": "sha512-tvCcgp1cVS6lM0Id4MHnzPwlcYJXJf2AZgM/B7z6SeBpQ1xDOrg7jJPqVwmb3EPfmghsYl9+/Omx6l+ZCmDpAw==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.12.0.tgz",
+      "integrity": "sha512-VFIWj1w7YH35rKeRic0NwDffh7JEvv+jXu4isFdxMxZvE6wcmpwgf8Fu35H0LuyZXLYoG4IvG5FFTxHTPp5lZw==",
       "dependencies": {
-        "ajv": "^8.12.0",
-        "antlr4": "4.13.1-patch-1",
-        "axios": "^1.6.5",
+        "ajv": "^8.17.1",
+        "antlr4": "^4.13.2",
+        "axios": "^1.7.5",
         "chalk": "^4.1.2",
-        "commander": "^11.1.0",
+        "commander": "^12.1.0",
         "fhir": "^4.12.0",
         "fhir-package-loader": "^1.0.0",
         "fs-extra": "^11.2.0",
         "html-minifier-terser": "5.1.1",
-        "https-proxy-agent": "^7.0.2",
-        "ini": "^4.1.1",
+        "https-proxy-agent": "^7.0.5",
+        "ini": "^4.1.3",
         "junk": "^3.1.0",
         "lodash": "^4.17.21",
         "readline-sync": "^1.4.10",
         "sanitize-filename": "^1.6.3",
-        "sax": "^1.2.4",
-        "temp": "^0.9.1",
+        "sax": "^1.4.1",
+        "temp": "^0.9.4",
         "text-table": "^0.2.0",
-        "title-case": "^3.0.2",
+        "title-case": "^3.0.3",
         "valid-url": "^1.0.9",
-        "winston": "^3.3.3",
+        "winston": "^3.14.2",
         "yaml": "^1.10.2"
       },
       "bin": {
@@ -3171,26 +3176,18 @@
       }
     },
     "node_modules/fsh-sushi/node_modules/ajv": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/fsh-sushi/node_modules/antlr4": {
-      "version": "4.13.1-patch-1",
-      "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.13.1-patch-1.tgz",
-      "integrity": "sha512-OjFLWWLzDMV9rdFhpvroCWR4ooktNg9/nvVYSA5z28wuVpU36QUNuioR1XLnQtcjVlf8npjyz593PxnU/f/Cow==",
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/fsh-sushi/node_modules/clean-css": {
@@ -3202,14 +3199,6 @@
       },
       "engines": {
         "node": ">= 4.0"
-      }
-    },
-    "node_modules/fsh-sushi/node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/fsh-sushi/node_modules/dot-case": {
@@ -3338,11 +3327,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/fsh-sushi/node_modules/sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "node_modules/fsh-sushi/node_modules/terser": {
       "version": "4.8.1",
@@ -3545,9 +3529,9 @@
       "dev": true
     },
     "node_modules/https-proxy-agent": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "4"
@@ -5161,6 +5145,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -5387,6 +5372,11 @@
       "dependencies": {
         "truncate-utf8-bytes": "^1.0.0"
       }
+    },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
     },
     "node_modules/semver": {
       "version": "7.6.3",
@@ -5976,6 +5966,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -7553,9 +7544,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -8269,6 +8260,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-uri": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.2.tgz",
+      "integrity": "sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row=="
+    },
     "fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -8518,49 +8514,44 @@
       "optional": true
     },
     "fsh-sushi": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.11.0.tgz",
-      "integrity": "sha512-tvCcgp1cVS6lM0Id4MHnzPwlcYJXJf2AZgM/B7z6SeBpQ1xDOrg7jJPqVwmb3EPfmghsYl9+/Omx6l+ZCmDpAw==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.12.0.tgz",
+      "integrity": "sha512-VFIWj1w7YH35rKeRic0NwDffh7JEvv+jXu4isFdxMxZvE6wcmpwgf8Fu35H0LuyZXLYoG4IvG5FFTxHTPp5lZw==",
       "requires": {
-        "ajv": "^8.12.0",
-        "antlr4": "4.13.1-patch-1",
-        "axios": "^1.6.5",
+        "ajv": "^8.17.1",
+        "antlr4": "^4.13.2",
+        "axios": "^1.7.5",
         "chalk": "^4.1.2",
-        "commander": "^11.1.0",
+        "commander": "^12.1.0",
         "fhir": "^4.12.0",
         "fhir-package-loader": "^1.0.0",
         "fs-extra": "^11.2.0",
         "html-minifier-terser": "5.1.1",
-        "https-proxy-agent": "^7.0.2",
-        "ini": "^4.1.1",
+        "https-proxy-agent": "^7.0.5",
+        "ini": "^4.1.3",
         "junk": "^3.1.0",
         "lodash": "^4.17.21",
         "readline-sync": "^1.4.10",
         "sanitize-filename": "^1.6.3",
-        "sax": "^1.2.4",
-        "temp": "^0.9.1",
+        "sax": "^1.4.1",
+        "temp": "^0.9.4",
         "text-table": "^0.2.0",
-        "title-case": "^3.0.2",
+        "title-case": "^3.0.3",
         "valid-url": "^1.0.9",
-        "winston": "^3.3.3",
+        "winston": "^3.14.2",
         "yaml": "^1.10.2"
       },
       "dependencies": {
         "ajv": {
-          "version": "8.12.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "version": "8.17.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+          "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
           "requires": {
-            "fast-deep-equal": "^3.1.1",
+            "fast-deep-equal": "^3.1.3",
+            "fast-uri": "^3.0.1",
             "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
+            "require-from-string": "^2.0.2"
           }
-        },
-        "antlr4": {
-          "version": "4.13.1-patch-1",
-          "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.13.1-patch-1.tgz",
-          "integrity": "sha512-OjFLWWLzDMV9rdFhpvroCWR4ooktNg9/nvVYSA5z28wuVpU36QUNuioR1XLnQtcjVlf8npjyz593PxnU/f/Cow=="
         },
         "clean-css": {
           "version": "4.2.4",
@@ -8569,11 +8560,6 @@
           "requires": {
             "source-map": "~0.6.0"
           }
-        },
-        "commander": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-          "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="
         },
         "dot-case": {
           "version": "3.0.4",
@@ -8689,11 +8675,6 @@
           "version": "0.2.7",
           "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
           "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog=="
-        },
-        "sax": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
         "terser": {
           "version": "4.8.1",
@@ -8844,9 +8825,9 @@
       "dev": true
     },
     "https-proxy-agent": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
-      "integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
       "requires": {
         "agent-base": "^7.0.2",
         "debug": "4"
@@ -10071,7 +10052,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "pure-rand": {
       "version": "6.1.0",
@@ -10215,6 +10197,11 @@
       "requires": {
         "truncate-utf8-bytes": "^1.0.0"
       }
+    },
+    "sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
     },
     "semver": {
       "version": "7.6.3",
@@ -10619,6 +10606,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "fhir-package-loader": "^1.0.0",
     "flat": "^5.0.2",
     "fs-extra": "^11.2.0",
-    "fsh-sushi": "^3.11.0",
+    "fsh-sushi": "^3.12.0",
     "ini": "^4.1.3",
     "lodash": "^4.17.21",
     "readline-sync": "^1.4.10",

--- a/src/utils/Processing.ts
+++ b/src/utils/Processing.ts
@@ -121,7 +121,7 @@ export async function loadExternalDependencies(
     config.config.dependencies?.map(
       (dep: fhirtypes.ImplementationGuideDependsOn) => `${dep.packageId}@${dep.version}`
     ) ?? [];
-  const fhirPackageId = determineCorePackageId(config.config.fhirVersion[0]);
+  const fhirPackageId = utils.getFHIRVersionInfo(config.config.fhirVersion[0])?.packageId;
   if (!allDependencies.includes(`${fhirPackageId}@${config.config.fhirVersion[0]}`)) {
     allDependencies.push(`${fhirPackageId}@${config.config.fhirVersion[0]}`);
   }
@@ -139,7 +139,7 @@ export function loadConfiguredDependencies(
   dependencies: string[] = []
 ): Promise<FHIRDefinitions | void>[] {
   // Automatically include FHIR R4 if no other versions of FHIR are already included
-  if (!dependencies.some(dep => /hl7\.fhir\.r(4|5|4b)\.core/.test(dep))) {
+  if (!dependencies.some(dep => /hl7\.fhir\.r(4|5|4b|6)\.core/.test(dep))) {
     dependencies.push('hl7.fhir.r4.core@4.0.1');
   }
 
@@ -330,20 +330,6 @@ export function getFilesRecursive(dir: string): string[] {
       return [];
     }
     return [dir];
-  }
-}
-
-export function determineCorePackageId(fhirVersion: string): string {
-  if (/^4\.0\./.test(fhirVersion)) {
-    return 'hl7.fhir.r4.core';
-  } else if (/^(4\.1\.|4\.3.\d+-)/.test(fhirVersion)) {
-    return 'hl7.fhir.r4b.core';
-  } else if (/^4\.3.\d+$/.test(fhirVersion)) {
-    return 'hl7.fhir.r4b.core';
-  } else if (/^5\.0.\d+$/.test(fhirVersion)) {
-    return 'hl7.fhir.r5.core';
-  } else {
-    return 'hl7.fhir.r5.core';
   }
 }
 

--- a/test/extractor/ConfigurationExtractor.test.ts
+++ b/test/extractor/ConfigurationExtractor.test.ts
@@ -157,6 +157,35 @@ describe('ConfigurationExtractor', () => {
         expect(loggerSpy.getAllMessages('warn')).toHaveLength(0);
       });
 
+      it('should create a Configuration from an ImplementationGuide with supported fhirVersions', () => {
+        const ig = JSON.parse(
+          fs.readFileSync(path.join(__dirname, 'fixtures', 'simple-ig.json'), 'utf-8')
+        );
+        let result = ConfigurationExtractor.process([ig, ...resources]);
+        expect(result).toBeInstanceOf(ExportableConfiguration);
+        expect(result.config.fhirVersion).toEqual(['4.5.0']); // From IG
+
+        ig.fhirVersion = ['4.0.1'];
+        result = ConfigurationExtractor.process([ig, ...resources]);
+        expect(result).toBeInstanceOf(ExportableConfiguration);
+        expect(result.config.fhirVersion).toEqual(['4.0.1']); // From IG
+
+        ig.fhirVersion = ['5.0.0'];
+        result = ConfigurationExtractor.process([ig, ...resources]);
+        expect(result).toBeInstanceOf(ExportableConfiguration);
+        expect(result.config.fhirVersion).toEqual(['5.0.0']); // From IG
+
+        ig.fhirVersion = ['6.0.0-ballot2'];
+        result = ConfigurationExtractor.process([ig, ...resources]);
+        expect(result).toBeInstanceOf(ExportableConfiguration);
+        expect(result.config.fhirVersion).toEqual(['6.0.0-ballot2']); // From IG
+
+        ig.fhirVersion = ['6.0.0'];
+        result = ConfigurationExtractor.process([ig, ...resources]);
+        expect(result).toBeInstanceOf(ExportableConfiguration);
+        expect(result.config.fhirVersion).toEqual(['6.0.0']); // From IG
+      });
+
       it('should create a Configuration with an inferred url form an ImplementationGuide missing a url', () => {
         const ig = JSON.parse(
           fs.readFileSync(path.join(__dirname, 'fixtures', 'missing-url-ig.json'), 'utf-8')


### PR DESCRIPTION
**Description:** Add support for using FHIR R6 versions. This mostly just switched from using our old regex if/else statement to using the nice util function from SUSHI for different supported FHIR versions.

**Testing Instructions:** Make sure the tests pass and you can run GoFSH on a project that uses a FHIR R6 version.

**Related Issue:** N/A
