### PR TITLE
v2.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gofsh",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gofsh",
-      "version": "2.3.1",
+      "version": "2.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "antlr4": "^4.13.2",
@@ -18,7 +18,7 @@
         "fhir-package-loader": "^1.0.0",
         "flat": "^5.0.2",
         "fs-extra": "^11.2.0",
-        "fsh-sushi": "^3.12.0",
+        "fsh-sushi": "^3.12.1",
         "ini": "^5.0.0",
         "lodash": "^4.17.21",
         "readline-sync": "^1.4.10",
@@ -795,9 +795,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.2.tgz",
-      "integrity": "sha512-CXtq5nR4Su+2I47WPOlWud98Y5Lv8Kyxp2ukhgFx/eW6Blm18VXJO5WuQylPugRo8nbluoi6GvvxBLqHcvqUUw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
+      "integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2364,10 +2364,11 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -3234,13 +3235,14 @@
       }
     },
     "node_modules/fsh-sushi": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.12.0.tgz",
-      "integrity": "sha512-VFIWj1w7YH35rKeRic0NwDffh7JEvv+jXu4isFdxMxZvE6wcmpwgf8Fu35H0LuyZXLYoG4IvG5FFTxHTPp5lZw==",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.12.1.tgz",
+      "integrity": "sha512-cvditqxO/FIimwZ0zmmodi2jPawy8mFkaEwLJn+cqohv/RnPEU9RpdGez5qefUrDAgU4qvY8zub29Or/TfQBrA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.17.1",
         "antlr4": "^4.13.2",
-        "axios": "^1.7.5",
+        "axios": "^1.7.7",
         "chalk": "^4.1.2",
         "commander": "^12.1.0",
         "fhir": "^4.12.0",
@@ -3248,7 +3250,7 @@
         "fs-extra": "^11.2.0",
         "html-minifier-terser": "5.1.1",
         "https-proxy-agent": "^7.0.5",
-        "ini": "^4.1.3",
+        "ini": "^5.0.0",
         "junk": "^3.1.0",
         "lodash": "^4.17.21",
         "readline-sync": "^1.4.10",
@@ -3258,7 +3260,7 @@
         "text-table": "^0.2.0",
         "title-case": "^3.0.3",
         "valid-url": "^1.0.9",
-        "winston": "^3.14.2",
+        "winston": "^3.15.0",
         "yaml": "^1.10.2"
       },
       "bin": {
@@ -3369,15 +3371,6 @@
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/fsh-sushi/node_modules/ini": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
-      "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/fsh-sushi/node_modules/json-schema-traverse": {
@@ -6835,9 +6828,9 @@
       "dev": true
     },
     "@eslint/plugin-kit": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.2.tgz",
-      "integrity": "sha512-CXtq5nR4Su+2I47WPOlWud98Y5Lv8Kyxp2ukhgFx/eW6Blm18VXJO5WuQylPugRo8nbluoi6GvvxBLqHcvqUUw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
+      "integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
       "dev": true,
       "requires": {
         "levn": "^0.4.1"
@@ -8036,9 +8029,9 @@
       "dev": true
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",
@@ -8657,13 +8650,13 @@
       "optional": true
     },
     "fsh-sushi": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.12.0.tgz",
-      "integrity": "sha512-VFIWj1w7YH35rKeRic0NwDffh7JEvv+jXu4isFdxMxZvE6wcmpwgf8Fu35H0LuyZXLYoG4IvG5FFTxHTPp5lZw==",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/fsh-sushi/-/fsh-sushi-3.12.1.tgz",
+      "integrity": "sha512-cvditqxO/FIimwZ0zmmodi2jPawy8mFkaEwLJn+cqohv/RnPEU9RpdGez5qefUrDAgU4qvY8zub29Or/TfQBrA==",
       "requires": {
         "ajv": "^8.17.1",
         "antlr4": "^4.13.2",
-        "axios": "^1.7.5",
+        "axios": "^1.7.7",
         "chalk": "^4.1.2",
         "commander": "^12.1.0",
         "fhir": "^4.12.0",
@@ -8671,7 +8664,7 @@
         "fs-extra": "^11.2.0",
         "html-minifier-terser": "5.1.1",
         "https-proxy-agent": "^7.0.5",
-        "ini": "^4.1.3",
+        "ini": "^5.0.0",
         "junk": "^3.1.0",
         "lodash": "^4.17.21",
         "readline-sync": "^1.4.10",
@@ -8681,7 +8674,7 @@
         "text-table": "^0.2.0",
         "title-case": "^3.0.3",
         "valid-url": "^1.0.9",
-        "winston": "^3.14.2",
+        "winston": "^3.15.0",
         "yaml": "^1.10.2"
       },
       "dependencies": {
@@ -8775,11 +8768,6 @@
               }
             }
           }
-        },
-        "ini": {
-          "version": "4.1.3",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
-          "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg=="
         },
         "json-schema-traverse": {
           "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gofsh",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "GoFSH is a FHIR Shorthand (FSH) decompiler, able to convert formal FHIR definitions from JSON to FSH.",
   "main": "dist/index.js",
   "scripts": {
@@ -76,7 +76,7 @@
     "fhir-package-loader": "^1.0.0",
     "flat": "^5.0.2",
     "fs-extra": "^11.2.0",
-    "fsh-sushi": "^3.12.0",
+    "fsh-sushi": "^3.12.1",
     "ini": "^5.0.0",
     "lodash": "^4.17.21",
     "readline-sync": "^1.4.10",


### PR DESCRIPTION
Update SUSHI dependency to 3.12.1. Update other dependencies based on notifications from `npm audit`. Bump version to prepare for upcoming release.
