### PR TITLE
Fix: prevent RangeError from spreading large arrays into `Array.push`'s argument list.

### DIFF
--- a/src/processor/ValueSetProcessor.ts
+++ b/src/processor/ValueSetProcessor.ts
@@ -41,10 +41,9 @@ export class ValueSetProcessor {
     fisher: utils.Fishable,
     config: fshtypes.Configuration
   ): void {
-    const newRules: ExportableValueSet['rules'] = [];
-    newRules.push(
+    const newRules: ExportableValueSet['rules'] = [
       ...CaretValueRuleExtractor.processResource(input, fisher, input.resourceType, config)
-    );
+    ];
     if (input.compose) {
       input.compose.include?.forEach((vsComponent: fhirtypes.ValueSetComposeIncludeOrExclude) => {
         newRules.push(ValueSetFilterComponentRuleExtractor.process(vsComponent, input, true));


### PR DESCRIPTION
Fixes: https://github.com/FHIR/GoFSH/issues/283