### PR TITLE
Process ValueSet that uses components from a contained system

### DIFF
--- a/test/processor/fixtures/valueset-with-contained-codesystem.json
+++ b/test/processor/fixtures/valueset-with-contained-codesystem.json
@@ -1,0 +1,65 @@
+{
+  "resourceType": "ValueSet",
+  "id": "example-valueset",
+  "name": "ValueSetWithContainedSystem",
+  "contained": [
+    {
+      "resourceType": "CodeSystem",
+      "id": "example-codesystem",
+      "url": "http://example.org/codesystem",
+      "version": "1.0.0",
+      "content": "complete",
+      "status": "active",
+      "concept": [
+        {
+          "code": "example-code-1",
+          "display": "Example Code 1"
+        },
+        {
+          "code": "example-code-2",
+          "display": "Example Code 2"
+        },
+        {
+          "code": "example-code-3",
+          "display": "Example Code 3"
+        }
+      ]
+    }
+  ],
+  "url": "http://example.org/valueset",
+  "version": "1.0.0",
+  "status": "active",
+  "compose": {
+    "include": [
+      {
+        "system": "http://example.org/codesystem",
+        "_system": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/valueset-system",
+              "valueCanonical": "#example-codesystem"
+            }
+          ]
+        }
+      }
+    ],
+    "exclude": [
+      {
+        "system": "http://example.org/codesystem",
+        "_system": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/valueset-system",
+              "valueCanonical": "#example-codesystem"
+            }
+          ]
+        },
+        "concept": [
+          {
+            "code": "example-code-2"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
**Description:**
When a ValueSet component references a contained system, the valueset-system extension should be present at compose.system.extension. When it is present, it is safe to throw it out, since SUSHI will add it back in automatically. When it is removed, also remove the extension list and containing underscore property if those become empty. This will often allow the input to be processed as a ValueSet.

This change is simpler than I expected, but this is largely due to the work on SUSHI to better handle various cases involving contained resources.

**Testing Instructions:**
Confirm that the new test and accompanying test fixture accurately reflect a ValueSet that references a contained system. Run a fshing trip with input that includes a ValueSet that references a contained system and confirm that the ValueSet is unchanged. 

**Related Issue:**
Fixes #271.